### PR TITLE
Change example url to sceptre homepage

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -182,7 +182,7 @@ class TestCli(object):
 
     def test_estimate_template_cost_with_browser(self):
         self.mock_stack_actions.estimate_cost.return_value = {
-            "Url": "http://example.com",
+            "Url": "https://sceptre.cloudreach.com",
             "ResponseMetadata": {
                 "HTTPStatusCode": 200
             }
@@ -195,7 +195,7 @@ class TestCli(object):
 
         assert result.output == \
             '{0}{1}'.format("View the estimated cost for mock-stack at:\n",
-                            "http://example.com\n\n")
+                            "https://sceptre.cloudreach.com\n\n")
 
     def test_estimate_template_cost_with_no_browser(self):
         client_error = ClientError(


### PR DESCRIPTION
This test is a little annoying anyway so may remove it in the future but for now changing the url to open the sceptre docs rather than example.com

## PR Checklist

- [ ] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes flake8 (`make lint`) checks.
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
