### PR TITLE
Add the stack_output_external_region resolver

### DIFF
--- a/sceptre/resolvers/stack_output.py
+++ b/sceptre/resolvers/stack_output.py
@@ -174,7 +174,7 @@ class StackOutputExternalRegion(StackOutputBase):
     Resolver for retrieving the value of an output of any Stack in any region.
 
     :param argument: The Stack name, output name, and region to get.
-    :type argument: str in the format ``"<full stack name>::<output key>"``
+    :type argument: str in the format ``"<full stack name>::<output key> <region>"``
     """
 
     def __init__(self, *args, **kwargs):

--- a/sceptre/resolvers/stack_output.py
+++ b/sceptre/resolvers/stack_output.py
@@ -168,6 +168,7 @@ class StackOutputExternal(StackOutputBase):
             dependency_stack_name, output_key, profile
         )
 
+
 class StackOutputExternalRegion(StackOutputBase):
     """
     Resolver for retrieving the value of an output of any Stack in any region.

--- a/sceptre/resolvers/stack_output.py
+++ b/sceptre/resolvers/stack_output.py
@@ -167,3 +167,41 @@ class StackOutputExternal(StackOutputBase):
         return self._get_output_value(
             dependency_stack_name, output_key, profile
         )
+
+class StackOutputExternalRegion(StackOutputBase):
+    """
+    Resolver for retrieving the value of an output of any Stack in any region.
+
+    :param argument: The Stack name, output name, and region to get.
+    :type argument: str in the format ``"<full stack name>::<output key>"``
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(StackOutputExternalRegion, self).__init__(*args, **kwargs)
+
+    def resolve(self):
+        """
+        Retrieves the value of CloudFormation output of the external Stack
+
+        :returns: The value of the Stack output.
+        :rtype: str
+        """
+
+        self.logger.debug(
+            "Resolving external Stack output: {0}".format(self.argument)
+        )
+
+        profile = None
+        arguments = shlex.split(self.argument)
+
+        stack_argument = arguments[0]
+        region = arguments[1]
+
+        # optional profile
+        if len(arguments) > 2:
+            profile = arguments[2]
+
+        dependency_stack_name, output_key = stack_argument.split("::")
+        return self._get_output_value(
+            dependency_stack_name, output_key, profile, region
+        )

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,9 @@ setup(
             "file_contents = sceptre.resolvers.file_contents:FileContents",
             "stack_output = sceptre.resolvers.stack_output:StackOutput",
             "stack_output_external ="
-            "sceptre.resolvers.stack_output:StackOutputExternal"
+            "sceptre.resolvers.stack_output:StackOutputExternal",
+            "stack_output_external_region ="
+            "sceptre.resolvers.stack_output:StackOutputExternalRegion",
         ]
     },
     data_files=[

--- a/tests/test_resolvers/test_stack_output.py
+++ b/tests/test_resolvers/test_stack_output.py
@@ -9,7 +9,8 @@ from botocore.exceptions import ClientError
 
 from sceptre.connection_manager import ConnectionManager
 from sceptre.resolvers.stack_output import \
-    StackOutput, StackOutputExternal, StackOutputBase
+    StackOutput, StackOutputExternal, StackOutputBase, \
+    StackOutputExternalRegion
 from sceptre.stack import Stack
 
 
@@ -162,6 +163,26 @@ class TestStackOutputExternalResolver(object):
         stack_output_external_resolver.resolve()
         mock_get_output_value.assert_called_once_with(
             "another/account-vpc", "VpcId", None
+        )
+        assert stack.dependencies == []
+
+
+class TestStackOutputExternalRegionResolver(object):
+
+    @patch(
+        "sceptre.resolvers.stack_output.StackOutputExternalRegion._get_output_value"
+    )
+    def test_resolve(self, mock_get_output_value):
+        stack = MagicMock(spec=Stack)
+        stack.dependencies = []
+        stack._connection_manager = MagicMock(spec=ConnectionManager)
+        stack_output_external_resolver = StackOutputExternalRegion(
+            "another/account-vpc::VpcId us-east-1", stack
+        )
+        mock_get_output_value.return_value = "output_value"
+        stack_output_external_resolver.resolve()
+        mock_get_output_value.assert_called_once_with(
+            "another/account-vpc", "VpcId", None, "us-east-1"
         )
         assert stack.dependencies == []
 

--- a/tests/test_resolvers/test_stack_output.py
+++ b/tests/test_resolvers/test_stack_output.py
@@ -186,6 +186,23 @@ class TestStackOutputExternalRegionResolver(object):
         )
         assert stack.dependencies == []
 
+    @patch(
+        "sceptre.resolvers.stack_output.StackOutputExternalRegion._get_output_value"
+    )
+    def test_resolve_with_profile(self, mock_get_output_value):
+        stack = MagicMock(spec=Stack)
+        stack.dependencies = []
+        stack._connection_manager = MagicMock(spec=ConnectionManager)
+        stack_output_external_resolver = StackOutputExternalRegion(
+            "another/account-vpc::VpcId us-east-1 my-other-profile", stack
+        )
+        mock_get_output_value.return_value = "output_value"
+        stack_output_external_resolver.resolve()
+        mock_get_output_value.assert_called_once_with(
+            "another/account-vpc", "VpcId", "my-other-profile", "us-east-1"
+        )
+        assert stack.dependencies == []
+
 
 class MockStackOutputBase(StackOutputBase):
     """


### PR DESCRIPTION
This PR adds the `!stack_output_external_region` resolver to Sceptre. It works the same way as `!stack_output_external` but with the added region parameter. This is so you can reference a stack in another region other than the region defined in the stack configuration. It also maintains the optional extra profile parameter that `!stack_output_external` has.

Here is a simple example use:

```yaml
# config/dev/us-east-1/example-io-zone.yaml
template_path: hosted-zone.yaml
profile: dev
parameters:
  Name: example.io
```
```yaml
# templates/hosted-zone.yaml
...

Outputs:
  HostedZoneID:
    Description: Hosted zone ID
    Value: !Ref HostedZone
```
```yaml
# config/dev/us-west-2/db-dns.yaml

region: us-west-2
profile: dev
parameters:
  HostedZoneID: !stack_output_external_region dev-us-east-1-example-com-zone::HostedZoneID us-east-1
```

Here is another example use with profile

```yaml
# config/internal/us-east-1/nessus-scanner.yaml
template_path: ec2-instance.yaml
profile: internal
parameters:
  ...
```
```yaml
# templates/ec2-instance.yaml
...

Outputs:
  InstanceId:
    Description: Instance ID
    Value: !Ref Instance
  PrivateIp:
    Description: Instance private IP
    Value: !GetAtt Instance.PrivateIp
  PublicIp:
    Description: Instance public IP (EIP)
    Value: !Ref ElasticIP
```
```yaml
# config/dev/us-west-2/app-server.yaml
template_path: ec2-instance.yaml
profile: prod
parameters:
  AllowAccess:
    - address: 0.0.0.0/0
      port: 80
    - address: !stack_group_external_region internal-us-east-1-nessus-scanner::PrivateIp internal
      port: 22
```

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`. _I could not find an existing issue to reference_
- [x] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable). _Integration tests might be useful but I'm not sure where to start to build those_
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
