### PR TITLE
Fix formatting error in terminology.rst

### DIFF
--- a/docs/_source/docs/cli.rst
+++ b/docs/_source/docs/cli.rst
@@ -63,7 +63,7 @@ given a variable file "vars.yaml":
     middle2:
       nested: world
 
-we could overwrite ``nested: hello`` to ``nested: hi`` using:
+we could overwrite ``nested: world`` to ``nested: hi`` using:
 
 ``sceptre --var-file vars.yaml --var top.middle2.nested=hi launch stack``
 

--- a/docs/_source/docs/terminology.rst
+++ b/docs/_source/docs/terminology.rst
@@ -66,7 +66,8 @@ and access the results from each stack. For example,
 
    responses = plan.launch()
 
-## SceptrePlanExecutor
+SceptrePlanExecutor
+-------------------
 
 You won’t be able to interact with the ``SceptrePlanExecutor`` directly but
 this part of the code is responsible for taking a ``SceptrePlan`` and ensuring


### PR DESCRIPTION
Fixup formatting of Terminology heading. This currently reflects as a rendering error in the public docs, on https://sceptre.cloudreach.com/2.2.1/docs/terminology.html