### PR TITLE
Add context to hooks and resolvers

### DIFF
--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -161,7 +161,7 @@ class ConfigReader(object):
                 # Retrieve name and class from entry point
                 node_tag = u'!' + entry_point.name
                 node_class = entry_point.load()
-
+                node_class.context = self.context
                 # Add constructor to PyYAML loader
                 yaml.SafeLoader.add_constructor(
                     node_tag, constructor_factory(node_class)

--- a/sceptre/context.py
+++ b/sceptre/context.py
@@ -78,28 +78,38 @@ class SceptreContext(object):
     def __repr__(self):
         return ("sceptre.context.SceptreContext("
                 "project_path='{project_path}', "
-                "config_path='{config_path}', "
                 "command_path='{command_path}', "
-                "normal_command_path='{normal_command_path}', "
-                "config_file='{config_path}', "
-                "templates_path='{templates_path}', "
-                "user_variables='{user_variables}', "
-                "options='{options}', "
+                "user_variables={user_variables}, "
+                "options={options}, "
                 "output_format='{output_format}', "
-                "no_colour='{no_colour}', "
-                "ignore_dependencies='{ignore_dependencies}'".format(
+                "no_colour={no_colour}, "
+                "ignore_dependencies={ignore_dependencies})".format(
                     project_path=self.project_path,
-                    config_path=self.config_path,
                     command_path=self.command_path,
-                    normal_command_path=self.normal_command_path,
-                    config_file=self.config_file,
-                    templates_path=self.templates_path,
                     user_variables=self.user_variables,
                     options=self.options,
                     output_format=self.output_format,
                     no_colour=self.no_colour,
-                    ignore_dependencies=self.ignore_dependencies)
-                )
+                    ignore_dependencies=self.ignore_dependencies
+                ))
+
+    def __eq__(self, context):
+        return (
+            self.project_path == context.project_path
+            and self.config_path == context.config_path
+            and self.command_path == context.command_path
+            and self.normal_command_path == context.normal_command_path
+            and self.config_file == context.config_file
+            and self.templates_path == context.templates_path
+            and self.user_variables == context.user_variables
+            and self.options == context.options
+            and self.output_format == context.output_format
+            and self.no_colour == context.no_colour
+            and self.ignore_dependencies == context.ignore_dependencies
+        )
+
+    def __hash__(self):
+        return hash(str(self))
 
     def full_config_path(self):
         """

--- a/sceptre/context.py
+++ b/sceptre/context.py
@@ -75,6 +75,32 @@ class SceptreContext(object):
         self.no_colour = no_colour if no_colour is True else False
         self.ignore_dependencies = ignore_dependencies if ignore_dependencies is True else False
 
+    def __repr__(self):
+        return ("sceptre.context.SceptreContext("
+                "project_path='{project_path}', "
+                "config_path='{config_path}', "
+                "command_path='{command_path}', "
+                "normal_command_path='{normal_command_path}', "
+                "config_file='{config_path}', "
+                "templates_path='{templates_path}', "
+                "user_variables='{user_variables}', "
+                "options='{options}', "
+                "output_format='{output_format}', "
+                "no_colour='{no_colour}', "
+                "ignore_dependencies='{ignore_dependencies}'".format(
+                    project_path=self.project_path,
+                    config_path=self.config_path,
+                    command_path=self.command_path,
+                    normal_command_path=self.normal_command_path,
+                    config_file=self.config_file,
+                    templates_path=self.templates_path,
+                    user_variables=self.user_variables,
+                    options=self.options,
+                    output_format=self.output_format,
+                    no_colour=self.no_colour,
+                    ignore_dependencies=self.ignore_dependencies)
+                )
+
     def full_config_path(self):
         """
         Returns the config path in the format: ``project_path/config_path``.

--- a/sceptre/hooks/__init__.py
+++ b/sceptre/hooks/__init__.py
@@ -2,12 +2,14 @@ import abc
 import logging
 from functools import wraps
 
+from sceptre.context import SceptreContext
 from sceptre.helpers import _call_func_on_values
 
 
 class HookData(object):
     def __init__(self, context):
-        self.context = context
+        if isinstance(context, SceptreContext):
+            self.context = context
 
 
 class Hook(HookData):

--- a/sceptre/hooks/__init__.py
+++ b/sceptre/hooks/__init__.py
@@ -5,7 +5,12 @@ from functools import wraps
 from sceptre.helpers import _call_func_on_values
 
 
