### PR TITLE
[Resolve #390] Cast all parameters to strings

### DIFF
--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -639,14 +639,27 @@ class StackActions(object):
         for name, value in parameters.items():
             if value is None:
                 continue
-            if isinstance(value, list):
-                value = ",".join(value)
             formatted_parameters.append({
                 "ParameterKey": name,
-                "ParameterValue": value
+                "ParameterValue": self._format_value(value)
             })
 
         return formatted_parameters
+
+    def _format_value(self, value):
+        """
+        Converts CloudFormation value to the format used by Boto3.
+        """
+        if isinstance(value, list):
+            # recurse
+            new_list = [self._format_value(item) for item in value]
+            return ",".join(new_list)
+        if value is True:
+            return "true"
+        elif value is False:
+            return "false"
+        else:
+            return str(value)
 
     def _get_role_arn(self):
         """

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -726,12 +726,7 @@ class TestStackActions(object):
             "key2": None,
             "key3": None
         }
-        formatted_parameters = self.actions._format_parameters(parameters)
-        sorted_formatted_parameters = sorted(
-            formatted_parameters,
-            key=lambda x: x["ParameterKey"]
-        )
-        assert sorted_formatted_parameters == []
+        assert self.actions._format_parameters(parameters) == []
 
     def test_format_parameters_with_none_and_string_values(self):
         parameters = {
@@ -749,6 +744,38 @@ class TestStackActions(object):
             {"ParameterKey": "key3", "ParameterValue": "value3"}
         ]
 
+    def test_format_parameters_with_number_values(self):
+        parameters = {
+            "key1": 0.0,
+            "key2": 2.349520,
+            "key3": 2173540618439890,
+        }
+        formatted_parameters = self.actions._format_parameters(parameters)
+        sorted_formatted_parameters = sorted(
+            formatted_parameters,
+            key=lambda x: x["ParameterKey"]
+        )
+        assert sorted_formatted_parameters == [
+            {"ParameterKey": "key1", "ParameterValue": "0.0"},
+            {"ParameterKey": "key2", "ParameterValue": "2.34952"},
+            {"ParameterKey": "key3", "ParameterValue": "2173540618439890"}
+        ]
+
+    def test_format_parameters_with_boolean_values(self):
+        parameters = {
+            "key1": True,
+            "key2": False
+        }
+        formatted_parameters = self.actions._format_parameters(parameters)
+        sorted_formatted_parameters = sorted(
+            formatted_parameters,
+            key=lambda x: x["ParameterKey"]
+        )
+        assert sorted_formatted_parameters == [
+            {"ParameterKey": "key1", "ParameterValue": "true"},
+            {"ParameterKey": "key2", "ParameterValue": "false"}
+        ]
+
     def test_format_parameters_with_list_values(self):
         parameters = {
             "key1": ["value1", "value2", "value3"],
@@ -764,6 +791,23 @@ class TestStackActions(object):
             {"ParameterKey": "key1", "ParameterValue": "value1,value2,value3"},
             {"ParameterKey": "key2", "ParameterValue": "value4,value5,value6"},
             {"ParameterKey": "key3", "ParameterValue": "value7,value8,value9"}
+        ]
+
+    def test_format_parameters_with_list_values_containing_mixed_values(self):
+        parameters = {
+            "key1": ["value1", 2.3, True],
+            "key2": ["value4", 5123.58, False],
+            "key3": ["value7", 0, "value9"]
+        }
+        formatted_parameters = self.actions._format_parameters(parameters)
+        sorted_formatted_parameters = sorted(
+            formatted_parameters,
+            key=lambda x: x["ParameterKey"]
+        )
+        assert sorted_formatted_parameters == [
+            {"ParameterKey": "key1", "ParameterValue": "value1,2.3,true"},
+            {"ParameterKey": "key2", "ParameterValue": "value4,5123.58,false"},
+            {"ParameterKey": "key3", "ParameterValue": "value7,0,value9"}
         ]
 
     def test_format_parameters_with_none_and_list_values(self):


### PR DESCRIPTION
### Problem
Sceptre allows you to pass non-string values as parameters. Boto3 only allows string parameters. Refer to #390 for more details.

Example config:
```yaml
parameters:
  Port: 3000
  RuleNumber: 500
  LoggingEnabled: True
```

### Solution
To solve this, all non-string values are coerced into strings. An exception is made for booleans (True/False becomes "true"/"false"). List values are now recursively formatted. This has the side effect of supporting nested array values for parameters (no tests for this).

### Alternatives

1. Create boto3 PR to support non-string parameters for CloudFormation create/update stack APIs. This is also a possibility but it doesn't hurt to cast the values to strings here as well.
2. Raise exception when passing non-string values. This is slightly better than current – more descriptive error messages – but personally, it isn't as good as the proposed solution. Development time is roughly the same.
3. Do nothing or add this to readme. This is definitely the simplest and least riskiest solution but the UX is weaker than point #2.