### PR TITLE
WIP [Resolve #426] resolver support for stack_tags

### DIFF
--- a/docs/_source/docs/resolvers.rst
+++ b/docs/_source/docs/resolvers.rst
@@ -2,8 +2,9 @@ Resolvers
 =========
 
 Sceptre implements resolvers, which can be used to resolve a value of a
-CloudFormation ``parameter`` or ``sceptre_user_data`` value at runtime. This is
-most commonly used to chain the outputs of one Stack to the inputs of another.
+CloudFormation ``parameter``, ``sceptre_user_data``, and ``stack_tags`` value
+at runtime. This is most commonly used to chain the outputs of one Stack to
+the inputs of another.
 
 If required, users can create their own resolvers, as described in the section
 on `Custom Resolvers`_.
@@ -16,6 +17,8 @@ Syntax:
      <parameter_name>: !<resolver_name> <resolver_value>
    sceptre_user_data:
      <name>: !<resolver_name> <resolver_value>
+   stack_tags:
+     <tag_name>: !<resolver_name> <resolver_value>
 
 Available Resolvers
 -------------------
@@ -29,7 +32,7 @@ Syntax:
 
 .. code-block:: yaml
 
-   parameter|sceptre_user_data:
+   parameter|sceptre_user_data|stack_tags:
      <name>: !environment_variable ENVIRONMENT_VARIABLE_NAME
 
 Example:
@@ -48,7 +51,7 @@ Syntax:
 
 .. code-block:: yaml
 
-   parameters|sceptre_user_data:
+   parameters|sceptre_user_data|stack_tags:
      <name>: !file_contents /path/to/file.txt
 
 Example:
@@ -67,7 +70,7 @@ Syntax:
 
 .. code-block:: yaml
 
-   parameters | sceptre_user_data:
+   parameters|sceptre_user_data|stack_tags:
      <name>: !stack_output <stack_name>.yaml::<output_name>
 
 Example:
@@ -97,7 +100,7 @@ Syntax:
 
 .. code-block:: yaml
 
-   parameters/sceptre_user_data:
+   parameters|sceptre_user_data|stack_tags:
      <name>: !stack_output_external <full_stack_name>::<output_name> <optional-aws-profile-name>
 
 Example:

--- a/docs/_source/docs/stack_config.rst
+++ b/docs/_source/docs/stack_config.rst
@@ -182,6 +182,9 @@ stack_tags
 ~~~~~~~~~~
 
 A dictionary of `CloudFormation Tags`_ to be applied to the Stack.
+It is also passed to the ``sceptre_handler(stack_tags)``
+function in Python templates or accessible under ``stack_tags`` variable
+key within Jinja2 templates.
 
 stack_timeout
 ~~~~~~~~~~~~~
@@ -286,7 +289,8 @@ Examples
        thing_2: !file_contents path/to/file.txt
    stack_tags:
        tag_1: value_1
-       tag_2: value_2
+       tag_2: {{ environment_variable.VALUE_2 }}
+       tag_3: !environment_variable VALUE_3
 
 .. _template_path: #template_path
 .. _dependencies: #dependencies

--- a/docs/_source/docs/templates.rst
+++ b/docs/_source/docs/templates.rst
@@ -27,9 +27,9 @@ Jinja
 Templates with ``.j2`` extensions are treated as Jinja2 Templates.
 These are rendered and should create a raw JSON or YAML CloudFormation
 Template. Sceptre User Data is accessible within Templates as
-``sceptre_user_data``. For example ``{{ sceptre_user_data.some_variable }}``.
-``sceptre_user_data`` accesses the ``sceptre_user_data`` key in the Stack
-Config file.
+``sceptre_user_data`` and ``stack_tags``. For example
+``{{ sceptre_user_data.some_variable }}``. ``sceptre_user_data``
+accesses the ``sceptre_user_data`` key in the Stack Config file.
 
 Python
 ------

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -476,7 +476,7 @@ class ConfigReader(object):
             dependencies=config.get("dependencies", []),
             role_arn=config.get("role_arn"),
             protected=config.get("protect", False),
-            tags=config.get("stack_tags", {}),
+            stack_tags=config.get("stack_tags", {}),
             external_name=config.get("stack_name"),
             notifications=config.get("notifications"),
             on_failure=config.get("on_failure"),

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -63,7 +63,7 @@ class StackActions(object):
             "NotificationARNs": self.stack.notifications,
             "Tags": [
                 {"Key": str(k), "Value": str(v)}
-                for k, v in self.stack.tags.items()
+                for k, v in self.stack.stack_tags.items()
             ]
         }
 
@@ -120,7 +120,7 @@ class StackActions(object):
                 "NotificationARNs": self.stack.notifications,
                 "Tags": [
                     {"Key": str(k), "Value": str(v)}
-                    for k, v in self.stack.tags.items()
+                    for k, v in self.stack.stack_tags.items()
                 ]
             }
             update_stack_kwargs.update(
@@ -446,7 +446,7 @@ class StackActions(object):
             "NotificationARNs": self.stack.notifications,
             "Tags": [
                 {"Key": str(k), "Value": str(v)}
-                for k, v in self.stack.tags.items()
+                for k, v in self.stack.stack_tags.items()
             ]
         }
         create_change_set_kwargs.update(


### PR DESCRIPTION
This change is to add resolver functionality to stack_tags.  The
idea behind this implementation is to make it work exactly like
sceptre_user_data.  Not only make tags resolvable but also make
them available to jinja templates.