### PR TITLE
Fix update command with change sets for multiple stacks

### DIFF
--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -830,6 +830,7 @@ class StackActions(object):
         cs_description = self.describe_change_set(change_set_name)
 
         cs_status = cs_description["Status"]
+        cs_reason = cs_description.get("StatusReason")
         cs_exec_status = cs_description["ExecutionStatus"]
         possible_statuses = [
             "CREATE_PENDING", "CREATE_IN_PROGRESS",
@@ -861,6 +862,12 @@ class StackActions(object):
                 cs_exec_status in ["UNAVAILABLE", "AVAILABLE"]
         ):
             return StackChangeSetStatus.PENDING
+        elif (
+                cs_status == "FAILED" and
+                cs_reason is not None and
+                "submitted information didn't contain changes" in cs_reason
+        ):
+            return StackChangeSetStatus.NO_CHANGES
         elif (
                 cs_status in ["DELETE_COMPLETE", "FAILED"] or
                 cs_exec_status in [

--- a/sceptre/stack_status.py
+++ b/sceptre/stack_status.py
@@ -25,3 +25,4 @@ class StackChangeSetStatus(object):
     PENDING = "pending"
     READY = "ready"
     DEFUNCT = "defunct"
+    NO_CHANGES = "no changes"

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -974,6 +974,17 @@ class TestStackActions(object):
                 )
                 assert response == returns[i]
 
+        mock_describe_change_set.return_value = {
+            "Status": "FAILED",
+            "StatusReason": "The submitted information didn't contain changes. "
+                            "Submit different information to create a change set.",
+            "ExecutionStatus": "UNAVAILABLE"
+        }
+        response = self.actions._get_cs_status(
+            sentinel.change_set_name
+        )
+        assert response == scss.NO_CHANGES
+
         for status in return_values['Status']:
             mock_describe_change_set.return_value = {
                 "Status": status,


### PR DESCRIPTION
Resolves #723

Previously the update command would exit if any change sets status was not equal to READY. However, when a stack does not contain any updates, it will not be READY since there is nothing to execute. This should not prevent other change sets to be executed.

Disclaimer: I'm no longer an active user of Sceptre, but following up on the request in my original bug issue.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