-class Hook(object):
+class HookData(object):
+    def __init__(self, context):
+        self.context = context
+
+
+class Hook(HookData):
     """
     Hook is an abstract base class that should be inherited by all hooks.
 

--- a/sceptre/resolvers/__init__.py
+++ b/sceptre/resolvers/__init__.py
@@ -3,12 +3,14 @@ import abc
 import six
 import logging
 
+from sceptre.context import SceptreContext
 from sceptre.helpers import _call_func_on_values
 
 
 class ResolverData(object):
     def __init__(self, context):
-        self.context = context
+        if isinstance(context, SceptreContext):
+            self.context = context
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/sceptre/resolvers/__init__.py
+++ b/sceptre/resolvers/__init__.py
@@ -6,8 +6,13 @@ import logging
 from sceptre.helpers import _call_func_on_values
 
 
+class ResolverData(object):
+    def __init__(self, context):
+        self.context = context
+
+
 @six.add_metaclass(abc.ABCMeta)
-class Resolver:
+class Resolver(ResolverData):
     """
     Resolver is an abstract base class that should be inherited by all
     Resolvers.

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,17 +1,25 @@
 from os import path
 from mock import sentinel
+import importlib
+
 from sceptre.context import SceptreContext
 
 
 class TestSceptreContext(object):
 
     def setup_method(self, test_method):
-        self.templates_path = "templates"
-        self.config_path = "config"
-        self.config_file = "config.yaml"
+        self.context = SceptreContext(
+            project_path="project_path/to/sceptre",
+            command_path="command/path",
+            user_variables={},
+            options={},
+            output_format="json",
+            no_colour=True,
+            ignore_dependencies=False
+        )
 
     def test_context_with_path(self):
-        self.context = SceptreContext(
+        context = SceptreContext(
             project_path="project_path/to/sceptre",
             command_path="command-path",
             user_variables=sentinel.user_variables,
@@ -22,7 +30,7 @@ class TestSceptreContext(object):
         )
 
         sentinel.project_path = "project_path/to/sceptre"
-        assert self.context.project_path == sentinel.project_path
+        assert context.project_path == sentinel.project_path
 
     def test_full_config_path_returns_correct_path(self):
         context = SceptreContext(
@@ -35,7 +43,7 @@ class TestSceptreContext(object):
             ignore_dependencies=sentinel.ignore_dependencies
         )
 
-        full_config_path = path.join("project_path", self.config_path)
+        full_config_path = path.join("project_path", self.context.config_path)
         assert context.full_config_path() == full_config_path
 
     def test_full_command_path_returns_correct_path(self):
@@ -49,7 +57,7 @@ class TestSceptreContext(object):
             ignore_dependencies=sentinel.ignore_dependencies
         )
         full_command_path = path.join("project_path",
-                                      self.config_path,
+                                      self.context.config_path,
                                       "command")
 
         assert context.full_command_path() == full_command_path
@@ -64,5 +72,30 @@ class TestSceptreContext(object):
             no_colour=sentinel.no_colour,
             ignore_dependencies=sentinel.ignore_dependencies
         )
-        full_templates_path = path.join("project_path", self.templates_path)
+        full_templates_path = path.join("project_path", self.context.templates_path)
         assert context.full_templates_path() == full_templates_path
+
+    def test_stack_repr(self):
+        assert self.context.__repr__() == \
+            "sceptre.context.SceptreContext(" \
+            "project_path='project_path/to/sceptre', " \
+            "command_path='command/path', " \
+            "user_variables={}, "\
+            "options={}, " \
+            "output_format='json', " \
+            "no_colour=True, " \
+            "ignore_dependencies=False" \
+            ")"
+
+    def test_repr_can_eval_correctly(self):
+        sceptre = importlib.import_module('sceptre')
+        mock = importlib.import_module('mock')
+        evaluated_context = eval(
+            repr(self.context),
+            {
+                'sceptre': sceptre,
+                'sentinel': mock.mock.sentinel
+            }
+        )
+        assert isinstance(evaluated_context, SceptreContext)
+        assert evaluated_context.__eq__(self.context)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -75,7 +75,7 @@ class TestSceptreContext(object):
         full_templates_path = path.join("project_path", self.context.templates_path)
         assert context.full_templates_path() == full_templates_path
 
-    def test_stack_repr(self):
+    def test_context_repr(self):
         assert self.context.__repr__() == \
             "sceptre.context.SceptreContext(" \
             "project_path='project_path/to/sceptre', " \
@@ -99,3 +99,16 @@ class TestSceptreContext(object):
         )
         assert isinstance(evaluated_context, SceptreContext)
         assert evaluated_context.__eq__(self.context)
+
+    def test_context_hash(self):
+        assert hash(self.context) == self.context.__hash__()
+
+    def test_command_path_is_stack_with_valid_stack(self):
+        self.context.project_path = "tests/fixtures"
+        self.context.command_path = "account/stack-group/region/vpc.yaml"
+        assert self.context.command_path_is_stack()
+
+    def test_command_path_is_stack_with_directory(self):
+        self.context.project_path = "tests/fixtures"
+        self.context.command_path = "account/stack-group/region"
+        assert self.context.command_path_is_stack() is False

