### PR TITLE
Fix version links

### DIFF
--- a/docs/_source/_templates/versions.html
+++ b/docs/_source/_templates/versions.html
@@ -32,7 +32,7 @@
                     function () {
                         versions.forEach(function (item, index) {
                             if (item !== "{{ version }}") {
-                                $('#other-versions').append('<dd><a href="../' + item + '">' + item + "<a/></dd>");
+                                $('#other-versions').append('<dd><a href="'+ window.location.origin + '/' + item +'">' + item + "<a/></dd>");
                             }
                         })
                     });


### PR DESCRIPTION
Fixes #833 

This fix will generate version urls from the origin to the version number which results into on every page:
```
origin: https://sceptre.cloudreach.com 
version number: 2.2.1
result: https://sceptre.cloudreach.com/2.2.1/
```
Additionally we could think of a slight improvement by adding "path" prefix for the future if needed.

E.g. 

```
origin: https://sceptre.cloudreach.com 
version number: 2.2.1
prefix: docs

result: https://sceptre.cloudreach.com/docs/2.2.1/
```