### PR TITLE
[Resolves #874] Allow generate command to run hooks

### DIFF
--- a/docs/_source/docs/hooks.rst
+++ b/docs/_source/docs/hooks.rst
@@ -12,6 +12,8 @@ If required, users can create their own ``hooks``, as described in the section
 Hook points
 -----------
 
+``before_generate`` or ``after_generate`` - run hook before or after generating stack template.
+
 ``before_create`` or ``after_create`` - run hook before or after Stack creation.
 
 ``before_update`` or ``after_update`` - run hook before or after Stack update.

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -573,6 +573,7 @@ class StackActions(object):
         except botocore.exceptions.ClientError:
             return []
 
+    @add_stack_hooks
     def generate(self):
         """
         Returns the Template for the Stack


### PR DESCRIPTION
This enables `before_generate` and `after_generate` hook actions to
allow users to execute hooks when running the `generate` command.