### PR TITLE
Allow to keep specific versions of docs

### DIFF
--- a/.circleci/documentation-versions.py
+++ b/.circleci/documentation-versions.py
@@ -67,7 +67,7 @@ def main():
     )
     with open(build_dir + "/version-helper.js", "w+") as outf:
         outf.write("let versions = {};".format(active_versions))
-    # print out old versions to be removed
+    # print versions_to_remove to stdout for deletion by bash script (github-pages.sh)
     print(",".join(versions_to_remove))
 
 


### PR DESCRIPTION
This update prevents github-pages script to delete specific versions.
Which is needed for docs of `1.5.0`.

Merge this before https://github.com/Sceptre/sceptre.github.io/pull/2