### PR TITLE
[Resolves #213] Add support for template handlers

### DIFF
--- a/docs/_source/docs/stack_config.rst
+++ b/docs/_source/docs/stack_config.rst
@@ -37,10 +37,6 @@ Sceptre treats the template as CloudFormation, Jinja2 or Python depending on
 the template’s file extension. Note that the template filename may be different
 from the Stack config filename.
 
-This path will be automatically wired into a ``file`` template handler. For more
-information on template handlers, find out more in the :doc:`template_handlers`
-section.
-
 template
 ~~~~~~~~
 

--- a/docs/_source/docs/stack_config.rst
+++ b/docs/_source/docs/stack_config.rst
@@ -12,7 +12,7 @@ Structure
 A Stack config file is a ``yaml`` object of key-value pairs configuring a
 particular Stack. The available keys are listed below.
 
--  `template_path`_ *(required)*
+-  `template_path`_ or `template`_ *(required)*
 -  `dependencies`_ *(optional)*
 -  `hooks`_ *(optional)*
 -  `notifications`_ *(optional)*
@@ -25,7 +25,10 @@ particular Stack. The available keys are listed below.
 -  `stack_tags`_ *(optional)*
 -  `stack_timeout`_ *(optional)*
 
-template_path - required
+It is not possible to define both `template_path`_ and `template`_. If you do so,
+you will receive an error when deploying the stack.
+
+template_path
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 The path to the CloudFormation, Jinja2 or Python template to build the Stack
@@ -33,6 +36,32 @@ from. The path can either be absolute or relative to the Sceptre Directory.
 Sceptre treats the template as CloudFormation, Jinja2 or Python depending on
 the template’s file extension. Note that the template filename may be different
 from the Stack config filename.
+
+This path will be automatically wired into a ``file`` template handler. For more
+information on template handlers, find out more in the :doc:`template_handlers`
+section.
+
+template
+~~~~~~~~
+
+Configuration for a template handler. Template handlers can take in parameters
+and resolve that to a CloudFormation template. This enables you to not only
+load templates from disk, but also from third-party storage or AWS services.
+
+Example for loading from S3 bucket:
+
+.. code-block:: yaml
+
+   template:
+     type: s3
+     path: infra-templates/s3/v1/bucket.yaml
+   parameters:
+     <parameter1_name>: "value"
+   sceptre_user_data:
+
+It is possible to write your own template handlers should you need to. You
+can find a list of currently supported template handlers and guidance for
+developing your own in the :doc:`template_handlers` section.
 
 dependencies
 ~~~~~~~~~~~~
@@ -289,6 +318,7 @@ Examples
        tag_2: value_2
 
 .. _template_path: #template_path
+.. _template: #template
 .. _dependencies: #dependencies
 .. _hooks: #hooks
 .. _notifications: #notifications

--- a/docs/_source/docs/template_handlers.rst
+++ b/docs/_source/docs/template_handlers.rst
@@ -80,8 +80,19 @@ implemented and return a Python dictionary with the schema. For examples of JSON
 the documentation of the `jsonschema library`_.
 
 Template handlers get access to the ``template`` block parameters, ``sceptre_user_data`` and ``connection_manager``.
-These properties are available on ``self``. Using ``connection_manager``, template handlers can call AWS SDKs
-to fetch templates.
+These properties are available on ``self``. Using ``connection_manager``, template handlers can call AWS endpoints
+to perform actions or fetch templates. These correspond to the AWS Python SDK (see Boto3_). For example:
+
+.. code-block:: python
+
+        self.connection_manager.call(
+            service="s3",
+            command="get_object",
+            kwargs={
+                "Bucket": bucket,
+                "Key": key
+            }
+        )
 
 Sceptre uses the ``sceptre.template_handlers`` entry point to load template handlers. They can be written anywhere and
 are installed as Python packages.
@@ -183,3 +194,4 @@ This template handler can be used in a Stack config file with the following synt
 
 .. _jsonschema library: https://github.com/Julian/jsonschema
 .. _Custom Template Handlers: #custom-template-handlers
+.. _Boto3: https://aws.amazon.com/sdk-for-python/

--- a/docs/_source/docs/template_handlers.rst
+++ b/docs/_source/docs/template_handlers.rst
@@ -1,0 +1,185 @@
+Template Handlers
+=================
+
+Template handlers can be used to resolve a ``template`` config block to a CloudFormation template. This can be used to
+fetch templates from S3, for example. Users can create their own template handlers to easily add support for other
+template loading mechanisms. See `Custom Template Handlers`_ for more information.
+
+When a ``template_path`` property is specified in the Stack config, it is wired into a ``file`` template handler by
+default. This saves you from having to specify a full ``template`` block if you just want to load a file from disk.
+Sceptre implements resolvers, which can be used to resolve a value of a
+CloudFormation ``parameter`` or ``sceptre_user_data`` value at runtime. This is
+most commonly used to chain the outputs of one Stack to the inputs of another.
+
+Syntax:
+
+.. code-block:: yaml
+
+   template:
+     type: s3
+     path: <bucket>/<key>
+
+Available Template Handlers
+---------------------------
+
+file
+~~~~~~~~~~~~~~~~~~~~
+
+Loads a template from disk. Supports JSON, YAML, Jinja2 and Python files. Will be used if the ``template_path`` Stack
+config property is set, for backwards compatibility reasons.
+
+Syntax:
+
+.. code-block:: yaml
+
+   template:
+     type: file
+     path: <path>
+
+Example:
+
+.. code-block:: yaml
+
+   template:
+     type: file
+     path: storage/bucket.yaml
+
+s3
+~~~~~~~~~~~~~
+
+Downloads a template from an S3 bucket. The template will be kept in memory and not be persisted to disk. Currently
+only supports YAML / JSON CloudFormation templates,
+
+Syntax:
+
+.. code-block:: yaml
+
+   template:
+     type: s3
+     path: <bucket>/<key>
+
+Example:
+
+.. code-block:: yaml
+
+   template:
+     type: s3
+     path: infra-templates/s3/v1/bucket.yaml
+
+Custom Template Handlers
+------------------------
+
+If you need to load templates from a different source, you can write your own template handler.
+
+A template handler is a Python class which inherits from abstract base class ``TemplateHandler`` found in the
+``sceptre.template_handlers`` module.
+
+To have Sceptre validate that the ``template`` block specified in the Stack config is correct, template handlers
+should provide a JSON schema with the required and optional properties. The ``schema()`` method should be
+implemented and return a Python dictionary with the schema. For examples of JSON schemas in Python, please see
+the documentation of the `jsonschema library`_.
+
+Template handlers get access to the ``template`` block parameters, ``sceptre_user_data`` and ``connection_manager``.
+These properties are available on ``self``. Using ``connection_manager``, template handlers can call AWS SDKs
+to fetch templates.
+
+Sceptre uses the ``sceptre.template_handlers`` entry point to load template handlers. They can be written anywhere and
+are installed as Python packages.
+
+Example
+~~~~~~~
+
+The following Python module template can be copied and used:
+
+.. code-block:: text
+
+   custom_template_handler
+   ├── custom_template_handler.py
+   └── setup.py
+
+The following Python module template can be copied and used:
+
+custom_template_handler.py
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+        from sceptre.template_handlers import TemplateHandler
+
+
+        class CustomTemplateHandler(TemplateHandler):
+            """
+            The following instance attributes are inherited from the parent class TemplateHandler.
+
+            Parameters
+            ----------
+            name: str
+                The name of the template. Corresponds to the name of the Stack this template belongs to.
+            handler_config: dict
+                Configuration of the template handler. All properties except for `type` are available.
+            sceptre_user_data: dict
+                Sceptre user data defined in the Stack config
+            connection_manager: sceptre.connection_manager.ConnectionManager
+                Connection manager that can be used to call AWS APIs
+            """
+
+            def __init__(self, *args, **kwargs):
+                super(CustomTemplateHandler, self).__init__(*args, **kwargs)
+
+            def schema(self):
+                """
+                Return a JSON schema of the properties that this template handler requires.
+                For help filling this, see https://github.com/Julian/jsonschema
+                """
+                return {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }
+
+            def handle(self):
+                """
+                `handle` should return a CloudFormation template string or bytes. If the return
+                value is a byte array, UTF-8 encoding is assumed.
+
+                To use instance attribute self.<attribute_name>. See the class-level docs for a
+                list of attributes that are inherited.
+
+                Returns
+                -------
+                str|bytes
+                    CloudFormation template
+                """
+                return ""
+
+
+setup.py
+^^^^^^^^
+
+.. code-block:: python
+
+   from setuptools import setup
+
+   setup(
+       name='<custom_resolver_package_name>',
+       py_modules=['<custom_resolver_module_name>'],
+       entry_points={
+           'sceptre.template_handlers': [
+               '<custom_template_handler_type> = <custom_template_handler_module_name>:CustomTemplateHandler',
+           ],
+       }
+   )
+
+Then install using ``python setup.py install`` or ``pip install .`` commands.
+
+This template handler can be used in a Stack config file with the following syntax. Any properties you put in the
+``template`` block will be passed to the template handler in the ``self.handler_config`` dictionary.
+
+.. code-block:: yaml
+
+   template:
+     type: <custom_template_handler_type>
+     <property>: <value>
+
+.. _jsonschema library: https://github.com/Julian/jsonschema
+.. _Custom Template Handlers: #custom-template-handlers

--- a/docs/_source/index.rst
+++ b/docs/_source/index.rst
@@ -16,6 +16,7 @@
    docs/stack_group_config.rst
    docs/stack_config.rst
    docs/templates.rst
+   docs/template_handlers.rst
    docs/hooks.rst
    docs/resolvers.rst
    docs/architecture.rst

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,6 +5,7 @@ flake8==3.5.0
 flake8-per-file-ignores==0.4
 freezegun==0.3.12
 Jinja2>=2.8,<3
+jsonschema==3.1.1
 mock>=2.0.0,<2.1.0
 moto==1.3.8
 networkx==2.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,7 +5,6 @@ flake8==3.5.0
 flake8-per-file-ignores==0.4
 freezegun==0.3.12
 Jinja2>=2.8,<3
-jsonschema==3.1.1
 mock>=2.0.0,<2.1.0
 moto==1.3.8
 networkx==2.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -2,6 +2,7 @@ boto3>=1.3.0,<2
 click==7.0
 colorama==0.3.9
 Jinja2>=2.8,<3
+jsonschema==3.1.1
 networkx==2.1
 PyYaml>=5.1,<6.0
 typing>=3.7,<3.8

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -53,7 +53,8 @@ CONFIG_MERGE_STRATEGIES = {
     "stack_timeout": strategies.child_wins,
     "template_bucket_name": strategies.child_wins,
     "template_key_value": strategies.child_wins,
-    "template_path": strategies.child_wins
+    "template_path": strategies.child_wins,
+    "template": strategies.child_wins
 }
 
 STACK_GROUP_CONFIG_ATTRIBUTES = ConfigAttributes(
@@ -69,10 +70,10 @@ STACK_GROUP_CONFIG_ATTRIBUTES = ConfigAttributes(
 )
 
 STACK_CONFIG_ATTRIBUTES = ConfigAttributes(
+    {},
     {
-        "template_path"
-    },
-    {
+        "template_path",
+        "template",
         "dependencies",
         "hooks",
         "iam_role",
@@ -488,7 +489,7 @@ class ConfigReader(object):
         abs_template_path = path.join(
             self.context.project_path, self.context.templates_path,
             sceptreise_path(config["template_path"])
-        )
+        ) if "template_path" in config else None
 
         s3_details = self._collect_s3_details(
             stack_name, config
@@ -497,6 +498,7 @@ class ConfigReader(object):
             name=stack_name,
             project_code=config["project_code"],
             template_path=abs_template_path,
+            template_handler_config=config.get("template"),
             region=config["region"],
             template_bucket_name=config.get("template_bucket_name"),
             template_key_prefix=config.get("template_key_prefix"),

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -486,18 +486,13 @@ class ConfigReader(object):
                     )
                 )
 
-        abs_template_path = path.join(
-            self.context.project_path, self.context.templates_path,
-            sceptreise_path(config["template_path"])
-        ) if "template_path" in config else None
-
         s3_details = self._collect_s3_details(
             stack_name, config
         )
         stack = Stack(
             name=stack_name,
             project_code=config["project_code"],
-            template_path=abs_template_path,
+            template_path=self._get_absolute_template_path(config.get("template_path")),
             template_handler_config=config.get("template"),
             region=config["region"],
             template_bucket_name=config.get("template_bucket_name"),
@@ -537,3 +532,12 @@ class ConfigReader(object):
         parsed_config.pop("project_path")
         parsed_config.pop("stack_group_path")
         return parsed_config
+
+    def _get_absolute_template_path(self, template_path):
+        if not template_path:
+            return None
+
+        return path.join(
+            self.context.project_path, self.context.templates_path,
+            sceptreise_path(template_path)
+        )

--- a/sceptre/exceptions.py
+++ b/sceptre/exceptions.py
@@ -166,3 +166,17 @@ class InvalidAWSCredentialsError(SceptreException):
     Error raised when AWS credentials are invalid.
     """
     pass
+
+
+class TemplateHandlerNotFoundError(SceptreException):
+    """
+    Error raised when a Template Handler of a certain type is not found
+    """
+    pass
+
+
+class TemplateHandlerArgumentsInvalidError(SceptreException):
+    """
+    Error raised when the arguments passed to a Template Handler do not
+    adhere to the specified JSON schema.
+    """

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -12,6 +12,7 @@ import os
 from typing import Mapping, Sequence
 
 from sceptre.connection_manager import ConnectionManager
+from sceptre.exceptions import InvalidConfigFileError
 from sceptre.helpers import get_external_stack_name, sceptreise_path
 from sceptre.hooks import HookProperty
 from sceptre.resolvers import ResolvableProperty
@@ -30,13 +31,13 @@ class Stack(object):
     :type project_code: str
 
     :param template_path: The relative path to the CloudFormation, Jinja2\
-            or Python template to build the Stack from. Takes precedence over
-            `template` if it is specified.
+            or Python template to build the Stack from. If this is filled,
+            `template_handler_config` should not be filled.
     :type template_path: str
 
     :param template_handler_config: Configuration for a Template Handler that can resolve
             its arguments to a template string. Should contain the `type` property to specify
-            the type of template handler to load
+            the type of template handler to load. Conflicts with `template_path`.
     :type template_handler_config: dict
 
     :param region: The AWS region to build Stacks in.
@@ -128,6 +129,12 @@ class Stack(object):
         stack_timeout=0, stack_group_config={}
     ):
         self.logger = logging.getLogger(__name__)
+
+        if template_path and template_handler_config:
+            raise InvalidConfigFileError("Both 'template_path' and 'template' are set, specify one or the other")
+
+        if not template_path and not template_handler_config:
+            raise InvalidConfigFileError("Neither 'template_path' nor 'template' is set")
 
         self.name = sceptreise_path(name)
         self.project_code = project_code
@@ -278,17 +285,15 @@ class Stack(object):
         """
         if self._template is None:
             if self.template_path:
-                name = os.path.basename(self.template_path).split(".")[0]
                 handler_config = {
                     "type": "file",
                     "path": self.template_path
                 }
             else:
-                name = self.name.replace('/', '-')
                 handler_config = self.template_handler_config
 
             self._template = Template(
-                name=name,
+                name=self.name,
                 handler_config=handler_config,
                 sceptre_user_data=self.sceptre_user_data,
                 s3_details=self.s3_details,

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -8,6 +8,7 @@ This module implements a Stack class, which stores a Stack's data.
 """
 
 import logging
+import os
 from typing import Mapping, Sequence
 
 from sceptre.connection_manager import ConnectionManager
@@ -29,8 +30,14 @@ class Stack(object):
     :type project_code: str
 
     :param template_path: The relative path to the CloudFormation, Jinja2\
-            or Python template to build the Stack from.
+            or Python template to build the Stack from. Takes precedence over
+            `template` if it is specified.
     :type template_path: str
+
+    :param template_handler_config: Configuration for a Template Handler that can resolve
+            its arguments to a template string. Should contain the `type` property to specify
+            the type of template handler to load
+    :type template_handler_config: dict
 
     :param region: The AWS region to build Stacks in.
     :type region: str
@@ -113,10 +120,10 @@ class Stack(object):
     hooks = HookProperty("hooks")
 
     def __init__(
-        self, name, project_code, template_path, region, template_bucket_name=None,
-        template_key_prefix=None, required_version=None, parameters=None,
-        sceptre_user_data=None, hooks=None, s3_details=None, iam_role=None,
-        dependencies=None, role_arn=None, protected=False, tags=None,
+        self, name, project_code, region, template_path=None, template_handler_config=None,
+        template_bucket_name=None, template_key_prefix=None, required_version=None,
+        parameters=None, sceptre_user_data=None, hooks=None, s3_details=None,
+        iam_role=None, dependencies=None, role_arn=None, protected=False, tags=None,
         external_name=None, notifications=None, on_failure=None, profile=None,
         stack_timeout=0, stack_group_config={}
     ):
@@ -129,8 +136,8 @@ class Stack(object):
         self.template_key_prefix = template_key_prefix
         self.required_version = required_version
         self.external_name = external_name or get_external_stack_name(self.project_code, self.name)
-
         self.template_path = template_path
+        self.template_handler_config = template_handler_config
         self.s3_details = s3_details
         self._template = None
         self._connection_manager = None
@@ -156,6 +163,7 @@ class Stack(object):
             "name='{name}', "
             "project_code={project_code}, "
             "template_path={template_path}, "
+            "template_handler_config={template_handler_config}, "
             "region={region}, "
             "template_bucket_name={template_bucket_name}, "
             "template_key_prefix={template_key_prefix}, "
@@ -179,6 +187,7 @@ class Stack(object):
                 name=self.name,
                 project_code=self.project_code,
                 template_path=self.template_path,
+                template_handler_config=self.template_handler_config,
                 region=self.region,
                 template_bucket_name=self.template_bucket_name,
                 template_key_prefix=self.template_key_prefix,
@@ -209,6 +218,7 @@ class Stack(object):
             self.name == stack.name and
             self.project_code == stack.project_code and
             self.template_path == stack.template_path and
+            self.template_handler_config == stack.template_handler_config and
             self.region == stack.region and
             self.template_bucket_name == stack.template_bucket_name and
             self.template_key_prefix == stack.template_key_prefix and
@@ -267,8 +277,19 @@ class Stack(object):
         :rtype: str
         """
         if self._template is None:
+            if self.template_path:
+                name = os.path.basename(self.template_path).split(".")[0]
+                handler_config = {
+                    "type": "file",
+                    "path": self.template_path
+                }
+            else:
+                name = self.name.replace('/', '-')
+                handler_config = self.template_handler_config
+
             self._template = Template(
-                path=self.template_path,
+                name=name,
+                handler_config=handler_config,
                 sceptre_user_data=self.sceptre_user_data,
                 s3_details=self.s3_details,
                 connection_manager=self.connection_manager

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -7,7 +7,6 @@ This module implements a Template class, which stores a CloudFormation template
 and implements methods for uploading it to S3.
 """
 
-import imp
 import logging
 import os
 import sys
@@ -15,12 +14,9 @@ import threading
 import traceback
 
 import botocore
-from jinja2 import Environment
-from jinja2 import FileSystemLoader
-from jinja2 import StrictUndefined
-from jinja2 import select_autoescape
-from sceptre.exceptions import UnsupportedTemplateFileTypeError
-from sceptre.exceptions import TemplateSceptreHandlerError
+from pkg_resources import iter_entry_points
+
+from sceptre.exceptions import TemplateHandlerNotFoundError
 
 
 class Template(object):
@@ -29,9 +25,11 @@ class Template(object):
     loading, storing and optionally uploading local templates for use by
     CloudFormation.
 
-    :param path: The absolute path to the file which stores the CloudFormation\
-            template.
-    :type path: str
+    :param name: The name of the template. Should be safe to use in filenames and not contain path segments.
+    :type name: str
+
+    :param handler_config: The configuration for a Template handler. Must contain a `type`.
+    :type handler_config: dict
 
     :param sceptre_user_data: A dictionary of arbitrary data to be passed to\
             a handler function in an external Python script.
@@ -47,60 +45,25 @@ class Template(object):
     _boto_s3_lock = threading.Lock()
 
     def __init__(
-        self, path, sceptre_user_data, connection_manager=None, s3_details=None
+            self, name, handler_config, sceptre_user_data, connection_manager=None, s3_details=None
     ):
         self.logger = logging.getLogger(__name__)
 
-        self.path = path
+        self.name = name
+        self.handler_config = handler_config
         self.sceptre_user_data = sceptre_user_data
         self.connection_manager = connection_manager
         self.s3_details = s3_details
 
-        self.name = os.path.basename(path).split(".")[0]
+        self._registry = None
         self._body = None
 
     def __repr__(self):
         return (
-            "sceptre.template.Template(name='{0}', path='{1}', "
-            "sceptre_user_data={2}, s3_details={3})".format(
-                self.name, self.path, self.sceptre_user_data, self.s3_details
+            "sceptre.template.Template(name='{0}', handler_config={1}, sceptre_user_data={2}, s3_details={3})".format(
+                self.name, self.handler_config, self.sceptre_user_data, self.s3_details
             )
         )
-
-    def _print_template_traceback(self):
-        """
-        Prints a stack trace, including only files which are inside a
-        'templates' directory. The function is intended to give the operator
-        instant feedback about why their templates are failing to compile.
-
-        :rtype: None
-        """
-        def _print_frame(filename, line, fcn, line_text):
-            self.logger.error("{}:{}:  Template error in '{}'\n=> `{}`".format(
-                filename, line, fcn, line_text))
-
-        try:
-            _, _, tb = sys.exc_info()
-            stack_trace = traceback.extract_tb(tb)
-            search_string = os.path.join('', 'templates', '')
-            if search_string in self.path:
-                template_path = self.path.split(search_string)[0] + search_string
-            else:
-                return
-            for frame in stack_trace:
-                if isinstance(frame, tuple):
-                    # Python 2 / Old style stack frame
-                    if template_path in frame[0]:
-                        _print_frame(frame[0], frame[1], frame[2], frame[3])
-                else:
-                    if template_path in frame.filename:
-                        _print_frame(frame.filename, frame.lineno, frame.name, frame.line)
-        except Exception as tb_exception:
-            self.logger.error(
-                'A template error occured. ' +
-                'Additionally, a traceback exception occured. Exception: %s',
-                tb_exception
-            )
 
     @property
     def body(self):
@@ -111,77 +74,21 @@ class Template(object):
         :rtype: str
         """
         if self._body is None:
-            file_extension = os.path.splitext(self.path)[1]
-
-            try:
-                if file_extension in {".json", ".yaml", ".template"}:
-                    with open(self.path) as template_file:
-                        self._body = template_file.read()
-                elif file_extension == ".j2":
-                    self._body = self._render_jinja_template(
-                        os.path.dirname(self.path),
-                        os.path.basename(self.path),
-                        {"sceptre_user_data": self.sceptre_user_data}
-                    )
-                elif file_extension == ".py":
-                    self._body = self._call_sceptre_handler()
-
-                else:
-                    raise UnsupportedTemplateFileTypeError(
-                        "Template has file extension %s. Only .py, .yaml, "
-                        ".template, .json and .j2 are supported.",
-                        os.path.splitext(self.path)[1]
-                    )
-            except Exception as e:
-                self._print_template_traceback()
-                raise e
+            type = self.handler_config.get("type")
+            handler_class = self._get_handler_of_type(type)
+            handler = handler_class(
+                name=self.name,
+                arguments={k: v for k, v in self.handler_config.items() if k != "type"},
+                sceptre_user_data=self.sceptre_user_data,
+                connection_manager=self.connection_manager
+            )
+            handler.validate()
+            body = handler.handle()
+            if isinstance(body, bytes):
+                body = body.decode('utf-8')
+            self._body = body
 
         return self._body
-
-    def _call_sceptre_handler(self):
-        """
-        Calls the function `sceptre_handler` within templates that are python
-        scripts.
-
-        :returns: The string returned from sceptre_handler in the template.
-        :rtype: str
-        :raises: IOError
-        :raises: TemplateSceptreHandlerError
-        """
-        # Get relative path as list between current working directory and where
-        # the template is
-        # NB: this is a horrible hack...
-        relpath = os.path.relpath(self.path, os.getcwd()).split(os.path.sep)
-        relpaths_to_add = [
-            os.path.sep.join(relpath[:i+1])
-            for i in range(len(relpath[:-1]))
-        ]
-        # Add any directory between the current working directory and where
-        # the template is to the python path
-        for directory in relpaths_to_add:
-            sys.path.append(os.path.join(os.getcwd(), directory))
-        self.logger.debug(
-            "%s - Getting CloudFormation from %s", self.name, self.path
-        )
-
-        if not os.path.isfile(self.path):
-            raise IOError("No such file or directory: '%s'", self.path)
-
-        module = imp.load_source(self.name, self.path)
-
-        try:
-            body = module.sceptre_handler(self.sceptre_user_data)
-        except AttributeError as e:
-            if 'sceptre_handler' in str(e):
-                raise TemplateSceptreHandlerError(
-                    "The template does not have the required "
-                    "'sceptre_handler(sceptre_user_data)' function."
-                )
-            else:
-                raise e
-        for directory in relpaths_to_add:
-            sys.path.remove(os.path.join(os.getcwd(), directory))
-        return body
 
     def upload_to_s3(self):
         """
@@ -315,33 +222,22 @@ class Template(object):
         else:
             return {"TemplateBody": self.body}
 
-    @staticmethod
-    def _render_jinja_template(template_dir, filename, jinja_vars):
+    def _get_handler_of_type(self, type):
         """
-        Renders a jinja template.
-
-        Sceptre supports passing sceptre_user_data to JSON and YAML
-        CloudFormation templates using Jinja2 templating.
-
-        :param template_dir: The directory containing the template.
-        :type template_dir: str
-        :param filename: The name of the template file.
-        :type filename: str
-        :param jinja_vars: Dict of variables to render into the template.
-        :type jinja_vars: dict
-        :returns: The body of the CloudFormation template.
-        :rtype: str
+        Gets a TemplateHandler typ from the registry that can be used to get a string
+        representation of a CloudFormation template.
+        :param type: The type of Template Handler to load
+        :type type: str
+        :return: Instantiated TemplateHandler
+        :rtype: class
         """
-        logger = logging.getLogger(__name__)
-        logger.debug("%s Rendering CloudFormation template", filename)
-        env = Environment(
-            autoescape=select_autoescape(
-                disabled_extensions=('j2',),
-                default=True,
-            ),
-            loader=FileSystemLoader(template_dir),
-            undefined=StrictUndefined
-        )
-        template = env.get_template(filename)
-        body = template.render(**jinja_vars)
-        return body
+        if not self._registry:
+            self._registry = {}
+
+            for entry_point in iter_entry_points("sceptre.template_handlers", type):
+                self._registry[entry_point.name] = entry_point.load()
+
+        if type not in self._registry:
+            raise TemplateHandlerNotFoundError('Handler of type "{0}" not found'.format(type))
+
+        return self._registry[type]

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -224,7 +224,7 @@ class Template(object):
 
     def _get_handler_of_type(self, type):
         """
-        Gets a TemplateHandler typ from the registry that can be used to get a string
+        Gets a TemplateHandler type from the registry that can be used to get a string
         representation of a CloudFormation template.
         :param type: The type of Template Handler to load
         :type type: str

--- a/sceptre/template_handlers/__init__.py
+++ b/sceptre/template_handlers/__init__.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+import abc
+import logging
+
+import six
+from jsonschema import validate
+
+
+@six.add_metaclass(abc.ABCMeta)
+class TemplateHandler:
+    """
+    TemplateHandler is an abstract base class that should be inherited
+    by all Template Handlers.
+
+    :param arguments: The arguments of the template handler
+    :type arguments: object
+    :param connection_manager: Connection manager used to call AWS
+    :type connection_manager: sceptre.connection_manager.ConnectionManager
+    """
+
+    __metaclass__ = abc.ABCMeta
+
+    def __init__(self, arguments=None, connection_manager=None):
+        self.logger = logging.getLogger(__name__)
+        self.arguments = arguments
+        self.connection_manager = connection_manager
+
+    @abc.abstractmethod
+    def schema(self):
+        """
+        Returns the schema for the arguments of this Template Resolver. This will
+        be used to validate that the arguments passed in the stack config are what
+        the Template Handler expects.
+        :return: JSON schema that can be validated
+        :rtype: object
+        """
+        pass
+
+    @abc.abstractmethod
+    def handle(self):
+        """
+        An abstract method which must be overwritten by all inheriting classes.
+        This method is called to retrieve the template.
+        Implementation of this method in subclasses must return a string that
+        can be interpreted by Sceptre (CloudFormation YAML / JSON, Jinja or Python)
+        """
+        pass  # pragma: no cover
+
+    def validate(self):
+        """
+        Validates if the current arguments are correct according to the schema.
+        :return: True if arguments valid, false if not
+        :rtype: bool
+        """
+        return validate(instance=self.arguments, schema=self.schema())

--- a/sceptre/template_handlers/file.py
+++ b/sceptre/template_handlers/file.py
@@ -1,0 +1,168 @@
+import logging
+import os
+import sys
+import traceback
+
+from jinja2 import Environment, select_autoescape, FileSystemLoader, StrictUndefined
+
+from sceptre.exceptions import UnsupportedTemplateFileTypeError, TemplateSceptreHandlerError
+from sceptre.template_handlers import TemplateHandler
+
+
+class File(TemplateHandler):
+    """
+    Template handler that can load files from disk. Supports JSON, YAML, Jinja2 and Python.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.logger = logging.getLogger(__name__)
+        super(File, self).__init__(*args, **kwargs)
+
+    def schema(self):
+        return {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+            },
+            "required": ["path"]
+        }
+
+    def handle(self):
+        file_extension = os.path.splitext(self.arguments["path"])[1]
+        path = self.arguments["path"]
+        try:
+            if file_extension in {".json", ".yaml", ".template"}:
+                with open(path) as template_file:
+                    return template_file.read()
+            elif file_extension == ".j2":
+                return self._render_jinja_template(
+                    os.path.dirname(path),
+                    os.path.basename(path),
+                    {"sceptre_user_data": self.sceptre_user_data}
+                )
+            elif file_extension == ".py":
+                return self._call_sceptre_handler()
+            else:
+                raise UnsupportedTemplateFileTypeError(
+                    "Template has file extension %s. Only .py, .yaml, "
+                    ".template, .json and .j2 are supported.",
+                    os.path.splitext(path)[1]
+                )
+        except Exception as e:
+            self._print_template_traceback()
+            raise e
+
+    def _call_sceptre_handler(self):
+        """
+        Calls the function `sceptre_handler` within templates that are python
+        scripts.
+
+        :returns: The string returned from sceptre_handler in the template.
+        :rtype: str
+        :raises: IOError
+        :raises: TemplateSceptreHandlerError
+        """
+        # Get relative path as list between current working directory and where
+        # the template is
+        # NB: this is a horrible hack...
+        path = self.arguments["path"]
+
+        relpath = os.path.relpath(path, os.getcwd()).split(os.path.sep)
+        relpaths_to_add = [
+            os.path.sep.join(relpath[:i + 1])
+            for i in range(len(relpath[:-1]))
+        ]
+        # Add any directory between the current working directory and where
+        # the template is to the python path
+        for directory in relpaths_to_add:
+            sys.path.append(os.path.join(os.getcwd(), directory))
+        self.logger.debug(
+            "%s - Getting CloudFormation from %s", self.name, path
+        )
+
+        if not os.path.isfile(path):
+            raise IOError("No such file or directory: '%s'", path)
+
+        import imp
+        module = imp.load_source(self.name, path)
+
+        try:
+            body = module.sceptre_handler(self.sceptre_user_data)
+        except AttributeError as e:
+            if 'sceptre_handler' in str(e):
+                raise TemplateSceptreHandlerError(
+                    "The template does not have the required "
+                    "'sceptre_handler(sceptre_user_data)' function."
+                )
+            else:
+                raise e
+        for directory in relpaths_to_add:
+            sys.path.remove(os.path.join(os.getcwd(), directory))
+        return body
+
+    def _print_template_traceback(self):
+        """
+        Prints a stack trace, including only files which are inside a
+        'templates' directory. The function is intended to give the operator
+        instant feedback about why their templates are failing to compile.
+
+        :rtype: None
+        """
+
+        def _print_frame(filename, line, fcn, line_text):
+            self.logger.error("{}:{}:  Template error in '{}'\n=> `{}`".format(
+                filename, line, fcn, line_text))
+
+        try:
+            _, _, tb = sys.exc_info()
+            stack_trace = traceback.extract_tb(tb)
+            search_string = os.path.join('', 'templates', '')
+            if search_string in self.arguments["path"]:
+                template_path = self.arguments["path"].split(search_string)[0] + search_string
+            else:
+                return
+            for frame in stack_trace:
+                if isinstance(frame, tuple):
+                    # Python 2 / Old style stack frame
+                    if template_path in frame[0]:
+                        _print_frame(frame[0], frame[1], frame[2], frame[3])
+                else:
+                    if template_path in frame.filename:
+                        _print_frame(frame.filename, frame.lineno, frame.name, frame.line)
+        except Exception as tb_exception:
+            self.logger.error(
+                'A template error occured. ' +
+                'Additionally, a traceback exception occured. Exception: %s',
+                tb_exception
+            )
+
+    @staticmethod
+    def _render_jinja_template(template_dir, filename, jinja_vars):
+        """
+        Renders a jinja template.
+
+        Sceptre supports passing sceptre_user_data to JSON and YAML
+        CloudFormation templates using Jinja2 templating.
+
+        :param template_dir: The directory containing the template.
+        :type template_dir: str
+        :param filename: The name of the template file.
+        :type filename: str
+        :param jinja_vars: Dict of variables to render into the template.
+        :type jinja_vars: dict
+        :returns: The body of the CloudFormation template.
+        :rtype: str
+        """
+        logger = logging.getLogger(__name__)
+        logger.debug("%s Rendering CloudFormation template", filename)
+        env = Environment(
+            autoescape=select_autoescape(
+                disabled_extensions=('j2',),
+                default=True,
+            ),
+            loader=FileSystemLoader(template_dir),
+            undefined=StrictUndefined
+        )
+        template = env.get_template(filename)
+        body = template.render(**jinja_vars)
+        return body

--- a/sceptre/template_handlers/s3.py
+++ b/sceptre/template_handlers/s3.py
@@ -1,0 +1,41 @@
+import logging
+
+from sceptre.template_handlers import TemplateHandler
+
+
+class S3(TemplateHandler):
+    """
+    Template Handler that can resolve templates from S3.
+    """
+    def __init__(self, *args, **kwargs):
+        self.logger = logging.getLogger(__name__)
+        super(S3, self).__init__(*args, **kwargs)
+
+    def schema(self):
+        return {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"}
+            }
+        }
+
+    def handle(self):
+        self.logger.debug("Downloading file from S3: %s" % self.argument)
+
+        segments = self.arguments["path"].split('/')
+        bucket = segments[0]
+        key = "/".join(segments[1:])
+
+        try:
+            response = self.connection_manager.call(
+                service="s3",
+                command="get_object",
+                kwargs={
+                    "Bucket": bucket,
+                    "Key": key
+                }
+            )
+            return response["Body"].read()
+        except Exception as e:
+            self.logger.fatal(e)
+            raise e

--- a/sceptre/template_handlers/s3.py
+++ b/sceptre/template_handlers/s3.py
@@ -5,8 +5,9 @@ from sceptre.template_handlers import TemplateHandler
 
 class S3(TemplateHandler):
     """
-    Template Handler that can resolve templates from S3.
+    Template handler that can resolve templates from S3.
     """
+
     def __init__(self, *args, **kwargs):
         self.logger = logging.getLogger(__name__)
         super(S3, self).__init__(*args, **kwargs)
@@ -16,11 +17,12 @@ class S3(TemplateHandler):
             "type": "object",
             "properties": {
                 "path": {"type": "string"}
-            }
+            },
+            "required": ["path"]
         }
 
     def handle(self):
-        self.logger.debug("Downloading file from S3: %s" % self.argument)
+        self.logger.debug("Downloading file from S3: %s" % self.arguments["path"])
 
         segments = self.arguments["path"].split('/')
         bucket = segments[0]

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ install_requirements = [
     "click==7.0",
     "PyYaml>=5.1,<6.0",
     "Jinja2>=2.8,<3",
+    "jsonschema==3.1.1",
     "colorama==0.3.9",
     "packaging==16.8",
     "six>=1.11.0,<2.0.0",
@@ -67,6 +68,9 @@ setup(
             "stack_output = sceptre.resolvers.stack_output:StackOutput",
             "stack_output_external ="
             "sceptre.resolvers.stack_output:StackOutputExternal"
+        ],
+        "sceptre.template_handlers": [
+            "s3 = sceptre.template_handlers.s3:S3"
         ]
     },
     data_files=[

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ install_requirements = [
     "packaging==16.8",
     "six>=1.11.0,<2.0.0",
     "networkx==2.1",
-    "typing>=3.7.0,<3.8.0"
+    "typing>=3.7.0,<3.8.0",
 ]
 
 test_requirements = [
@@ -70,6 +70,7 @@ setup(
             "sceptre.resolvers.stack_output:StackOutputExternal"
         ],
         "sceptre.template_handlers": [
+            "file = sceptre.template_handlers.file:File",
             "s3 = sceptre.template_handlers.s3:S3"
         ]
     },

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -13,7 +13,7 @@ from sceptre.plan.actions import StackActions
 from sceptre.template import Template
 from sceptre.stack_status import StackStatus
 from sceptre.stack_status import StackChangeSetStatus
-from sceptre.exceptions import CannotUpdateFailedStackError
+from sceptre.exceptions import CannotUpdateFailedStackError, InvalidConfigFileError
 from sceptre.exceptions import UnknownStackStatusError
 from sceptre.exceptions import UnknownStackChangeSetStatusError
 from sceptre.exceptions import StackDoesNotExistError
@@ -29,10 +29,9 @@ class TestStackActions(object):
         self.mock_ConnectionManager = self.patcher_connection_manager.start()
         self.stack = Stack(
             name='prod/app/stack', project_code=sentinel.project_code,
-            template_path=sentinel.template_path, template_handler_config=sentinel.template_handler_config,
-            region=sentinel.region, profile=sentinel.profile, parameters={"key1": "val1"},
-            sceptre_user_data=sentinel.sceptre_user_data, hooks={},
-            s3_details=None, dependencies=sentinel.dependencies,
+            template_path=sentinel.template_path, region=sentinel.region,
+            profile=sentinel.profile, parameters={"key1": "val1"}, sceptre_user_data=sentinel.sceptre_user_data,
+            hooks={}, s3_details=None, dependencies=sentinel.dependencies,
             role_arn=sentinel.role_arn, protected=False,
             tags={"tag1": "val1"}, external_name=sentinel.external_name,
             notifications=[sentinel.notification],
@@ -56,7 +55,7 @@ class TestStackActions(object):
         response = self.stack.template
 
         mock_Template.assert_called_once_with(
-            name='prod-app-stack',
+            name='prod/app/stack',
             handler_config={
                 "type": "file",
                 "path": sentinel.template_path

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -29,8 +29,8 @@ class TestStackActions(object):
         self.mock_ConnectionManager = self.patcher_connection_manager.start()
         self.stack = Stack(
             name='prod/app/stack', project_code=sentinel.project_code,
-            template_path=sentinel.template_path, region=sentinel.region,
-            profile=sentinel.profile, parameters={"key1": "val1"},
+            template_path=sentinel.template_path, template_handler_config=sentinel.template_handler_config,
+            region=sentinel.region, profile=sentinel.profile, parameters={"key1": "val1"},
             sceptre_user_data=sentinel.sceptre_user_data, hooks={},
             s3_details=None, dependencies=sentinel.dependencies,
             role_arn=sentinel.role_arn, protected=False,
@@ -41,7 +41,7 @@ class TestStackActions(object):
         )
         self.actions = StackActions(self.stack)
         self.template = Template(
-            "fixtures/templates", self.stack.sceptre_user_data,
+            "fixtures/templates", self.stack.template_handler_config, self.stack.sceptre_user_data,
             self.actions.connection_manager, self.stack.s3_details
         )
         self.stack._template = self.template
@@ -56,7 +56,11 @@ class TestStackActions(object):
         response = self.stack.template
 
         mock_Template.assert_called_once_with(
-            path=sentinel.template_path,
+            name='prod-app-stack',
+            handler_config={
+                "type": "file",
+                "path": sentinel.template_path
+            },
             sceptre_user_data=sentinel.sceptre_user_data,
             connection_manager=self.stack.connection_manager,
             s3_details=None

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -240,6 +240,7 @@ class TestConfigReader(object):
             template_path=os.path.join(
                 self.context.project_path, "templates/path/to/template"
             ),
+            template_handler_config=None,
             region="region_region",
             profile="account_profile",
             parameters={"param1": "val1"},

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -297,7 +297,6 @@ class TestConfigReader(object):
     @pytest.mark.parametrize("filepaths, del_key", [
         (["A/1.yaml"], "project_code"),
         (["A/1.yaml"], "region"),
-        (["A/1.yaml"], "template_path"),
     ])
     def test_missing_attr(
         self, filepaths, del_key

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -16,6 +16,7 @@ def stack_factory(**kwargs):
         'template_key_prefix': sentinel.template_key_prefix,
         'required_version': sentinel.required_version,
         'template_path': sentinel.template_path,
+        'template_handler_config': sentinel.template_handler_config,
         'region': sentinel.region,
         'profile': sentinel.profile,
         'parameters': {"key1": "val1"},
@@ -44,7 +45,9 @@ class TestStack(object):
             template_bucket_name=sentinel.template_bucket_name,
             template_key_prefix=sentinel.template_key_prefix,
             required_version=sentinel.required_version,
-            template_path=sentinel.template_path, region=sentinel.region,
+            template_path=sentinel.template_path,
+            template_handler_config=sentinel.template_handler_config,
+            region=sentinel.region,
             profile=sentinel.profile, parameters={"key1": "val1"},
             sceptre_user_data=sentinel.sceptre_user_data, hooks={},
             s3_details=None, dependencies=sentinel.dependencies,
@@ -61,6 +64,7 @@ class TestStack(object):
         stack = Stack(
             name='dev/stack/app', project_code=sentinel.project_code,
             template_path=sentinel.template_path,
+            template_handler_config=sentinel.template_handler_config,
             template_bucket_name=sentinel.template_bucket_name,
             template_key_prefix=sentinel.template_key_prefix,
             required_version=sentinel.required_version,
@@ -76,6 +80,7 @@ class TestStack(object):
         assert stack.parameters == {}
         assert stack.sceptre_user_data == {}
         assert stack.template_path == sentinel.template_path
+        assert stack.template_handler_config == sentinel.template_handler_config
         assert stack.s3_details is None
         assert stack._template is None
         assert stack.protected is False
@@ -93,6 +98,7 @@ class TestStack(object):
             "name='dev/app/stack', " \
             "project_code=sentinel.project_code, " \
             "template_path=sentinel.template_path, " \
+            "template_handler_config=sentinel.template_handler_config, " \
             "region=sentinel.region, " \
             "template_bucket_name=sentinel.template_bucket_name, "\
             "template_key_prefix=sentinel.template_key_prefix, "\

--- a/tests/test_template_handlers/test_file.py
+++ b/tests/test_template_handlers/test_file.py
@@ -1,0 +1,66 @@
+import os
+
+import pytest
+import yaml
+
+from sceptre.template_handlers.file import File
+
+
+@pytest.mark.parametrize("filename,sceptre_user_data,expected", [
+    (
+        "vpc.j2",
+        {"vpc_id": "10.0.0.0/16"},
+        """Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+Outputs:
+  VpcId:
+    Value:
+      Ref: VPC"""
+    ),
+    (
+        "vpc.yaml.j2",
+        {"vpc_id": "10.0.0.0/16"},
+        """Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/16
+Outputs:
+  VpcId:
+    Value:
+      Ref: VPC"""
+    ),
+    (
+        "sg.j2",
+        [
+            {"name": "sg_a", "inbound_ip": "10.0.0.0"},
+            {"name": "sg_b", "inbound_ip": "10.0.0.1"}
+        ],
+        """Resources:
+    sg_a:
+        Type: "AWS::EC2::SecurityGroup"
+        Properties:
+            InboundIp: 10.0.0.0
+    sg_b:
+        Type: "AWS::EC2::SecurityGroup"
+        Properties:
+            InboundIp: 10.0.0.1
+"""
+    )
+])
+def test_render_jinja_template(filename, sceptre_user_data, expected):
+    jinja_template_dir = os.path.join(
+        os.getcwd(),
+        "tests/fixtures/templates"
+    )
+    result = File._render_jinja_template(
+        template_dir=jinja_template_dir,
+        filename=filename,
+        jinja_vars={"sceptre_user_data": sceptre_user_data}
+    )
+    expected_yaml = yaml.safe_load(expected)
+    result_yaml = yaml.safe_load(result)
+    assert expected_yaml == result_yaml

--- a/tests/test_template_handlers/test_s3.py
+++ b/tests/test_template_handlers/test_s3.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+import io
+
+import pytest
+from mock import MagicMock
+
+from sceptre.connection_manager import ConnectionManager
+from sceptre.exceptions import SceptreException
+from sceptre.template_handlers.s3 import S3
+
+
+class TestS3(object):
+
+    def test_template_handler(self):
+        connection_manager = MagicMock(spec=ConnectionManager)
+        connection_manager.call.return_value = {
+            "Body": io.BytesIO(b"Stuff is working")
+        }
+        template_handler = S3(
+            name="vpc",
+            arguments={"path": "my-fancy-bucket/account/vpc.yaml"},
+            connection_manager=connection_manager
+        )
+        result = template_handler.handle()
+
+        connection_manager.call.assert_called_once_with(
+            service="s3",
+            command="get_object",
+            kwargs={
+                "Bucket": "my-fancy-bucket",
+                "Key": "account/vpc.yaml"
+            }
+        )
+        assert result == b"Stuff is working"
+
+    def test_invalid_response_reraises_exception(self):
+        connection_manager = MagicMock(spec=ConnectionManager)
+        connection_manager.call.side_effect = SceptreException("BOOM!")
+
+        template_handler = S3(
+            name="vpc",
+            arguments={"path": "my-fancy-bucket/account/vpc.yaml"},
+            connection_manager=connection_manager
+        )
+
+        with pytest.raises(SceptreException) as e:
+            template_handler.handle()
+
+        assert str(e.value) == "BOOM!"

--- a/tests/test_template_handlers/test_template_handlers.py
+++ b/tests/test_template_handlers/test_template_handlers.py
@@ -1,0 +1,32 @@
+import pytest
+
+from sceptre.exceptions import TemplateHandlerArgumentsInvalidError
+from sceptre.template_handlers import TemplateHandler
+
+
+class MockTemplateHandler(TemplateHandler):
+    def __init__(self, *args, **kwargs):
+        super(MockTemplateHandler, self).__init__(*args, **kwargs)
+
+    def schema(self):
+        return {
+            "type": "object",
+            "properties": {
+                "argument": {"type": "string"}
+            },
+            "required": ["argument"]
+        }
+
+    def handle(self):
+        return "TestTemplateHandler"
+
+
+class TestTemplateHandlers(object):
+    def test_template_handler_validates_schema(self):
+        handler = MockTemplateHandler(name="mock", arguments={"argument": "test"})
+        handler.validate()
+
+    def test_template_handler_errors_when_arguments_invalid(self):
+        with pytest.raises(TemplateHandlerArgumentsInvalidError):
+            handler = MockTemplateHandler(name="mock", arguments={"non-existent": "test"})
+            handler.validate()


### PR DESCRIPTION
This PR adds support for template handlers, a new entity used to load templates from external sources. The `Template` class now always expects a configuration object for the template handler, and will instantiate it based on the entry points found for `sceptre.template_handlers`. In this way, others can add new template handlers and use them in the Sceptre config.

`TemplateHandler` objects define a JSON schema that will be validated upon use. This will make sure that template handler authors and users provide the correct configuration.

An example of the S3 template handler is as follows:

```yaml
template:
    type: s3
    path: my-bucket/my-fancy-template.yaml
parameters:
    ...
sceptre_user_data:
    ...
```

All the properties of the complex `template` object will be passed into the template handler as arguments (except for `type`). 

To not break backwards compatibility, the `template_path` property can still be used. It will be wired into a `file` template handler in `stack.py`, so the 'ugliness' is contained there. `Template` can then always work with handlers, without considering `template_path`. The `file` template handler contains all the logic for loading Jinja2 templates and/or Python scripts, that was moved from `Template`. So that logic is not in the core of Sceptre any more (which is good IMHO).

The `s3` template handler that is included here does not support Jinja2 templates or Python scripts. That is a limitation that can be solved by writing some code that will check the extension and parse the S3 contents from memory (similar to what `file` does, but that only supports files on disk, not strings in memory).

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
