### PR TITLE
Fix infinite recursion in sceptre_user_data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Categories: Added, Removed, Changed, Fixed, Nonfunctional, Deprecated
 
 ## Unreleased
 
+- Fix recursion in sceptre_user_data becoming infinite
+
 ## 2.1.5 (2019.06.28)
 
 ### Fixed

--- a/sceptre/resolvers/__init__.py
+++ b/sceptre/resolvers/__init__.py
@@ -1,9 +1,14 @@
 # -*- coding: utf-8 -*-
 import abc
-import six
 import logging
+from contextlib import contextmanager
 
+import six
 from sceptre.helpers import _call_func_on_values
+
+
+class RecursiveGet(Exception):
+    pass
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -58,6 +63,7 @@ class ResolvableProperty(object):
     def __init__(self, name):
         self.name = "_" + name
         self.logger = logging.getLogger(__name__)
+        self._get_in_progress = False
 
     def __get__(self, instance, type):
         """
@@ -67,13 +73,19 @@ class ResolvableProperty(object):
         :return: The attribute stored with the suffix ``name`` in the instance.
         :rtype: dict or list
         """
-        def resolve(attr, key, value):
-            attr[key] = value.resolve()
+        with self._no_recursive_get():
+            def resolve(attr, key, value):
+                try:
+                    attr[key] = value.resolve()
+                except RecursiveGet:
+                    attr[key] = self.ResolveLater(instance, self.name, key,
+                                                  lambda: value.resolve())
 
-        if hasattr(instance, self.name):
-            return _call_func_on_values(
-                resolve, getattr(instance, self.name), Resolver
-            )
+            if hasattr(instance, self.name):
+                retval = _call_func_on_values(
+                    resolve, getattr(instance, self.name), Resolver
+                )
+                return retval
 
     def __set__(self, instance, value):
         """
@@ -87,3 +99,26 @@ class ResolvableProperty(object):
 
         _call_func_on_values(setup, value, Resolver)
         setattr(instance, self.name, value)
+
+    class ResolveLater(object):
+        """Represents a value that could not yet be resolved but can be resolved in the future."""
+        def __init__(self, instance, name, key, resolution_function):
+            self._instance = instance
+            self._name = name
+            self._key = key
+            self._resolution_function = resolution_function
+
+        def __call__(self):
+            """Resolve the value."""
+            attr = getattr(self._instance, self._name)
+            attr[self._key] = self._resolution_function()
+
+    @contextmanager
+    def _no_recursive_get(self):
+        if self._get_in_progress:
+            raise RecursiveGet()
+        self._get_in_progress = True
+        try:
+            yield
+        finally:
+            self._get_in_progress = False

--- a/tests/test_resolvers/test_cache.py
+++ b/tests/test_resolvers/test_cache.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+
+class TestResolverCache(object):
+    def setup_method(self, setup_method):
+        pass
+
+    def test_singleton_cache(self):
+        pass

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -1,10 +1,39 @@
 # -*- coding: utf-8 -*-
 
 import importlib
-from mock import sentinel, MagicMock
 
+from mock import MagicMock, sentinel
+from sceptre.resolvers import Resolver
 from sceptre.stack import Stack
 from sceptre.template import Template
+
+
+def stack_factory(**kwargs):
+    call_kwargs = {
+        'name': 'dev/app/stack',
+        'project_code': sentinel.project_code,
+        'template_bucket_name': sentinel.template_bucket_name,
+        'template_key_prefix': sentinel.template_key_prefix,
+        'required_version': sentinel.required_version,
+        'template_path': sentinel.template_path,
+        'region': sentinel.region,
+        'profile': sentinel.profile,
+        'parameters': {"key1": "val1"},
+        'sceptre_user_data': sentinel.sceptre_user_data,
+        'hooks': {},
+        's3_details': None,
+        'dependencies': sentinel.dependencies,
+        'role_arn': sentinel.role_arn,
+        'protected': False,
+        'tags': {"tag1": "val1"},
+        'external_name': sentinel.external_name,
+        'notifications': [sentinel.notification],
+        'on_failure': sentinel.on_failure,
+        'stack_timeout': sentinel.stack_timeout,
+        'stack_group_config': {}
+    }
+    call_kwargs.update(kwargs)
+    return Stack(**call_kwargs)
 
 
 class TestStack(object):
@@ -95,3 +124,43 @@ class TestStack(object):
         )
         assert isinstance(evaluated_stack, Stack)
         assert evaluated_stack.__eq__(self.stack)
+
+
+class TestStackSceptreUserData(object):
+    def test_user_data_is_accessible(self):
+        """
+        .sceptre_user_data is a property. Let's make sure it accesses the right
+        data.
+        """
+        stack = stack_factory(sceptre_user_data={'test_key': sentinel.test_value})
+        assert stack.sceptre_user_data['test_key'] is sentinel.test_value
+
+    def test_user_data_gets_resolved(self):
+        class TestResolver(Resolver):
+            def setup(self):
+                pass
+
+            def resolve(self):
+                return sentinel.resolved_value
+
+        stack = stack_factory(sceptre_user_data={'test_key': TestResolver()})
+        assert stack.sceptre_user_data['test_key'] is sentinel.resolved_value
+
+    def test_recursive_user_data_gets_resolved(self):
+        """
+        .sceptre_user_data can have resolvers that refer to .sceptre_user_data itself.
+        Those must be instantiated before the attribute can be used.
+        """
+        class TestResolver(Resolver):
+            def setup(self):
+                pass
+
+            def resolve(self):
+                return self.stack.sceptre_user_data['primitive']
+
+        stack = stack_factory()
+        stack._sceptre_user_data = {
+            'primitive': sentinel.primitive_value,
+            'resolved': TestResolver(stack=stack),
+        }
+        assert stack.sceptre_user_data['resolved'] == sentinel.primitive_value


### PR DESCRIPTION
This fixes issue [#733 ](https://github.com/Sceptre/sceptre/issues/733): When a resolver in Stack.sceptre_user_data refers to .sceptre_user_data, it would eventually crash after running out of stack space.

The Stack now does a 2-pass instantiation of .sceptre_user_data to avoid that.

## PR Checklist

- [ ] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes flake8 (`make lint`) checks.
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
