### PR TITLE
[Resolve #785] Clean up code blocks in doc

### DIFF
--- a/docs/_source/docs/faq.rst
+++ b/docs/_source/docs/faq.rst
@@ -11,9 +11,9 @@ substituted out.
 
 In config.yaml:
 
-.. code-block:: jinja
+.. code-block:: yaml
 
-   {% raw %}region: {{ var.region }}{% endraw %}
+   region: {{ var.region }}
 
 On the CLI:
 
@@ -53,7 +53,7 @@ It is possible to replace values in stack config files with environment
 variables in two ways.
 
 The first is by using templating, and the syntax
-``{% raw %}{{ environment_variable.VALUE }}{% endraw %}``. Any value in a
+``{{ environment_variable.VALUE }}``. Any value in a
 config file may be replaced using this method.
 
 The second is by using a resolver, and the syntax:

--- a/docs/_source/docs/stack_config.rst
+++ b/docs/_source/docs/stack_config.rst
@@ -211,10 +211,10 @@ StackGroup config
 StackGroup config properties are available via the stack_group_config variable
 when using templating.
 
-.. code-block:: jinja
+.. code-block:: yaml
 
    parameters:
-     sceptre-project-code: {% raw %}{{ stack_group_config.sceptre-project-code }}{% endraw %}
+     sceptre-project-code: {{ stack_group_config.sceptre-project-code }}
 
 Environment Variables
 ---------------------
@@ -255,9 +255,8 @@ Examples
      param_1: value_1
      param_2: value_2
 
-.. code-block:: jinja
+.. code-block:: yaml
 
-   {% raw %}
    template_path: example.json
    dependencies:
        - dev/vpc.yaml
@@ -286,7 +285,6 @@ Examples
    stack_tags:
        tag_1: value_1
        tag_2: value_2
-   {% endraw %}
 
 .. _template_path: #template_path
 .. _dependencies: #dependencies

--- a/docs/_source/docs/stack_group_config.rst
+++ b/docs/_source/docs/stack_group_config.rst
@@ -131,9 +131,9 @@ Var
 User variables are used to replace the value of any item in a config file with
 a value defined by a CLI flag or in a YAML variable file:
 
-.. code-block:: jinja
+.. code-block:: yaml
 
-   profile: {% raw %}{{ var.profile }}{% endraw %}
+   profile: {{ var.profile }}
    region: eu-west-1
 
 This item can be set using either a command line flag:
@@ -162,16 +162,16 @@ will overwrite any value defined in the variable files.
 
 For example if we have the following variable files:
 
-.. TODO split into 2 blocks
-
 .. code-block:: yaml
 
-   ---- default.yaml
+   # default.yaml
    region: eu-west-1
    profile: dev
    project_code: api
 
-   ---- prod.yaml
+.. code-block:: yaml
+
+   # prod.yaml
    profile: prod
 
 The following sceptre command:
@@ -202,9 +202,9 @@ Environment Variables
 
 Config item values can be replaced with environment variables:
 
-.. code-block:: jinja
+.. code-block:: yaml
 
-   profile: {% raw %}{{ environment_variable.PROFILE }}{% endraw %}
+   profile: {{ environment_variable.PROFILE }}
    region: eu-west-1
 
 Where ``PROFILE`` is the name of an environment variable.
@@ -214,9 +214,9 @@ Command Path
 
 Config item values can be replaced with parts of the ``command_path``
 
-.. code-block:: jinja
+.. code-block:: yaml
 
-   region: {% raw %}{{ command_path.0 }}{% endraw %}
+   region: {{ command_path.0 }}
    profile: default
 
 Where the value is taken from the first part of the ``command_path`` from the
@@ -231,9 +231,9 @@ Template Defaults
 
 Any templated value can be supplied with a default value with the syntax:
 
-.. code-block:: jinja
+.. code-block:: text
 
-   {% raw %}{{ var.value | default("default_value") }}{% endraw %}
+   {{ var.value | default("default_value") }}
 
 Examples
 --------
@@ -246,14 +246,12 @@ Examples
    template_bucket_name: sceptre-artifacts
    template_key_prefix: my/prefix
 
-.. code-block:: jinja
+.. code-block:: yaml
 
-   {% raw %}
    profile: {{ var.profile }}
    project_code: {{ var.project_code | default("prj") }}
    region: {{ command_path.2 }}
    template_bucket_name: {{ environment_variable.TEMPLATE_BUCKET_NAME }}
-   {% endraw %}
 
 .. _project_code: #project_code
 .. _region: #region

--- a/docs/_source/docs/templates.rst
+++ b/docs/_source/docs/templates.rst
@@ -24,12 +24,12 @@ Templates. They are read in and used without modification.
 Jinja
 -----
 
-{% raw %} Templates with ``.j2`` extensions are treated as Jinja2 Templates.
+Templates with ``.j2`` extensions are treated as Jinja2 Templates.
 These are rendered and should create a raw JSON or YAML CloudFormation
 Template. Sceptre User Data is accessible within Templates as
 ``sceptre_user_data``. For example ``{{ sceptre_user_data.some_variable }}``.
 ``sceptre_user_data`` accesses the ``sceptre_user_data`` key in the Stack
-Config file. {% endraw %}
+Config file.
 
 Python
 ------


### PR DESCRIPTION
As mentioned in the issue, there are a lot of raw and endraw tags around that are not replaced during the doc build. Looking at this, I also saw that the type of code block could be changed to yaml in many cases for better readability.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
