### PR TITLE
Fix `--ignore-dependencies` with `stack_output`

### DIFF
--- a/integration-tests/features/stack-output-resolver.feature
+++ b/integration-tests/features/stack-output-resolver.feature
@@ -7,6 +7,14 @@ Feature: Stack output resolver
     When the user launches stack "6/1/B"
     Then stack "6/1/B" exists in "CREATE_COMPLETE" state
 
+  Scenario: launch a stack referencing an output of existing stack with ignore dependencies
+    Given stack "6/1/A" exists using "dependencies/independent_template.json"
+    and stack "6/1/B" does not exist
+    and stack "6/1/C" does not exist
+    When the user launches stack "6/1/B" with ignore dependencies
+    Then stack "6/1/B" exists in "CREATE_COMPLETE" state
+    And stack "6/1/C" does not exist
+
   Scenario: launch a stack referencing an output of a non-existant stack
     Given stack "6/1/B" does not exist
     and stack "6/1/A" does not exist

--- a/sceptre/resolvers/stack_output.py
+++ b/sceptre/resolvers/stack_output.py
@@ -121,16 +121,39 @@ class StackOutput(StackOutputBase):
         """
         self.logger.debug("Resolving Stack output: {0}".format(self.argument))
 
-        friendly_stack_name = self.dependency_stack_name.replace(TEMPLATE_EXTENSION, "")
+        if self.stack.dependencies:
+            friendly_stack_name = self.dependency_stack_name.replace(
+                TEMPLATE_EXTENSION, "")
 
-        stack = next(
-            stack for stack in self.stack.dependencies if stack.name == friendly_stack_name
-        )
+            stack = next(
+                stack for stack in self.stack.dependencies
+                if stack.name == friendly_stack_name
+            )
 
-        stack_name = "-".join([stack.project_code, friendly_stack_name.replace("/", "-")])
+            stack_name = "-".join([
+                stack.project_code,
+                friendly_stack_name.replace("/", "-")
+            ])
 
-        return self._get_output_value(stack_name, self.output_key,
-                                      profile=stack.profile, region=stack.region)
+            return self._get_output_value(
+                stack_name,
+                self.output_key,
+                profile=stack.profile,
+                region=stack.region
+            )
+        else:
+            dep_stack_name, self.output_key = self.argument.split("::")
+            friendly_stack_name = dep_stack_name.replace(TEMPLATE_EXTENSION, "")
+            stack_name = "-".join([
+                self.stack.project_code,
+                friendly_stack_name.replace("/", "-")
+            ])
+            return self._get_output_value(
+                stack_name,
+                self.output_key,
+                profile=self.stack.profile,
+                region=self.stack.region
+            )
 
 
 class StackOutputExternal(StackOutputBase):


### PR DESCRIPTION
This commit fixes an issue where a users attempts to launch a single
stack that utilises the `stack_output_resolver` with the
`--ignore-dependencies`.

Previously, with `--ignore-dependencies` set, any dependencies that arose
through `!stack_output_resolver` would not be added to
`stack.dependencies` and the `next()` function in
`StackOutput.resolve()` would raise a `StopIteration` as the
stack.dependencies list would be empty.

This commit handles the stack_output by utilising the argument passed
into `stack_output`.

[Resolves #778]

## PR Checklist

- [ ] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes flake8 (`make lint`) checks.
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
