### PR TITLE
[Resolve #546] select command stacks based on exact stack-group name

### DIFF
--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -228,7 +228,9 @@ class ConfigReader(object):
             stack = self._construct_stack(rel_path, stack_group_config)
             stack_map[sceptreise_path(rel_path)] = stack
 
-            if abs_path.startswith(self.context.full_command_path()):
+            full_command_path = self.context.full_command_path()
+            if abs_path == full_command_path\
+                    or abs_path.startswith(full_command_path.rstrip(path.sep) + path.sep):
                 command_stacks.add(stack)
 
         stacks = self.resolve_stacks(stack_map)


### PR DESCRIPTION
When specifying a `command_path` for cli operations, commands will be executed on all stack-groups which share a prefix with `command_path`. So, if you have two configs `env1` and `env2`, but then provide `env` as your `command_path`, both `env1` and `env2` will be executed.

In my opinion, `env` is not a valid stack-group and should therefore not start anything. We should either specify `env1` or `env2` expicitly or alternatively group them under one common directory `my-envs` when you want to launch stack together.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