--- a/tests/test_hooks/test_hooks.py
+++ b/tests/test_hooks/test_hooks.py
@@ -1,7 +1,13 @@
 # -*- coding: utf-8 -*-
 from mock import MagicMock
 
-from sceptre.hooks import Hook, HookProperty, add_stack_hooks, execute_hooks
+from sceptre.context import SceptreContext
+from sceptre.hooks import Hook, HookData, HookProperty, add_stack_hooks, execute_hooks
+
+
+class MockHookData(HookData):
+    def __init__(self, context):
+        self.context = context
 
 
 class MockHook(Hook):
@@ -60,11 +66,23 @@ class TestHooksFunctions(object):
         hook_2.run.called_once_with()
 
 
+class TestHookData(object):
+    def setup_method(self):
+        self.mock_context = MagicMock(spec=SceptreContext)
+
+    def test_init(self):
+        self.hook_data = HookData(self.mock_context)
+        assert isinstance(self.hook_data.context, SceptreContext)
+        assert hasattr(self.hook_data, 'context')
+        assert self.hook_data.context == self.mock_context
+
+
 class TestHook(object):
     def setup_method(self, test_method):
         self.hook = MockHook()
 
     def test_hook_inheritance(self):
+        assert issubclass(Hook, HookData)
         assert isinstance(self.hook, Hook)
 
 

--- a/tests/test_resolvers/test_resolver.py
+++ b/tests/test_resolvers/test_resolver.py
@@ -2,7 +2,24 @@
 
 from mock import sentinel, MagicMock
 
-from sceptre.resolvers import Resolver, ResolvableProperty
+from sceptre.context import SceptreContext
+from sceptre.resolvers import Resolver, ResolverData, ResolvableProperty
+
+
+class MockResolverData(ResolverData):
+    def __init__(self):
+        self.context = MagicMock(spec=SceptreContext)
+
+
+class TestResolverData(object):
+    def setup_method(self, test_method):
+        self.mock_context = MagicMock(SceptreContext)
+
+    def test_resolver_data_has_context(self):
+        self.resolver_data = ResolverData(self.mock_context)
+        assert isinstance(self.resolver_data.context, SceptreContext)
+        assert hasattr(self.resolver_data, 'context')
+        assert self.resolver_data.context == self.mock_context
 
 
 class MockResolver(Resolver):
@@ -29,9 +46,10 @@ class TestResolver(object):
             stack=sentinel.stack
         )
 
-    def test_init(self):
+    def test_resolver_init(self):
         assert self.mock_resolver.stack == sentinel.stack
         assert self.mock_resolver.argument == sentinel.argument
+        assert issubclass(Resolver, ResolverData)
 
 
 class TestResolvablePropertyDescriptor(object):
@@ -131,22 +149,22 @@ class TestResolvablePropertyDescriptor(object):
             "None": None,
             "Resolver": mock_resolver,
             "List": [
-                    [
-                        mock_resolver,
-                        "String",
-                        None
-                    ],
-                    {
-                        "Dictionary": {},
-                        "String": "String",
-                        "None": None,
-                        "Resolver": mock_resolver,
-                        "List": [
-                            mock_resolver
-                        ]
-                    },
+                [
                     mock_resolver,
-                    "String"
+                    "String",
+                    None
+                ],
+                {
+                    "Dictionary": {},
+                    "String": "String",
+                    "None": None,
+                    "Resolver": mock_resolver,
+                    "List": [
+                        mock_resolver
+                    ]
+                },
+                mock_resolver,
+                "String"
             ],
             "Dictionary": {
                 "Resolver": mock_resolver,
@@ -174,22 +192,22 @@ class TestResolvablePropertyDescriptor(object):
             "None": None,
             "Resolver": "Resolved",
             "List": [
-                    [
+                [
                         "Resolved",
                         "String",
                         None
-                    ],
-                    {
-                        "Dictionary": {},
-                        "String": "String",
-                        "None": None,
-                        "Resolver": "Resolved",
-                        "List": [
-                            "Resolved"
-                        ]
-                    },
-                    "Resolved",
-                    "String"
+                ],
+                {
+                    "Dictionary": {},
+                    "String": "String",
+                    "None": None,
+                    "Resolver": "Resolved",
+                    "List": [
+                        "Resolved"
+                    ]
+                },
+                "Resolved",
+                "String"
             ],
             "Dictionary": {
                 "Resolver": "Resolved",


### PR DESCRIPTION
Adds SceptreContext to Hooks and Resolvers. Useful for accessing general information about the project paths and options specified in API or CLI.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
