### PR TITLE
[Resolves #758] Improve error message for stack_output dependencies

### DIFF
--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -220,16 +220,20 @@ class ConfigReader(object):
             if abs_path.startswith(self.context.full_command_path()):
                 command_stacks.add(stack)
 
-        stacks = self.resolveStacks(stack_map)
+        stacks = self.resolve_stacks(stack_map)
 
         return stacks, command_stacks
 
-    def resolveStacks(self, stack_map):
+    def resolve_stacks(self, stack_map):
         """
+        Transforms map of Stacks into a set of Stacks, transforms dependencies
+        from a list of Strings (stack names) to a list of Stacks.
+
         :param stack_map: Map of stacks, containing dependencies as list of Strings.
         :type base_config: dict
         :returns: Set of stacks, containing dependencies as list of Stacks.
         :rtype: set
+        :raises: sceptre.exceptions.DependencyDoesNotExistError
         """
         stacks = set()
         for stack in stack_map.values():

--- a/sceptre/exceptions.py
+++ b/sceptre/exceptions.py
@@ -36,6 +36,13 @@ class TemplateSceptreHandlerError(SceptreException):
     pass
 
 
+class DependencyDoesNotExistError(SceptreException):
+    """
+    Error raised when a dependency cannot be found
+    """
+    pass
+
+
 class DependencyStackNotLaunchedError(SceptreException):
     """
     Error raised when a dependency stack has not been launched

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -38,6 +38,34 @@ class TestConfigReader(object):
         with pytest.raises(InvalidSceptreDirectoryError):
             ConfigReader(SceptreContext("/path/does/not/exist", "example"))
 
+    def create_project(self):
+        """
+        Creates a new random temporary directory with a config subdirectory
+        """
+        with self.runner.isolated_filesystem():
+            project_path = os.path.abspath('./example')
+        config_dir = os.path.join(project_path, "config")
+        os.makedirs(config_dir)
+        return (project_path, config_dir)
+
+    def write_config(self, abs_path, config):
+        """
+        Writes a configuration dict to the specified path as YAML
+        """
+        if abs_path.endswith(".yaml"):
+            dir_path = os.path.split(abs_path)[0]
+        if not os.path.exists(dir_path):
+            try:
+                os.makedirs(dir_path)
+            except OSError as exc:
+                if exc.errno != errno.EEXIST:
+                    raise
+
+        with open(abs_path, 'w') as config_file:
+            yaml.safe_dump(
+                config, stream=config_file, default_flow_style=False
+            )
+
     @pytest.mark.parametrize("filepaths,target", [
         (
             ["A/1.yaml"], "A/1.yaml"
@@ -50,34 +78,21 @@ class TestConfigReader(object):
         )
     ])
     def test_read_reads_config_file(self, filepaths, target):
-        with self.runner.isolated_filesystem():
-            project_path = os.path.abspath('./example')
-            config_dir = os.path.join(project_path, "config")
-            os.makedirs(config_dir)
+        project_path, config_dir = self.create_project()
 
-            for rel_path in filepaths:
-                abs_path = os.path.join(config_dir, rel_path)
-                if not os.path.exists(os.path.dirname(abs_path)):
-                    try:
-                        os.makedirs(os.path.dirname(abs_path))
-                    except OSError as exc:
-                        if exc.errno != errno.EEXIST:
-                            raise
+        for rel_path in filepaths:
+            config = {"filepath": rel_path}
+            abs_path = os.path.join(config_dir, rel_path)
+            self.write_config(abs_path, config)
 
-                config = {"filepath": rel_path}
-                with open(abs_path, 'w') as config_file:
-                    yaml.safe_dump(
-                        config, stream=config_file, default_flow_style=False
-                    )
+        self.context.project_path = project_path
+        config = ConfigReader(self.context).read(target)
 
-            self.context.project_path = project_path
-            config = ConfigReader(self.context).read(target)
-
-            assert config == {
-                "project_path": project_path,
-                "stack_group_path": os.path.split(target)[0],
-                "filepath": target
-            }
+        assert config == {
+            "project_path": project_path,
+            "stack_group_path": os.path.split(target)[0],
+            "filepath": target
+        }
 
     def test_read_reads_config_file_with_base_config(self):
         with self.runner.isolated_filesystem():
@@ -110,13 +125,10 @@ class TestConfigReader(object):
             }
 
     def test_read_with_nonexistant_filepath(self):
-        with self.runner.isolated_filesystem():
-            project_path = os.path.abspath('./example')
-            config_dir = os.path.join(project_path, "config")
-            os.makedirs(config_dir)
-            self.context.project_path = project_path
-            with pytest.raises(ConfigFileNotFoundError):
-                ConfigReader(self.context).read("stack.yaml")
+        project_path, config_dir = self.create_project()
+        self.context.project_path = project_path
+        with pytest.raises(ConfigFileNotFoundError):
+            ConfigReader(self.context).read("stack.yaml")
 
     def test_read_with_empty_config_file(self):
         config_reader = ConfigReader(self.context)
@@ -262,37 +274,23 @@ class TestConfigReader(object):
     def test_construct_stacks_with_valid_config(
         self, filepaths, expected_stacks
     ):
-        with self.runner.isolated_filesystem():
-            project_path = os.path.abspath('./example')
-            config_dir = os.path.join(project_path, "config")
-            os.makedirs(config_dir)
+        project_path, config_dir = self.create_project()
 
-            for rel_path in filepaths:
-                abs_path = os.path.join(config_dir, rel_path)
-                dir_path = abs_path
-                if abs_path.endswith(".yaml"):
-                    dir_path = os.path.split(abs_path)[0]
-                if not os.path.exists(dir_path):
-                    try:
-                        os.makedirs(dir_path)
-                    except OSError as exc:
-                        if exc.errno != errno.EEXIST:
-                            raise
+        for rel_path in filepaths:
 
-                config = {
-                    "region": "region",
-                    "project_code": "project_code",
-                    "template_path": rel_path
-                }
-                with open(abs_path, 'w') as config_file:
-                    yaml.safe_dump(
-                        config, stream=config_file, default_flow_style=False
-                    )
+            config = {
+                "region": "region",
+                "project_code": "project_code",
+                "template_path": rel_path
+            }
 
-            self.context.project_path = project_path
-            config_reader = ConfigReader(self.context)
-            all_stacks, command_stacks = config_reader.construct_stacks()
-            assert {str(stack) for stack in all_stacks} == expected_stacks
+            abs_path = os.path.join(config_dir, rel_path)
+            self.write_config(abs_path, config)
+
+        self.context.project_path = project_path
+        config_reader = ConfigReader(self.context)
+        all_stacks, command_stacks = config_reader.construct_stacks()
+        assert {str(stack) for stack in all_stacks} == expected_stacks
 
     @pytest.mark.parametrize("filepaths, del_key", [
         (["A/1.yaml"], "project_code"),
@@ -302,49 +300,32 @@ class TestConfigReader(object):
     def test_missing_attr(
         self, filepaths, del_key
     ):
-        with self.runner.isolated_filesystem():
-            project_path = os.path.abspath('./example')
-            config_dir = os.path.join(project_path, "config")
-            os.makedirs(config_dir)
+        project_path, config_dir = self.create_project()
 
-            self.context.project_path = project_path
+        for rel_path in filepaths:
 
-            for rel_path in filepaths:
-                abs_path = os.path.join(config_dir, rel_path)
-                dir_path = abs_path
-                if abs_path.endswith(".yaml"):
-                    dir_path = os.path.split(abs_path)[0]
-                if not os.path.exists(dir_path):
-                    try:
-                        os.makedirs(dir_path)
-                    except OSError as exc:
-                        if exc.errno != errno.EEXIST:
-                            raise
+            config = {
+                "project_code": "project_code",
+                "region": "region",
+                "template_path": rel_path
+            }
+            # Delete the mandatory key to be tested.
+            del config[del_key]
 
-                config = {
-                    "project_code": "project_code",
-                    "region": "region",
-                    "template_path": rel_path
-                }
+            abs_path = os.path.join(config_dir, rel_path)
+            self.write_config(abs_path, config)
 
-                # Delete the mandatory key to be tested.
-                del config[del_key]
-
-                with open(abs_path, 'w') as config_file:
-                    yaml.safe_dump(
-                        config, stream=config_file, default_flow_style=False
-                    )
-
-            try:
-                config_reader = ConfigReader(self.context)
-                all_stacks, command_stacks = config_reader.construct_stacks()
-            except InvalidConfigFileError as e:
-                # Test that the missing key is reported.
-                assert del_key in str(e)
-            except Exception:
-                raise
-            else:
-                assert False
+        self.context.project_path = project_path
+        try:
+            config_reader = ConfigReader(self.context)
+            all_stacks, command_stacks = config_reader.construct_stacks()
+        except InvalidConfigFileError as e:
+            # Test that the missing key is reported.
+            assert del_key in str(e)
+        except Exception:
+            raise
+        else:
+            assert False
 
     @pytest.mark.parametrize("filepaths, dependency", [
         (["A/1.yaml", "B/1.yaml", "B/2.yaml"], "A/1.yaml"),
@@ -353,48 +334,31 @@ class TestConfigReader(object):
     def test_existing_dependency(
         self, filepaths, dependency
     ):
-        with self.runner.isolated_filesystem():
-            project_path = os.path.abspath('./example')
-            config_dir = os.path.join(project_path, "config")
-            os.makedirs(config_dir)
+        project_path, config_dir = self.create_project()
 
-            self.context.project_path = project_path
+        for rel_path in filepaths:
+            # Set up config with reference to an existing stack
+            config = {
+                "project_code": "project_code",
+                "region": "region",
+                "template_path": rel_path,
+                "dependencies": [dependency]
+            }
 
-            for rel_path in filepaths:
-                abs_path = os.path.join(config_dir, rel_path)
-                dir_path = abs_path
-                if abs_path.endswith(".yaml"):
-                    dir_path = os.path.split(abs_path)[0]
-                if not os.path.exists(dir_path):
-                    try:
-                        os.makedirs(dir_path)
-                    except OSError as exc:
-                        if exc.errno != errno.EEXIST:
-                            raise
+            abs_path = os.path.join(config_dir, rel_path)
+            self.write_config(abs_path, config)
 
-                # Set up config with reference to non-existing stack
-                config = {
-                    "project_code": "project_code",
-                    "region": "region",
-                    "template_path": rel_path,
-                    "dependencies": [dependency]
-                }
-
-                with open(abs_path, 'w') as config_file:
-                    yaml.safe_dump(
-                        config, stream=config_file, default_flow_style=False
-                    )
-
-            try:
-                config_reader = ConfigReader(self.context)
-                all_stacks, command_stacks = config_reader.construct_stacks()
-            except DependencyDoesNotExistError as e:
-                # Test that the missing dependency is reported.
-                assert False
-            except Exception:
-                raise
-            else:
-                assert True
+        self.context.project_path = project_path
+        try:
+            config_reader = ConfigReader(self.context)
+            all_stacks, command_stacks = config_reader.construct_stacks()
+        except DependencyDoesNotExistError as e:
+            # Test that the missing dependency is reported.
+            assert False
+        except Exception:
+            raise
+        else:
+            assert True
 
     @pytest.mark.parametrize("filepaths, dependency", [
         (["A/1.yaml", "B/1.yaml", "B/2.yaml"], "A/2.yaml"),
@@ -403,45 +367,29 @@ class TestConfigReader(object):
     def test_missing_dependency(
         self, filepaths, dependency
     ):
-        with self.runner.isolated_filesystem():
-            project_path = os.path.abspath('./example')
-            config_dir = os.path.join(project_path, "config")
-            os.makedirs(config_dir)
+        project_path, config_dir = self.create_project()
 
-            self.context.project_path = project_path
 
-            for rel_path in filepaths:
-                abs_path = os.path.join(config_dir, rel_path)
-                dir_path = abs_path
-                if abs_path.endswith(".yaml"):
-                    dir_path = os.path.split(abs_path)[0]
-                if not os.path.exists(dir_path):
-                    try:
-                        os.makedirs(dir_path)
-                    except OSError as exc:
-                        if exc.errno != errno.EEXIST:
-                            raise
+        for rel_path in filepaths:
+            # Set up config with reference to non-existing stack
+            config = {
+                "project_code": "project_code",
+                "region": "region",
+                "template_path": rel_path,
+                "dependencies": [dependency]
+            }
 
-                # Set up config with reference to non-existing stack
-                config = {
-                    "project_code": "project_code",
-                    "region": "region",
-                    "template_path": rel_path,
-                    "dependencies": [dependency]
-                }
+            abs_path = os.path.join(config_dir, rel_path)
+            self.write_config(abs_path, config)
 
-                with open(abs_path, 'w') as config_file:
-                    yaml.safe_dump(
-                        config, stream=config_file, default_flow_style=False
-                    )
-
-            try:
-                config_reader = ConfigReader(self.context)
-                all_stacks, command_stacks = config_reader.construct_stacks()
-            except DependencyDoesNotExistError as e:
-                # Test that the missing dependency is reported.
-                assert dependency in str(e)
-            except Exception:
-                raise
-            else:
-                assert False
+        self.context.project_path = project_path
+        try:
+            config_reader = ConfigReader(self.context)
+            all_stacks, command_stacks = config_reader.construct_stacks()
+        except DependencyDoesNotExistError as e:
+            # Test that the missing dependency is reported.
+            assert dependency in str(e)
+        except Exception:
+            raise
+        else:
+            assert False

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -352,9 +352,6 @@ class TestConfigReader(object):
         try:
             config_reader = ConfigReader(self.context)
             all_stacks, command_stacks = config_reader.construct_stacks()
-        except DependencyDoesNotExistError as e:
-            # Test that the missing dependency is reported.
-            assert False
         except Exception:
             raise
         else:
@@ -368,7 +365,6 @@ class TestConfigReader(object):
         self, filepaths, dependency
     ):
         project_path, config_dir = self.create_project()
-
 
         for rel_path in filepaths:
             # Set up config with reference to non-existing stack

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -293,13 +293,13 @@ class TestConfigReader(object):
             all_stacks, command_stacks = config_reader.construct_stacks()
             assert {str(stack) for stack in all_stacks} == expected_stacks
 
-    @pytest.mark.parametrize("filepaths,target,del_key", [
-        (["A/1.yaml"], "A/1.yaml", "project_code"),
-        (["A/1.yaml"], "A/1.yaml", "region"),
-        (["A/1.yaml"], "A/1.yaml", "template_path"),
+    @pytest.mark.parametrize("filepaths, del_key", [
+        (["A/1.yaml"], "project_code"),
+        (["A/1.yaml"], "region"),
+        (["A/1.yaml"], "template_path"),
     ])
     def test_missing_attr(
-        self, filepaths, target, del_key
+        self, filepaths, del_key
     ):
         with self.runner.isolated_filesystem():
             project_path = os.path.abspath('./example')


### PR DESCRIPTION
Broke the list comprehension apart because otherwise we can't get info on the current iteration (dependency name).
Had to take the edited part out as a separate function because construct_stacks was getting too complex according to make lint.
Unit test is still missing, please let me know if my general approach is ok and I'll add it.
I set up a small test repo that replicates the issue here: https://github.com/uhinze/sceptre-stackoutput

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
