### PR TITLE
[Resolves #798] complex data for resolvers and hooks

### DIFF
--- a/docs/_source/docs/hooks.rst
+++ b/docs/_source/docs/hooks.rst
@@ -196,7 +196,27 @@ This hook can be used in a Stack config file with the following syntax:
      before_create:
        - !custom_hook_command_name <argument> # The argument is accessible via self.argument
 
+hook arguments
+^^^^^^^^^^^^^^
+Hook arguments can be a simple string or a complex data structure.
+Assume a Sceptre `copy` hook that calls the `cp command`_:
+
+.. code-block:: yaml
+
+   template_path: <...>
+   hooks:
+     before_create:
+       - !copy "-r from_dir to_dir"
+     before_update:
+       - !copy {"options":"-r", "source": "from_dir", "destination": "to_dir"}
+     after_update:
+       - !copy
+           options: "-r"
+           source: "from_dir"
+           destination: "to_dir"
+
 .. _Custom Hooks: #custom-hooks
 .. _subprocess documentation: https://docs.python.org/3/library/subprocess.html
 .. _documentation: http://docs.aws.amazon.com/autoscaling/latest/userguide/as-suspend-resume-processes.html
 .. _this is great place to start: https://docs.python.org/3/distributing/
+.. _cp command: http://man7.org/linux/man-pages/man1/cp.1.html

--- a/docs/_source/docs/resolvers.rst
+++ b/docs/_source/docs/resolvers.rst
@@ -213,5 +213,19 @@ This resolver can be used in a Stack config file with the following syntax:
    parameters:
      param1: !<custom_resolver_command_name> <value> <optional-aws-profile>
 
+
+resolver arguments
+^^^^^^^^^^^^^^^^^^
+Resolver arguments can be a simple string or a complex data structure.
+
+.. code-block:: yaml
+
+    template_path: <...>
+    parameters:
+      Param1: !ssm "/dev/DbPassword"
+      Param2: !ssm {"name": "/dev/DbPassword"}
+      Param3: !ssm
+        name: "/dev/DbPassword"
+
 .. _Custom Resolvers: #custom-resolvers
 .. _this is great place to start: https://docs.python.org/3/distributing/

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -8,6 +8,7 @@ and constructing Stacks.
 """
 
 import collections
+import copy
 import datetime
 import fnmatch
 import logging
@@ -157,7 +158,7 @@ class ConfigReader(object):
             # This function signture is required by PyYAML
             def class_constructor(loader, node):
                 return node_class(
-                    loader.construct_scalar(node)
+                    loader.construct_object(self.resolve_node_tag(loader, node))
                 )  # pragma: no cover
 
             return class_constructor
@@ -176,6 +177,11 @@ class ConfigReader(object):
                     "Added constructor for %s with node tag %s",
                     str(node_class), node_tag
                 )
+
+    def resolve_node_tag(self, loader, node):
+        node = copy.copy(node)
+        node.tag = loader.resolve(type(node), node.value, (True, False))
+        return node
 
     def construct_stacks(self):
         """

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
-from mock import patch, sentinel
+from mock import patch, sentinel, MagicMock
 import pytest
 import yaml
 import errno
@@ -390,3 +390,16 @@ class TestConfigReader(object):
             raise
         else:
             assert False
+
+    def test_resolve_node_tag(self):
+        mock_loader = MagicMock(yaml.Loader)
+        mock_loader.resolve.return_value = "new_tag"
+
+        mock_node = MagicMock(yaml.Node)
+        mock_node.tag = "old_tag"
+        mock_node.value = "String"
+
+        config_reader = ConfigReader(self.context)
+        new_node = config_reader.resolve_node_tag(mock_loader, mock_node)
+
+        assert new_node.tag == 'new_tag'


### PR DESCRIPTION
Allow hooks and resolvers to take complex data objects as arguments.
This is a port of commit ed681aa9 to Sceptre V2
