### PR TITLE
Fix Jinja autoescape vulnerability

### DIFF
--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -15,7 +15,10 @@ from os import environ, path, walk
 from pkg_resources import iter_entry_points
 import yaml
 
-import jinja2
+from jinja2 import Environment
+from jinja2 import StrictUndefined
+from jinja2 import FileSystemLoader
+from jinja2 import select_autoescape
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
@@ -338,9 +341,13 @@ class ConfigReader(object):
         config = {}
         abs_directory_path = path.join(self.full_config_path, directory_path)
         if path.isfile(path.join(abs_directory_path, basename)):
-            jinja_env = jinja2.Environment(
-                loader=jinja2.FileSystemLoader(abs_directory_path),
-                undefined=jinja2.StrictUndefined
+            jinja_env = Environment(
+                autoescape=select_autoescape(
+                    disabled_extensions=('yaml',),
+                    default=True,
+                ),
+                loader=FileSystemLoader(abs_directory_path),
+                undefined=StrictUndefined
             )
             template = jinja_env.get_template(basename)
             self.templating_vars.update(stack_group_config)

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -15,9 +15,12 @@ import threading
 import traceback
 
 import botocore
-import jinja2
-from .exceptions import UnsupportedTemplateFileTypeError
-from .exceptions import TemplateSceptreHandlerError
+from jinja2 import Environment
+from jinja2 import FileSystemLoader
+from jinja2 import StrictUndefined
+from jinja2 import select_autoescape
+from sceptre.exceptions import UnsupportedTemplateFileTypeError
+from sceptre.exceptions import TemplateSceptreHandlerError
 
 
 class Template(object):
@@ -331,9 +334,13 @@ class Template(object):
         """
         logger = logging.getLogger(__name__)
         logger.debug("%s Rendering CloudFormation template", filename)
-        env = jinja2.Environment(
-            loader=jinja2.FileSystemLoader(template_dir),
-            undefined=jinja2.StrictUndefined
+        env = Environment(
+            autoescape=select_autoescape(
+                disabled_extensions=('j2',),
+                default=True,
+            ),
+            loader=FileSystemLoader(template_dir),
+            undefined=StrictUndefined
         )
         template = env.get_template(filename)
         body = template.render(**jinja_vars)

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -190,15 +190,15 @@ class TestConfigReader(object):
             }
         ),
         (
-                "name",
-                {
-                    "template_bucket_name": "bucket-name",
-                },
-                {
-                    "bucket_name": "bucket-name",
-                    "bucket_key": "name/2012-01-01-00-00-00-000000Z.json",
-                    "bucket_region": None,
-                }
+            "name",
+            {
+                "template_bucket_name": "bucket-name",
+            },
+            {
+                "bucket_name": "bucket-name",
+                "bucket_key": "name/2012-01-01-00-00-00-000000Z.json",
+                "bucket_region": None,
+            }
         ),
         (
             "name", {}, None


### PR DESCRIPTION
Template engines have an HTML autoescape mechanism that protects web
applications against most common cross-site-scripting (XSS)
vulnerabilities.

By default, it automatically replaces HTML special characters in any
template variables. This secure by design configuration should not be
globally disabled.

Escaping HTML from template variables prevents switching into any
execution context, like <script>. Disabling autoescaping forces
developers to manually escape each template variable for the application
to be safe. A more pragmatic approach is to escape by default and to
manually disable escaping when needed.

A successful exploitation of a cross-site-scripting vulnerability by an
attacker allow him to execute malicious JavaScript code in a user's web
browser. The most severe XSS attacks involve:

Forced redirection
Modify presentation of content
User accounts takeover after disclosure of sensitive information like
session cookies or passwords

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
