### PR TITLE
[Resolves #571] Add iam_role capability for stack-config

### DIFF
--- a/integration-tests/sceptre-project/config/9/B.yaml
+++ b/integration-tests/sceptre-project/config/9/B.yaml
@@ -1,5 +1,4 @@
 template_path: dependencies/dependent_template_local_export.json
 region: eu-west-1
 parameters:
-  DependentStackName: !stack_output_external {project_code}-9-A::StackName 9-A
-
+  DependentStackName: !stack_output_external {project_code}-9-A::StackName default::eu-west-1

--- a/integration-tests/sceptre-project/config/9/aws-config
+++ b/integration-tests/sceptre-project/config/9/aws-config
@@ -1,2 +1,2 @@
-[profile 9-A]
-region = eu-west-1
+[default]
+region = us-east-1

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -31,24 +31,25 @@ from sceptre.config import strategies
 ConfigAttributes = collections.namedtuple("Attributes", "required optional")
 
 CONFIG_MERGE_STRATEGIES = {
-    'dependencies': strategies.list_join,
-    'hooks': strategies.child_wins,
-    'notifications': strategies.child_wins,
-    'on_failure': strategies.child_wins,
-    'parameters': strategies.child_wins,
-    'profile': strategies.child_wins,
-    'project_code': strategies.child_wins,
-    'protect': strategies.child_wins,
-    'region': strategies.child_wins,
-    'required_version': strategies.child_wins,
-    'role_arn': strategies.child_wins,
-    'sceptre_user_data': strategies.child_wins,
-    'stack_name': strategies.child_wins,
-    'stack_tags': strategies.child_wins,
-    'stack_timeout': strategies.child_wins,
-    'template_bucket_name': strategies.child_wins,
-    'template_key_value': strategies.child_wins,
-    'template_path': strategies.child_wins
+    "dependencies": strategies.list_join,
+    "hooks": strategies.child_wins,
+    "iam_role": strategies.child_wins,
+    "notifications": strategies.child_wins,
+    "on_failure": strategies.child_wins,
+    "parameters": strategies.child_wins,
+    "profile": strategies.child_wins,
+    "project_code": strategies.child_wins,
+    "protect": strategies.child_wins,
+    "region": strategies.child_wins,
+    "required_version": strategies.child_wins,
+    "role_arn": strategies.child_wins,
+    "sceptre_user_data": strategies.child_wins,
+    "stack_name": strategies.child_wins,
+    "stack_tags": strategies.child_wins,
+    "stack_timeout": strategies.child_wins,
+    "template_bucket_name": strategies.child_wins,
+    "template_key_value": strategies.child_wins,
+    "template_path": strategies.child_wins
 }
 
 STACK_GROUP_CONFIG_ATTRIBUTES = ConfigAttributes(
@@ -70,6 +71,7 @@ STACK_CONFIG_ATTRIBUTES = ConfigAttributes(
     {
         "dependencies",
         "hooks",
+        "iam_role",
         "notifications",
         "on_failure",
         "parameters",
@@ -468,6 +470,7 @@ class ConfigReader(object):
             template_bucket_name=config.get("template_bucket_name"),
             template_key_prefix=config.get("template_key_prefix"),
             required_version=config.get("required_version"),
+            iam_role=config.get("iam_role"),
             profile=config.get("profile"),
             parameters=config.get("parameters", {}),
             sceptre_user_data=config.get("sceptre_user_data", {}),

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -43,7 +43,8 @@ class StackActions(object):
         self.name = self.stack.name
         self.logger = logging.getLogger(__name__)
         self.connection_manager = ConnectionManager(
-            self.stack.region, self.stack.profile, self.stack.external_name
+            self.stack.region, self.stack.profile,
+            self.stack.external_name, self.stack.iam_role
         )
 
     @add_stack_hooks

--- a/sceptre/resolvers/stack_output.py
+++ b/sceptre/resolvers/stack_output.py
@@ -25,7 +25,7 @@ class StackOutputBase(Resolver):
         self.logger = logging.getLogger(__name__)
         super(StackOutputBase, self).__init__(*args, **kwargs)
 
-    def _get_output_value(self, stack_name, output_key, profile=None, region=None):
+    def _get_output_value(self, stack_name, output_key, profile=None, region=None, iam_role=None):
         """
         Attempts to get the Stack output named by ``output_key``
 
@@ -37,7 +37,7 @@ class StackOutputBase(Resolver):
         :rtype: str
         :raises: sceptre.exceptions.DependencyStackMissingOutputError
         """
-        outputs = self._get_stack_outputs(stack_name, profile, region)
+        outputs = self._get_stack_outputs(stack_name, profile, region, iam_role)
 
         try:
             return outputs[output_key]
@@ -48,7 +48,7 @@ class StackOutputBase(Resolver):
                 )
             )
 
-    def _get_stack_outputs(self, stack_name, profile=None, region=None):
+    def _get_stack_outputs(self, stack_name, profile=None, region=None, iam_role=None):
         """
         Communicates with AWS CloudFormation to fetch outputs from a specific
         Stack.
@@ -71,7 +71,8 @@ class StackOutputBase(Resolver):
                 kwargs={"StackName": stack_name},
                 profile=profile,
                 region=region,
-                stack_name=stack_name
+                stack_name=stack_name,
+                iam_role=iam_role
             )
         except ClientError as e:
             if "does not exist" in e.response["Error"]["Message"]:
@@ -129,8 +130,8 @@ class StackOutput(StackOutputBase):
 
         stack_name = "-".join([stack.project_code, friendly_stack_name.replace("/", "-")])
 
-        return self._get_output_value(stack_name, self.output_key,
-                                      profile=stack.profile, region=stack.region)
+        return self._get_output_value(stack_name, self.output_key, profile=stack.profile,
+                                      region=stack.region, iam_role=stack.iam_role)
 
 
 class StackOutputExternal(StackOutputBase):
@@ -157,13 +158,17 @@ class StackOutputExternal(StackOutputBase):
         )
 
         profile = None
+        region = None
+        iam_role = None
         arguments = shlex.split(self.argument)
 
         stack_argument = arguments[0]
         if len(arguments) > 1:
-            profile = arguments[1]
+            extra_args = arguments[1].split("::", 2)
+            profile, region, iam_role = extra_args + (3 - len(extra_args)) * [None]
 
         dependency_stack_name, output_key = stack_argument.split("::")
         return self._get_output_value(
-            dependency_stack_name, output_key, profile
+            dependency_stack_name, output_key,
+            profile or None, region or None, iam_role or None
         )

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -87,6 +87,11 @@ class Stack(object):
             CloudFormation when a Stack fails to create.
     :type on_failure: str
 
+    :param iam_role: The ARN of a role for Sceptre to assume before interacting\
+            with the environment. If not supplied, Sceptre uses the user's AWS CLI\
+            credentials.
+    :type iam_role: str
+
     :param profile: The name of the profile as defined in ~/.aws/config and\
             ~/.aws/credentials.
     :type profile: str
@@ -110,7 +115,7 @@ class Stack(object):
     def __init__(
         self, name, project_code, template_path, region, template_bucket_name=None,
         template_key_prefix=None, required_version=None, parameters=None,
-        sceptre_user_data=None, hooks=None, s3_details=None,
+        sceptre_user_data=None, hooks=None, s3_details=None, iam_role=None,
         dependencies=None, role_arn=None, protected=False, tags=None,
         external_name=None, notifications=None, on_failure=None, profile=None,
         stack_timeout=0, stack_group_config={}
@@ -136,6 +141,7 @@ class Stack(object):
         self.dependencies = dependencies or []
         self.tags = tags or {}
         self.stack_timeout = stack_timeout
+        self.iam_role = iam_role
         self.profile = profile
         self.hooks = hooks or {}
         self.parameters = parameters or {}
@@ -153,6 +159,7 @@ class Stack(object):
             "template_bucket_name={template_bucket_name}, "
             "template_key_prefix={template_key_prefix}, "
             "required_version={required_version}, "
+            "iam_role={iam_role}, "
             "profile={profile}, "
             "sceptre_user_data={sceptre_user_data}, "
             "parameters={parameters}, "
@@ -175,6 +182,7 @@ class Stack(object):
                 template_bucket_name=self.template_bucket_name,
                 template_key_prefix=self.template_key_prefix,
                 required_version=self.required_version,
+                iam_role=self.iam_role,
                 profile=self.profile,
                 sceptre_user_data=self.sceptre_user_data,
                 parameters=self.parameters,
@@ -204,6 +212,7 @@ class Stack(object):
             self.template_bucket_name == stack.template_bucket_name and
             self.template_key_prefix == stack.template_key_prefix and
             self.required_version == stack.required_version and
+            self.iam_role == stack.iam_role and
             self.profile == stack.profile and
             self.sceptre_user_data == stack.sceptre_user_data and
             self.parameters == stack.parameters and
@@ -232,7 +241,7 @@ class Stack(object):
         """
         if self._connection_manager is None:
             self._connection_manager = ConnectionManager(
-                self.region, self.profile, self.external_name
+                self.region, self.profile, self.external_name, self.iam_role
             )
 
         return self._connection_manager

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -234,6 +234,7 @@ class TestConfigReader(object):
             hooks={},
             s3_details=sentinel.s3_details,
             dependencies=["child/level", "top/level"],
+            iam_role=None,
             role_arn=None,
             protected=False,
             tags={},

--- a/tests/test_resolvers/test_stack_output.py
+++ b/tests/test_resolvers/test_stack_output.py
@@ -27,8 +27,9 @@ class TestStackOutputResolver(object):
         dependency = MagicMock()
         dependency.project_code = "meh"
         dependency.name = "account/dev/vpc"
-        dependency.profile = 'dependency_profile'
-        dependency.region = 'dependency_region'
+        dependency.profile = "dependency_profile"
+        dependency.region = "dependency_region"
+        dependency.iam_role = "dependency_iam_role"
 
         mock_get_output_value.return_value = "output_value"
 
@@ -44,7 +45,8 @@ class TestStackOutputResolver(object):
         assert result == "output_value"
         mock_get_output_value.assert_called_once_with(
             "meh-account-dev-vpc", "VpcId",
-            profile='dependency_profile', region='dependency_region'
+            profile="dependency_profile", region="dependency_region",
+            iam_role="dependency_iam_role"
         )
 
     @patch(
@@ -59,8 +61,9 @@ class TestStackOutputResolver(object):
         dependency = MagicMock()
         dependency.project_code = "meh"
         dependency.name = "account/dev/vpc"
-        dependency.profile = 'dependency_profile'
-        dependency.region = 'dependency_region'
+        dependency.profile = "dependency_profile"
+        dependency.region = "dependency_region"
+        dependency.iam_role = "dependency_iam_role"
 
         mock_get_output_value.return_value = "output_value"
 
@@ -76,7 +79,8 @@ class TestStackOutputResolver(object):
         assert result == "output_value"
         mock_get_output_value.assert_called_once_with(
             "meh-account-dev-vpc", "VpcId",
-            profile='dependency_profile', region='dependency_region'
+            profile="dependency_profile", region="dependency_region",
+            iam_role="dependency_iam_role"
         )
 
     @patch(
@@ -94,8 +98,9 @@ class TestStackOutputResolver(object):
         dependency = MagicMock()
         dependency.project_code = "meh"
         dependency.name = "account/dev/vpc"
-        dependency.profile = 'dependency_profile'
-        dependency.region = 'dependency_region'
+        dependency.profile = "dependency_profile"
+        dependency.region = "dependency_region"
+        dependency.iam_role = "dependency_iam_role"
 
         mock_get_output_value.return_value = "output_value"
 
@@ -109,7 +114,8 @@ class TestStackOutputResolver(object):
         assert result == "output_value"
         mock_get_output_value.assert_called_once_with(
             "meh-account-dev-vpc", "VpcId",
-            profile='dependency_profile', region='dependency_region'
+            profile="dependency_profile", region="dependency_region",
+            iam_role="dependency_iam_role"
         )
 
     @patch(
@@ -127,8 +133,9 @@ class TestStackOutputResolver(object):
         dependency = MagicMock()
         dependency.project_code = "meh"
         dependency.name = "vpc"
-        dependency.profile = 'dependency_profile'
-        dependency.region = 'dependency_region'
+        dependency.profile = "dependency_profile"
+        dependency.region = "dependency_region"
+        dependency.iam_role = "dependency_iam_role"
 
         mock_get_output_value.return_value = "output_value"
 
@@ -142,7 +149,8 @@ class TestStackOutputResolver(object):
         assert result == "output_value"
         mock_get_output_value.assert_called_once_with(
             "meh-vpc", "VpcId",
-            profile='dependency_profile', region='dependency_region'
+            profile="dependency_profile", region="dependency_region",
+            iam_role="dependency_iam_role"
         )
 
 
@@ -161,7 +169,24 @@ class TestStackOutputExternalResolver(object):
         mock_get_output_value.return_value = "output_value"
         stack_output_external_resolver.resolve()
         mock_get_output_value.assert_called_once_with(
-            "another/account-vpc", "VpcId", None
+            "another/account-vpc", "VpcId", None, None, None
+        )
+        assert stack.dependencies == []
+
+    @patch(
+        "sceptre.resolvers.stack_output.StackOutputExternal._get_output_value"
+    )
+    def test_resolve_with_args(self, mock_get_output_value):
+        stack = MagicMock(spec=Stack)
+        stack.dependencies = []
+        stack._connection_manager = MagicMock(spec=ConnectionManager)
+        stack_output_external_resolver = StackOutputExternal(
+            "another/account-vpc::VpcId region::profile::iam_role", stack
+        )
+        mock_get_output_value.return_value = "output_value"
+        stack_output_external_resolver.resolve()
+        mock_get_output_value.assert_called_once_with(
+            "another/account-vpc", "VpcId", "region", "profile", "iam_role"
         )
         assert stack.dependencies == []
 

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -22,7 +22,7 @@ class TestStack(object):
             role_arn=sentinel.role_arn, protected=False,
             tags={"tag1": "val1"}, external_name=sentinel.external_name,
             notifications=[sentinel.notification],
-            on_failure=sentinel.on_failure,
+            on_failure=sentinel.on_failure, iam_role=sentinel.iam_role,
             stack_timeout=sentinel.stack_timeout,
             stack_group_config={}
         )
@@ -50,6 +50,7 @@ class TestStack(object):
         assert stack.s3_details is None
         assert stack._template is None
         assert stack.protected is False
+        assert stack.iam_role is None
         assert stack.role_arn is None
         assert stack.dependencies == []
         assert stack.tags == {}
@@ -67,6 +68,7 @@ class TestStack(object):
             "template_bucket_name=sentinel.template_bucket_name, "\
             "template_key_prefix=sentinel.template_key_prefix, "\
             "required_version=sentinel.required_version, "\
+            "iam_role=sentinel.iam_role, "\
             "profile=sentinel.profile, " \
             "sceptre_user_data=sentinel.sceptre_user_data, " \
             "parameters={'key1': 'val1'}, "\


### PR DESCRIPTION
This is to resolve #571 / #796 

The functionality for `iam_role` has been re-introduced into the stack config and can be used at any level in the stack config (child overrides parent).

I've kept the precedence pretty much the same, the only difference is that if you specify `iam_role` then that role is assumed after Sceptre creates the session (either using environment variables, profile or local credentials). This follows what was written [here](https://github.com/Sceptre/sceptre/issues/571).

In addition, I've added support for additional arguments for the `stack_output_external` resolver, initially it would allow a profile argument only:

` !stack_output_external StackName::StackOutput my-profile`

This has now changed to support the following:
- `!stack_output_external StackName::StackOutput profile::eu-west-1::role_arn`
  - Creates session from profile, assumes role and uses region
- `!stack_output_external StackName::StackOutput ::eu-west-1::role_arn`
  - Assumes the role from the default credentials and uses region
- `!stack_output_external StackName::StackOutput profile`
  - Uses profile, profile can include role and region as well
- `!stack_output_external StackName::StackOutput ::::role_arn`
  - Assumes the role from the default credentials

There's no support right now for using an external id with an IAM role. The main reason for this is because it wasn't present in v1 so I've kept it out.

I did perform some minor testing but will probably needs extensive testing on complex Sceptre stack configurations. You can find the CircleCI checks on [my repo](https://github.com/nabeelamjad/sceptre/pull/2) (click on ✔️) for this commit sha, unsure whether this PR will run them on the Sceptre CircleCI.

## PR Checklist

- [ ] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes flake8 (`make lint`) checks.
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
