### PR TITLE
[Resolves #686] Add docs clean target

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -20,3 +20,8 @@ help:
 
 apidoc:
 	@sphinx-apidoc -fM -o "$(SOURCEDIR)/apidoc" ../sceptre
+
+clean:
+	rm -f sceptre*rst
+	rm -f modules.rst
+	rm -rf _build


### PR DESCRIPTION
Before this commit, during installation there is an error message about missing dependencies (`sphinx-build` or, if this is present, `sphinx-apidoc`).

Root cause is that a `clean` target is missing from docs/Makefile. From the main Makefile target `docs-clean` this target is called, but ends up in the catch-all target which needs sphinx-build.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
