### PR TITLE
Replace JSON with YAML as default Cloudformation format in doc

### DIFF
--- a/docs/_source/docs/get_started.rst
+++ b/docs/_source/docs/get_started.rst
@@ -45,43 +45,33 @@ On \*nix systems:
 .. code-block:: text
 
    mkdir config/dev
-   touch config/dev/config.yaml config/dev/vpc.yaml templates/vpc.json
+   touch config/dev/config.yaml config/dev/vpc.yaml templates/vpc.yaml
 
-``vpc.json`` will contain a CloudFormation template, ``vpc.yaml`` will contain
+``templates/vpc.yaml`` will contain a CloudFormation template, ``config/dev/vpc.yaml`` will contain
 config relevant to that template, and ``config.yaml`` will contain environment
 config.
 
-Our First Template - vpc.json
+Our First Template - vpc.yaml
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Add the following CloudFormation to ``templates/vpc.json``:
+Add the following CloudFormation to ``templates/vpc.yaml``:
 
-.. code-block:: json
+.. code-block:: yaml
 
-   {
-     "Parameters": {
-       "CidrBlock": {
-         "Type": "String"
-       }
-     },
-     "Resources": {
-       "VPC": {
-         "Type": "AWS::EC2::VPC",
-         "Properties": {
-           "CidrBlock": {
-             "Ref": "CidrBlock"
-           }
-         }
-       }
-     },
-     "Outputs": {
-       "VpcId": {
-         "Value": {
-           "Ref": "VPC"
-         }
-       }
-     }
-   }
+  Parameters:
+    CidrBlock:
+      Type: String
+  Resources:
+    VPC:
+      Type: 'AWS::EC2::VPC'
+      Properties:
+        CidrBlock:
+          Ref: CidrBlock
+  Outputs:
+    VpcId:
+      Value:
+        Ref: VPC
+
 
 For more information on CloudFormation, see the AWS documentation on
 `CloudFormation`_.
@@ -106,7 +96,7 @@ Add the following configuration to ``config/dev/vpc.yaml``:
 
 .. code-block:: yaml
 
-   template_path: vpc.json
+   template_path: vpc.yaml
    parameters:
      CidrBlock: 10.0.0.0/16
 
@@ -115,7 +105,7 @@ Jinja2 template to use to launch the Stack. Sceptre will use the ``templates``
 directory as the root templates directory to base your ``template_path`` from.
 
 ``parameters`` lists the parameters which are supplied to the template
-``vpc.json``.
+``vpc.yaml``.
 
 You should now have a Sceptre project that looks a bit like:
 
@@ -129,7 +119,7 @@ You should now have a Sceptre project that looks a bit like:
    │       ├── config.yaml
    │       └── vpc.yaml
    └── templates
-       └── vpc.json
+       └── vpc.yaml
 
 ..
 

--- a/docs/_source/docs/stack_config.rst
+++ b/docs/_source/docs/stack_config.rst
@@ -257,7 +257,7 @@ Examples
 
 .. code-block:: yaml
 
-   template_path: example.json
+   template_path: example.yaml
    dependencies:
        - dev/vpc.yaml
    hooks:


### PR DESCRIPTION
YAML has replaced JSON as a more popular format for writing Cloudformation templates, this should be reflected in the documentation.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
