### PR TITLE
[Resolves #70] Support resolvers in template_path

### DIFF
--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -98,6 +98,7 @@ REQUIRED_KEYS = STACK_GROUP_CONFIG_ATTRIBUTES.required.union(
     STACK_CONFIG_ATTRIBUTES.required
 )
 
+
 class ConfigReader(object):
     """
     Parses YAML configuration files and produces Stack objects.
@@ -288,7 +289,7 @@ class ConfigReader(object):
             shutil.rmtree(local_temp_dir)
 
         # For now also delete .sceptre, as it serves no other purpose
-        shutil.rmtree(os.path.join(getcwd(), ".sceptre"))
+        shutil.rmtree(path.join(getcwd(), ".sceptre"))
 
     def _recursive_read(self, directory_path, filename, stack_group_config):
         """

--- a/sceptre/plan/plan.py
+++ b/sceptre/plan/plan.py
@@ -34,10 +34,13 @@ class SceptrePlan(object):
         all_stacks, command_stacks = config_reader.construct_stacks()
         self.graph = StackGraph(all_stacks)
         self.command_stacks = command_stacks
+        self.config_reader = config_reader
 
     def _execute(self, *args):
         executor = SceptrePlanExecutor(self.command, self.launch_order)
-        return executor.execute(*args)
+        result = executor.execute(*args)
+        self.config_reader.clean()
+        return result
 
     def _generate_launch_order(self, reverse=False):
         if self.context.ignore_dependencies:

--- a/sceptre/resolvers/s3.py
+++ b/sceptre/resolvers/s3.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from sceptre.resolvers import Resolver
+
+
+class S3(Resolver):
+    """
+    Resolver for the contents of an object in an S3 bucket.
+
+    :param argument: S3 path to object
+    :type argument: str
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.logger = logging.getLogger(__name__)
+        super(S3, self).__init__(*args, **kwargs)
+
+    def resolve(self):
+        self.logger.debug("Downloading file from S3: %s" % self.argument)
+
+        segments = self.argument.split('/')
+        bucket = segments[0]
+        key = "/".join(segments[1:])
+
+        connection_manager = self.stack.connection_manager
+        try:
+            response = connection_manager.call(
+                service="s3",
+                command="get_object",
+                kwargs={
+                    "Bucket": bucket,
+                    "Key": key
+                }
+            )
+            return response["Body"].read()
+        except Exception as e:
+            self.logger.fatal(e)
+            raise e

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -102,6 +102,7 @@ class Stack(object):
 
     """
 
+    template_path = ResolvableProperty("template_path")
     parameters = ResolvableProperty("parameters")
     _sceptre_user_data = ResolvableProperty("_sceptre_user_data")
     notifications = ResolvableProperty("notifications")

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,8 @@ setup(
             "file_contents = sceptre.resolvers.file_contents:FileContents",
             "stack_output = sceptre.resolvers.stack_output:StackOutput",
             "stack_output_external ="
-            "sceptre.resolvers.stack_output:StackOutputExternal"
+            "sceptre.resolvers.stack_output:StackOutputExternal",
+            "s3 = sceptre.resolvers.s3:S3"
         ]
     },
     data_files=[

--- a/tests/fixtures-resolvers/config/config.yaml
+++ b/tests/fixtures-resolvers/config/config.yaml
@@ -1,0 +1,4 @@
+profile: account_profile
+project_code: account_project_code
+region: account_region
+required_version: ">1.0"

--- a/tests/fixtures-resolvers/config/top/level.yaml
+++ b/tests/fixtures-resolvers/config/top/level.yaml
@@ -1,0 +1,1 @@
+template_path: !s3 path.yaml

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -272,17 +272,19 @@ class TestConfigReader(object):
 
         ConfigReader(self.context).construct_stacks()
 
-        assert os.path.isdir(os.path.join(os.getcwd(), ".sceptre"))
-        assert os.path.isfile(os.path.join(os.getcwd(), ".sceptre", "path.yaml"))
+        temp_dir = os.path.join(os.getcwd(), ".sceptre", "tmp")
+        temp_file = os.path.join(temp_dir, "path.yaml")
+        assert os.path.isdir(temp_dir)
+        assert os.path.isfile(temp_file)
 
-        with open(os.path.join(os.getcwd(), ".sceptre", "path.yaml"), "rb") as f:
+        with open(temp_file, "rb") as f:
             content = f.read()
             assert content == b"my template"
 
         mock_Stack.assert_any_call(
             name="top/level",
             project_code="account_project_code",
-            template_path=os.path.join(os.getcwd(), ".sceptre", "path.yaml"),
+            template_path=temp_file,
             region="account_region",
             template_bucket_name=None,
             template_key_prefix=None,

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -56,3 +56,17 @@ class TestSceptrePlan(object):
             plan = MagicMock(spec=SceptrePlan)
             plan.context = self.mock_context
             plan.invalid_command()
+
+    @patch("sceptre.plan.plan.SceptrePlanExecutor")
+    @patch("sceptre.plan.plan.ConfigReader")
+    def test_should_cleanup_after_execution(self, mock_config_reader_creator, mock_executor):
+        mock_config_reader_creator.return_value = self.mock_config_reader
+        self.mock_config_reader.construct_stacks.return_value = [], []
+
+        self.mock_context.ignore_dependencies = True
+
+        plan = SceptrePlan(self.mock_context)
+        plan.config_reader = self.mock_config_reader
+        plan.launch()
+
+        self.mock_config_reader.clean.assert_called_once()

--- a/tests/test_resolvers/test_s3.py
+++ b/tests/test_resolvers/test_s3.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+import io
+
+import pytest
+from mock import MagicMock
+
+from sceptre.connection_manager import ConnectionManager
+from sceptre.exceptions import SceptreException
+from sceptre.resolvers.s3 import S3
+from sceptre.stack import Stack
+
+
+class TestS3Resolver(object):
+
+    def test_resolver(self):
+        stack = MagicMock(spec=Stack)
+        stack.dependencies = []
+        stack.project_code = "project-code"
+
+        stack._connection_manager = MagicMock(spec=ConnectionManager)
+        stack.connection_manager.call.return_value = {
+            "Body": io.BytesIO(b"Stuff is working")
+        }
+
+        s3_resolver = S3(
+            "my-fancy-bucket/account/vpc.yaml", stack
+        )
+        s3_resolver.setup()
+
+        result = s3_resolver.resolve()
+
+        stack.connection_manager.call.assert_called_once_with(
+            service="s3",
+            command="get_object",
+            kwargs={
+                "Bucket": "my-fancy-bucket",
+                "Key": "account/vpc.yaml"
+            }
+        )
+        assert result == b"Stuff is working"
+
+    def test_invalid_response_reraises_exception(self):
+        stack = MagicMock(spec=Stack)
+        stack.dependencies = []
+        stack.project_code = "project-code"
+
+        stack._connection_manager = MagicMock(spec=ConnectionManager)
+        stack.connection_manager.call.side_effect = SceptreException("BOOM!")
+
+        s3_resolver = S3(
+            "my-fancy-bucket/account/vpc.yaml", stack
+        )
+        s3_resolver.setup()
+
+        with pytest.raises(SceptreException) as e:
+            s3_resolver.resolve()
+
+        assert str(e.value) == "BOOM!"


### PR DESCRIPTION
Allows resolvers in the `template_path` property of a stack config. This is done by extending the ConfigReader a little so it knows that it is dealing with a resolver. A temporary path to store the remote contents will be created and when the `Stack` is created, it writes the content there. After the plan has executed the local directory (currently `.sceptre` in the CWD) will be removed.

A new resolver was added that allows support for a config like this:

```
template_path: !s3 my-bucket/my-template.yaml
parameters:
    ....
```

This also resolves issue #213 

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
