### PR TITLE
Bump networkx to 2.4

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,7 +7,7 @@ freezegun>=0.3.12,<0.4.0
 Jinja2>=2.8,<3
 mock>=2.0.0,<2.1.0
 moto>=1.3.8,<2.0.0
-networkx==2.1
+networkx==2.4
 packaging>=16.8,<17.0
 pygments>=2.2.0,<3.0.0
 pytest-runner>=3.0.0,<3.1.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -2,6 +2,6 @@ boto3>=1.3.0,<2
 click>=7.0,<8.0
 colorama==0.3.9
 Jinja2>=2.8,<3
-networkx==2.1
+networkx==2.4
 PyYaml>=5.1,<6.0
 typing>=3.7,<3.8

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ install_requirements = [
     "colorama==0.3.9",
     "packaging>=16.8,<17.0",
     "six>=1.11.0,<2.0.0",
-    "networkx==2.1",
+    "networkx==2.4",
     "typing>=3.7.0,<3.8.0"
 ]
 


### PR DESCRIPTION
This is a fix for https://github.com/Sceptre/sceptre/issues/916.

**NOTE:** This should not be merged until https://github.com/Sceptre/sceptre/issues/893 is fixed, because `networkx>2.1` is not available for 2.7. 

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes flake8 (`make lint`) checks.
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
