### PR TITLE
[Resolves #788] Debug output of dependency graph misses stack name and edge name

### DIFF
--- a/sceptre/config/graph.py
+++ b/sceptre/config/graph.py
@@ -90,7 +90,7 @@ class StackGraph(object):
         :type dependencies: list
         """
         self.logger.debug(
-            "Generate edges for graph {0}".format(stack)
+            "Generate dependencies for stack {0}".format(stack)
         )
         for dependency in dependencies:
             self.graph.add_edge(dependency, stack)
@@ -98,7 +98,7 @@ class StackGraph(object):
                 raise CircularDependenciesError(
                     "Dependency cycle detected: {} {}".format(stack,
                                                               dependency))
-            self.logger.debug("Added edge: {}".format(dependency))
+            self.logger.debug("  Added dependency: {}".format(dependency))
 
         if not dependencies:
             self.graph.add_node(stack)

--- a/sceptre/config/graph.py
+++ b/sceptre/config/graph.py
@@ -90,15 +90,15 @@ class StackGraph(object):
         :type dependencies: list
         """
         self.logger.debug(
-            "Generate edges for graph {0}".format(self.graph)
+            "Generate edges for graph {0}".format(stack)
         )
         for dependency in dependencies:
-            edge = self.graph.add_edge(dependency, stack)
+            self.graph.add_edge(dependency, stack)
             if not nx.is_directed_acyclic_graph(self.graph):
                 raise CircularDependenciesError(
                     "Dependency cycle detected: {} {}".format(stack,
                                                               dependency))
-            self.logger.debug("Added edge: {}".format(edge))
+            self.logger.debug("Added edge: {}".format(dependency))
 
         if not dependencies:
             self.graph.add_node(stack)


### PR DESCRIPTION
This fixes #788: Debug output of dependency graph misses stack name and edge name .
The correct variables are now used in the debug output so that the stack names are displayed properly.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
