### PR TITLE
Fix execution on empty change-sets

### DIFF
--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -526,6 +526,17 @@ class StackActions(object):
         :rtype: str
         """
         self._protect_execution()
+        change_set = self.describe_change_set(change_set_name)
+        status = change_set.get("Status")
+        reason = change_set.get("StatusReason")
+        if status == "FAILED" and "submitted information didn't contain changes" in reason:
+            self.logger.info(
+                    "Skipping ChangeSet on Stack: {} - there are no changes".format(
+                        change_set.get("StackName")
+                        )
+            )
+            return 0
+
         self.logger.debug(
             "%s - Executing Change Set '%s'", self.stack.name, change_set_name
         )


### PR DESCRIPTION
Our execute change-set command was attempting to execute all change sets
even if the change-set creation had failed due to no changes.

This commit adds a filter for change-sets that have failed because there
are no changes. Information is logged to the user and sceptre continues
launching all change-sets that were successfully created.

[Resolves #846]

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
