### PR TITLE
[Resolve #870] Bugfix in _call_sceptre_handler

### DIFF
--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -148,18 +148,20 @@ class Template(object):
         :raises: IOError
         :raises: TemplateSceptreHandlerError
         """
+
         # Get relative path as list between current working directory and where
         # the template is
         # NB: this is a horrible hack...
         relpath = os.path.relpath(self.path, os.getcwd()).split(os.path.sep)
-        relpaths_to_add = [
-            os.path.sep.join(relpath[:i+1])
+        paths_to_add = [
+            os.path.join(os.getcwd(), os.path.sep.join(relpath[:i+1]))
             for i in range(len(relpath[:-1]))
         ]
+
         # Add any directory between the current working directory and where
         # the template is to the python path
-        for directory in relpaths_to_add:
-            sys.path.append(os.path.join(os.getcwd(), directory))
+        for path in paths_to_add:
+            sys.path.append(path)
         self.logger.debug(
             "%s - Getting CloudFormation from %s", self.name, self.path
         )
@@ -179,8 +181,10 @@ class Template(object):
                 )
             else:
                 raise e
-        for directory in relpaths_to_add:
-            sys.path.remove(os.path.join(os.getcwd(), directory))
+
+        for path in paths_to_add:
+            sys.path.remove(path)
+
         return body
 
     def upload_to_s3(self):

--- a/tests/fixtures/templates/chdir.py
+++ b/tests/fixtures/templates/chdir.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+from troposphere import Template
+
+from os import chdir
+
+
+def sceptre_handler(sceptre_user_data):
+    t = Template()
+
+    chdir("..")
+
+    return t.to_json()

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -210,6 +210,21 @@ class TestTemplate(object):
             expected_output_dict = json.loads(f.read())
         assert output_dict == expected_output_dict
 
+    def test_body_with_chdir_template(self):
+        self.template.sceptre_user_data = None
+        self.template.name = "chdir"
+        current_dir = os.getcwd()
+        self.template.path = os.path.join(
+            os.getcwd(),
+            "tests/fixtures/templates/chdir.py"
+        )
+        try:
+            json.loads(self.template.body)
+        except ValueError:
+            assert False
+        finally:
+            os.chdir(current_dir)
+
     def test_body_with_missing_file(self):
         self.template.path = "incorrect/template/path.py"
         with pytest.raises(IOError):


### PR DESCRIPTION
Before this, the _call_sceptre_handler method makes multiple calls to
os.getcwd() in determining paths to add and then later paths to remove.
In the event that the sceptre_handler code then makes a call to
os.chdir, the second call ends up removing the wrong path.

This patch ensures that the paths removed are the same ones that are
added.

## PR Checklist

- [X] Wrote a good commit message & description [see guide below].
- [X] Commit message starts with `[Resolve #issue-number]`.
- [X] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [X] All unit tests (`make test`) are passing.
- [X] Used the same coding conventions as the rest of the project.
- [X] The new code passes flake8 (`make lint`) checks.
- [X] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
