### PR TITLE
Stack Configuration & Parameter List processing Enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ Temporary Items
 
 # User-specific stuff:
 .idea/
+.vscode/
 
 ## File-based project format:
 *.iws

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -560,6 +560,7 @@ class StackActions(object):
         """
         Returns the Template for the Stack
         """
+        self.stack.template.stack_configuration['formatted_parameters'] = self._format_parameters(self.stack.parameters)
         return self.stack.template.body
 
     def validate(self):
@@ -637,12 +638,17 @@ class StackActions(object):
             if value is None:
                 continue
             if isinstance(value, list):
-                value = ",".join(value)
+                value_list = []
+                for item in value:
+                    if isinstance(item, list):
+                        value_list.append(",".join(item))
+                    else:
+                        value_list.append(item)
+                value = ",".join(value_list)
             formatted_parameters.append({
                 "ParameterKey": name,
                 "ParameterValue": value
             })
-
         return formatted_parameters
 
     def _get_role_arn(self):

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -196,31 +196,56 @@ class Stack(object):
 
     def __eq__(self, stack):
         return (
-            self.name == stack.name and
-            self.project_code == stack.project_code and
-            self.template_path == stack.template_path and
-            self.region == stack.region and
-            self.template_bucket_name == stack.template_bucket_name and
-            self.template_key_prefix == stack.template_key_prefix and
-            self.required_version == stack.required_version and
-            self.profile == stack.profile and
-            self.sceptre_user_data == stack.sceptre_user_data and
-            self.parameters == stack.parameters and
-            self.hooks == stack.hooks and
-            self.s3_details == stack.s3_details and
-            self.dependencies == stack.dependencies and
-            self.role_arn == stack.role_arn and
-            self.protected == stack.protected and
-            self.tags == stack.tags and
-            self.external_name == stack.external_name and
-            self.notifications == stack.notifications and
-            self.on_failure == stack.on_failure and
-            self.stack_timeout == stack.stack_timeout and
-            self.stack_group_config == stack.stack_group_config
+            self.name == stack.name
+            and self.project_code == stack.project_code
+            and self.template_path == stack.template_path
+            and self.region == stack.region
+            and self.template_bucket_name == stack.template_bucket_name
+            and self.template_key_prefix == stack.template_key_prefix
+            and self.required_version == stack.required_version
+            and self.profile == stack.profile
+            and self.sceptre_user_data == stack.sceptre_user_data
+            and self.parameters == stack.parameters
+            and self.hooks == stack.hooks
+            and self.s3_details == stack.s3_details
+            and self.dependencies == stack.dependencies
+            and self.role_arn == stack.role_arn
+            and self.protected == stack.protected
+            and self.tags == stack.tags
+            and self.external_name == stack.external_name
+            and self.notifications == stack.notifications
+            and self.on_failure == stack.on_failure
+            and self.stack_timeout == stack.stack_timeout
+            and self.stack_group_config == stack.stack_group_config
         )
 
     def __hash__(self):
         return hash(str(self))
+
+    def return_dict(self):
+
+        return {
+            "name": self.name,
+            "project_code": self.project_code,
+            "template_path": self.template_path,
+            "region": self.region,
+            "template_bucket_name": self.template_bucket_name,
+            "template_key_prefix": self.template_key_prefix,
+            "required_version": self.required_version,
+            "profile": self.profile,
+            "parameters": self.parameters,
+            "hooks": self.hooks,
+            "s3_details": self.s3_details,
+            "dependencies": self.dependencies,
+            "role_arn": self.role_arn,
+            "protected": self.protected,
+            "tags": self.tags,
+            "external_name": self.external_name,
+            "notifications": self.notifications,
+            "on_failure": self.on_failure,
+            "stack_timeout": self.stack_timeout,
+            "stack_group_config": self.stack_group_config
+        }
 
     @property
     def template(self):
@@ -237,6 +262,7 @@ class Stack(object):
             self._template = Template(
                 path=self.template_path,
                 sceptre_user_data=self.sceptre_user_data,
+                stack_configuration=self.return_dict(),
                 s3_details=self.s3_details,
                 connection_manager=self.connection_manager
             )


### PR DESCRIPTION
This PR provides additional functionality and an enhancement to how Lists are processed when provided as a parameter value.

* Added stack_configuration as an optional argument to accept for sceptre_handler(). This allows templates written in python to get additional information about the stack being built to enhance the capabilities of the Python code generating the template.

* Enhanced list processing when a list of values is provided to a Parameter. If the value provided to a parameter was from a variable which was a list of values, it would treat the list as a single item where as now it will form 1 string from all values in the list. This allows for a combination of variable values from files and static values to be used.

### Example
```yaml
Subnets: {{ var.subnets }} # Wouldn't work before, if var.subnets was itself a list
Subnets: # Wouldn't work before, the string would become [subnet-1234,subnet,1234],subnet-123
  - {{ var.subnets }}
  - subnet-123 
```
## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
