### PR TITLE
[Resolves #919] Add merge_keys option

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,9 +209,10 @@ Options:
   --dir TEXT                 Specify sceptre directory.
   --output [text|yaml|json]  The formatting style for command output.
   --no-colour                Turn off output colouring.
-  --var TEXT                 A variable to template into config files.
-  --var-file FILENAME        A YAML file of variables to template into config
-                             files.
+  --var TEXT                 A variable to replace the value of an item in
+                             config file.
+  --var-file FILENAME        A YAML file of variables to replace the values
+                             of items in config files.
   --ignore-dependencies      Ignore dependencies when executing command.
   --merge-vars               Merge dict keys in vars and var files.
   --help                     Show this message and exit.

--- a/README.md
+++ b/README.md
@@ -214,7 +214,8 @@ Options:
   --var-file FILENAME        A YAML file of variables to replace the values
                              of items in config files.
   --ignore-dependencies      Ignore dependencies when executing command.
-  --merge-vars               Merge dict keys in vars and var files.
+  --merge-vars               Merge variables from successive --vars and var
+                             files.
   --help                     Show this message and exit.
 
 Commands:

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Options:
   --var-file FILENAME        A YAML file of variables to template into config
                              files.
   --ignore-dependencies      Ignore dependencies when executing command.
-  --merge-keys               Merge dict keys in vars and var files not overwrite.
+  --merge-vars               Merge dict keys in vars and var files.
   --help                     Show this message and exit.
 
 Commands:

--- a/README.md
+++ b/README.md
@@ -198,23 +198,23 @@ Sceptre can be used from the CLI, or imported as a Python package.
 
 ## CLI
 
-```sh
+```text
 Usage: sceptre [OPTIONS] COMMAND [ARGS]...
 
   Sceptre is a tool to manage your cloud native infrastructure deployments.
 
 Options:
-  --version              Show the version and exit.
-  --debug                Turn on debug logging.
-  --dir TEXT             Specify sceptre directory.
-  --output [yaml|json]   The formatting style for command output.
-  --no-colour            Turn off output colouring.
-  --var TEXT             A variable to template into config files.
-  --var-file FILENAME    A YAML file of variables to template into config
-                         files.
-  --ignore-dependencies  Ignore dependencies when executing command.
-  --merge-keys           Merge keys in successive var files not overwrite.
-  --help                 Show this message and exit.
+  --version                  Show the version and exit.
+  --debug                    Turn on debug logging.
+  --dir TEXT                 Specify sceptre directory.
+  --output [text|yaml|json]  The formatting style for command output.
+  --no-colour                Turn off output colouring.
+  --var TEXT                 A variable to template into config files.
+  --var-file FILENAME        A YAML file of variables to template into config
+                             files.
+  --ignore-dependencies      Ignore dependencies when executing command.
+  --merge-keys               Merge keys in successive var files not overwrite.
+  --help                     Show this message and exit.
 
 Commands:
   create         Creates a stack or a change set.

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Options:
   --var-file FILENAME    A YAML file of variables to template into config
                          files.
   --ignore-dependencies  Ignore dependencies when executing command.
+  --merge-keys           Merge keys in successive var files not overwrite.
   --help                 Show this message and exit.
 
 Commands:

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Options:
   --var-file FILENAME        A YAML file of variables to template into config
                              files.
   --ignore-dependencies      Ignore dependencies when executing command.
-  --merge-keys               Merge keys in successive var files not overwrite.
+  --merge-keys               Merge dict keys in vars and var files not overwrite.
   --help                     Show this message and exit.
 
 Commands:

--- a/docs/_source/docs/cli.rst
+++ b/docs/_source/docs/cli.rst
@@ -75,9 +75,9 @@ we could overwrite ``nested: world`` to ``nested: hi`` using:
   requirement.
 
 Alternatively, it is possible to have keys merged according to a deep merge
-algorith, by specifying ``--merge-keys``. For example:
+algorithm, by specifying ``--merge-keys``. For example:
 
-``sceptre --var CommonTags.Version=1 --var-file vars.yaml launch stack``
+``sceptre --merge-keys --var CommonTags.Version=1 --var-file other_tags.yaml launch stack``
 
 Command reference
 -----------------

--- a/docs/_source/docs/cli.rst
+++ b/docs/_source/docs/cli.rst
@@ -74,10 +74,34 @@ we could overwrite ``nested: world`` to ``nested: hi`` using:
   a dependency. Using a --var-file with all variables set can help meet this
   requirement.
 
-Alternatively, it is possible to have keys merged according to a deep merge
-algorithm, by specifying ``--merge-keys``. For example:
+It is also possible to have keys merged according to a deep merge
+algorithm from successive var files, by specifying ``--merge-vars``. So, if we
+had a second variable file "vars2.yaml":
 
-``sceptre --merge-keys --var CommonTags.Version=1 --var-file other_tags.yaml launch stack``
+.. code-block:: yaml
+
+  # other_vars.yaml
+  ---
+  top:
+    middle3:
+      nested: more world
+
+
+We could merge all of this together using:
+
+``sceptre --merge-vars --var-file vars.yaml --var-file other_vars.yaml launch stack``
+
+The ``top`` dictionary would then be expected to contain:
+
+.. code-block:: python
+
+  {
+    "top": {
+      "middle": {"nested": "hello"},
+      "middle2": {"nested": "world"},
+      "middle3": {"nested": "more world"}
+    }
+  }
 
 Command reference
 -----------------

--- a/docs/_source/docs/cli.rst
+++ b/docs/_source/docs/cli.rst
@@ -74,6 +74,11 @@ we could overwrite ``nested: world`` to ``nested: hi`` using:
   a dependency. Using a --var-file with all variables set can help meet this
   requirement.
 
+Alternatively, it is possible to have keys merged according to a deep merge
+algorith, by specifying ``--merge-keys``. For example:
+
+``sceptre --var CommonTags.Version=1 --var-file vars.yaml launch stack``
+
 Command reference
 -----------------
 

--- a/docs/_source/docs/stack_group_config.rst
+++ b/docs/_source/docs/stack_group_config.rst
@@ -191,7 +191,7 @@ Will result in the following variables being available to the jinja templating:
    profile: prod
    project_code: api
 
-Note that there is no merging of dictionaries. If the variable appearing in
+Note that by default, dictionaries are not merged. If the variable appearing in
 the last variable file is a dictionary, and the same variable is defined in an
 earlier variable file, that whole dictionary will be overwritten. For example,
 this would not work as intended:
@@ -207,6 +207,18 @@ this would not work as intended:
    tags: {"Env": "prod"}
 
 Rather, the final dictionary would only contain the ``Env`` key.
+
+By using the ``--merge-vars`` option, these tags can be merged as intended:
+
+.. code-block:: text
+
+    sceptre --merge-vars --var-file=default.yaml --var-file=prod.yaml --var region=us-east-1 <COMMAND>
+
+This will result in the following:
+
+.. code-block:: yaml
+
+    tags: {"Env": "prod", "Project": "Widget"}
 
 For command line flags, Sceptre splits the string on the first equals sign “=”,
 and sets the key to be the first substring, and the value to be the second. Due

--- a/sceptre/cli/__init__.py
+++ b/sceptre/cli/__init__.py
@@ -47,12 +47,12 @@ from sceptre.cli.helpers import catch_exceptions, setup_vars
     "--ignore-dependencies", is_flag=True,
     help="Ignore dependencies when executing command.")
 @click.option(
-    "--merge-keys", is_flag=True, default=False,
-    help="Merge dict keys in successive vars and var files not overwrite.")
+    "--merge-vars", is_flag=True, default=False,
+    help="Merge dict keys in successive vars and var files.")
 @click.pass_context
 @catch_exceptions
 def cli(
-        ctx, debug, directory, output, no_colour, var, var_file, ignore_dependencies, merge_keys
+        ctx, debug, directory, output, no_colour, var, var_file, ignore_dependencies, merge_vars
 ):
     """
     Sceptre is a tool to manage your cloud native infrastructure deployments.
@@ -61,7 +61,7 @@ def cli(
     # Enable deprecation warnings
     warnings.simplefilter("always", DeprecationWarning)
     ctx.obj = {
-        "user_variables": setup_vars(var_file, var, merge_keys, debug, no_colour),
+        "user_variables": setup_vars(var_file, var, merge_vars, debug, no_colour),
         "output_format": output,
         "no_colour": no_colour,
         "ignore_dependencies": ignore_dependencies,

--- a/sceptre/cli/__init__.py
+++ b/sceptre/cli/__init__.py
@@ -12,7 +12,6 @@ import warnings
 
 import click
 import colorama
-import yaml
 
 from sceptre import __version__
 from sceptre.cli.new import new_group

--- a/sceptre/cli/__init__.py
+++ b/sceptre/cli/__init__.py
@@ -48,7 +48,7 @@ from sceptre.cli.helpers import catch_exceptions, setup_vars
     help="Ignore dependencies when executing command.")
 @click.option(
     "--merge-vars", is_flag=True, default=False,
-    help="Merge dict keys in successive vars and var files.")
+    help="Merge variables from successive --vars and var files")
 @click.pass_context
 @catch_exceptions
 def cli(

--- a/sceptre/cli/__init__.py
+++ b/sceptre/cli/__init__.py
@@ -48,7 +48,7 @@ from sceptre.cli.helpers import setup_logging, catch_exceptions, setup_vars
     help="Ignore dependencies when executing command.")
 @click.option(
     "--merge-keys", is_flag=True, default=False,
-    help="Merge keys in successive var files not overwrite.")
+    help="Merge dict keys in successive vars and var files not overwrite.")
 @click.pass_context
 @catch_exceptions
 def cli(

--- a/sceptre/cli/__init__.py
+++ b/sceptre/cli/__init__.py
@@ -26,7 +26,7 @@ from sceptre.cli.policy import set_policy_command
 from sceptre.cli.status import status_command
 from sceptre.cli.template import (validate_command, generate_command,
                                   estimate_cost_command)
-from sceptre.cli.helpers import setup_logging, catch_exceptions, setup_vars
+from sceptre.cli.helpers import catch_exceptions, setup_vars
 
 
 @click.group()
@@ -57,12 +57,11 @@ def cli(
     """
     Sceptre is a tool to manage your cloud native infrastructure deployments.
     """
-    logger = setup_logging(debug, no_colour)
     colorama.init()
     # Enable deprecation warnings
     warnings.simplefilter("always", DeprecationWarning)
     ctx.obj = {
-        "user_variables": setup_vars(var_file, var, merge_keys, logger),
+        "user_variables": setup_vars(var_file, var, merge_keys, debug, no_colour),
         "output_format": output,
         "no_colour": no_colour,
         "ignore_dependencies": ignore_dependencies,

--- a/sceptre/cli/__init__.py
+++ b/sceptre/cli/__init__.py
@@ -39,10 +39,10 @@ from sceptre.cli.helpers import catch_exceptions, setup_vars
 @click.option("--no-colour", is_flag=True, help="Turn off output colouring.")
 @click.option(
     "--var", multiple=True,
-    help="A variable to template into config files.")
+    help="A variable to replace the value of an item in config file.")
 @click.option(
     "--var-file", multiple=True, type=click.File("rb"),
-    help="A YAML file of variables to template into config files.")
+    help="A YAML file of variables to replace the values of items in config files.")
 @click.option(
     "--ignore-dependencies", is_flag=True,
     help="Ignore dependencies when executing command.")

--- a/sceptre/cli/helpers.py
+++ b/sceptre/cli/helpers.py
@@ -164,7 +164,7 @@ def _generate_text(stream):
     return stream
 
 
-def setup_vars(var_file, var, merge_keys, logger):
+def setup_vars(var_file, var, merge_keys, debug, no_colour):
     """
     Handle --var-file and --var arguments before
     returning data for the user_variables as required
@@ -177,11 +177,16 @@ def setup_vars(var_file, var, merge_keys, logger):
     :param merge_keys: Merge instead of
         overwrite duplicate keys.
     :type merge_keys: bool
-    :param logger: the logger object.
-    :type logger: logging.Logger
+    :param debug: debug mode.
+    :type debug: bool
+    :param no_colour: no_colour mode.
+    :type no_colour: bool
+
     :returns: data for the user_variables.
     :rtype: Dict
     """
+    logger = setup_logging(debug, no_colour)
+
     return_value = {}
 
     def _update_dict(variable):

--- a/sceptre/cli/helpers.py
+++ b/sceptre/cli/helpers.py
@@ -164,6 +164,85 @@ def _generate_text(stream):
     return stream
 
 
+def setup_vars(var_file, var, merge_keys, logger):
+    """
+    Handle --var-file and --var arguments before
+    returning data for the user_variables as required
+    by the ConfigReader and SceptreContext.
+
+    :param var_file: the var_file list.
+    :type var_file: List[Dict]
+    :param var: the var list.
+    :type var: List[str]
+    :param merge_keys: Merge instead of
+        overwrite duplicate keys.
+    :type merge_keys: bool
+    :param logger: the logger object.
+    :type logger: logging.Logger
+    :returns: data for the user_variables.
+    :rtype: Dict
+    """
+    return_value = {}
+
+    def _update_dict(variable):
+        variable_key, variable_value = variable.split("=")
+        keys = variable_key.split(".")
+
+        def _nested_set(dic, keys, value):
+            for key in keys[:-1]:
+                dic = dic.setdefault(key, {})
+            dic[keys[-1]] = value
+
+        _nested_set(return_value, keys, variable_value)
+
+    if var_file:
+        for fh in var_file:
+            parsed = yaml.safe_load(fh.read())
+
+            if merge_keys:
+                return_value = _deep_merge(parsed, return_value)
+            else:
+                return_value.update(parsed)
+
+            # the rest of this block is for debug purposes only
+            existing_keys = set(return_value.keys())
+            new_keys = set(parsed.keys())
+            overloaded_keys = existing_keys & new_keys  # intersection
+
+            if overloaded_keys:
+                message = "Duplicate variables encountered: "
+
+                if merge_keys:
+                    message += "{0}. Using values from: {1}.".format(
+                        ", ".join(overloaded_keys), fh.name)
+                else:
+                    message += "{0}. Performing deep merge, {1} wins.".format(
+                        ", ".join(overloaded_keys), fh.name)
+
+                logger.debug(message)
+
+    if var:
+        # --var options overwrite --var-file options, unless a dict and --merge-keys.
+        for variable in var:
+            if isinstance(variable, dict) and merge_keys:
+                return_value = _deep_merge(variable, return_value)
+            else:
+                _update_dict(variable)
+
+    return return_value
+
+
+def _deep_merge(source, destination):
+    for key, value in source.items():
+        if isinstance(value, dict):
+            node = destination.setdefault(key, {})
+            _deep_merge(value, node)
+        else:
+            destination[key] = value
+
+    return destination
+
+
 def stack_status_exit_code(statuses):
     if not all(
             status == StackStatus.COMPLETE

--- a/sceptre/cli/helpers.py
+++ b/sceptre/cli/helpers.py
@@ -164,7 +164,7 @@ def _generate_text(stream):
     return stream
 
 
-def setup_vars(var_file, var, merge_keys, debug, no_colour):
+def setup_vars(var_file, var, merge_vars, debug, no_colour):
     """
     Handle --var-file and --var arguments before
     returning data for the user_variables as required
@@ -174,9 +174,9 @@ def setup_vars(var_file, var, merge_keys, debug, no_colour):
     :type var_file: List[Dict]
     :param var: the var list.
     :type var: List[str]
-    :param merge_keys: Merge instead of
+    :param merge_vars: Merge instead of
         overwrite duplicate keys.
-    :type merge_keys: bool
+    :type merge_vars: bool
     :param debug: debug mode.
     :type debug: bool
     :param no_colour: no_colour mode.
@@ -204,7 +204,7 @@ def setup_vars(var_file, var, merge_keys, debug, no_colour):
         for fh in var_file:
             parsed = yaml.safe_load(fh.read())
 
-            if merge_keys:
+            if merge_vars:
                 return_value = _deep_merge(parsed, return_value)
             else:
                 return_value.update(parsed)
@@ -217,7 +217,7 @@ def setup_vars(var_file, var, merge_keys, debug, no_colour):
             if overloaded_keys:
                 message = "Duplicate variables encountered: "
 
-                if merge_keys:
+                if merge_vars:
                     message += "{0}. Using values from: {1}.".format(
                         ", ".join(overloaded_keys), fh.name)
                 else:
@@ -227,9 +227,9 @@ def setup_vars(var_file, var, merge_keys, debug, no_colour):
                 logger.debug(message)
 
     if var:
-        # --var options overwrite --var-file options, unless a dict and --merge-keys.
+        # --var options overwrite --var-file options, unless a dict and --merge-vars.
         for variable in var:
-            if isinstance(variable, dict) and merge_keys:
+            if isinstance(variable, dict) and merge_vars:
                 return_value = _deep_merge(variable, return_value)
             else:
                 _update_dict(variable)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -211,7 +211,7 @@ class TestCli(object):
                 "CommonTags": {
                     "Organization": "Parts Unlimited",
                     "Department": "IT Operations",
-                    "Envlist": ["test"]  # May not be what we ultimately want!
+                    "Envlist": ["test"]
                 }
             }
         ),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -238,7 +238,10 @@ class TestCli(object):
         ),
         # multiple --var-file and --var combined.
         (
-            ["--merge-vars", "--var-file", "common.yaml", "--var-file", "test.yaml", "--var", "CommonTags.Project=Unboxing", "noop"],
+            [
+                "--merge-vars", "--var-file", "common.yaml", "--var-file", "test.yaml",
+                "--var", "CommonTags.Project=Unboxing", "noop"
+            ],
             {
                 "common.yaml": {
                     "CommonTags": {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -142,6 +142,17 @@ class TestCli(object):
                 "key1": {"a": "b", "c": "d"}
             }
         ),
+        # multiple --var-file option, illustrating dictionaries not merged.
+        (
+            ["--var-file", "foo.yaml", "--var-file", "bar.yaml", "noop"],
+            {
+                "foo.yaml": {"key1": {"a": "b"}},
+                "bar.yaml": {"key1": {"c": "d"}}
+            },
+            {
+                "key1": {"c": "d"}
+            }
+        ),
         # multiple --var-file option, dictionaries merged, complex example.
         (
             ["--merge-vars", "--var-file", "common.yaml", "--var-file", "dev.yaml", "noop"],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -215,6 +215,27 @@ class TestCli(object):
                 "a": {"b": {"c": "r", "d": "q", "e": "s"}}
             }
         ),
+        # multiple --var-file and --var combined.
+        (
+            ["--merge-keys", "--var-file", "common.yaml", "--var", "CommonTags.Version=1.0.0", "noop"],
+            {
+                "common.yaml": {
+                    "CommonTags": {
+                        "Organization": "Parts Unlimited",
+                        "Department": "IT Operations",
+                        "Envlist": ["sandbox", "dev"]
+                    }
+                }
+            },
+            {
+                "CommonTags": {
+                    "Organization": "Parts Unlimited",
+                    "Department": "IT Operations",
+                    "Envlist": ["sandbox", "dev"],
+                    "Version": "1.0.0"
+                }
+            }
+        ),
     ])
     def test_user_variables(self, command, files, output):
         @cli.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -133,7 +133,7 @@ class TestCli(object):
         ),
         # multiple --var-file option, dictionaries merged.
         (
-            ["--merge-keys", "--var-file", "foo.yaml", "--var-file", "bar.yaml", "noop"],
+            ["--merge-vars", "--var-file", "foo.yaml", "--var-file", "bar.yaml", "noop"],
             {
                 "foo.yaml": {"key1": {"a": "b"}},
                 "bar.yaml": {"key1": {"c": "d"}}
@@ -144,7 +144,7 @@ class TestCli(object):
         ),
         # multiple --var-file option, dictionaries merged, complex example.
         (
-            ["--merge-keys", "--var-file", "common.yaml", "--var-file", "dev.yaml", "noop"],
+            ["--merge-vars", "--var-file", "common.yaml", "--var-file", "dev.yaml", "noop"],
             {
                 "common.yaml": {
                     "CommonTags": {
@@ -164,7 +164,7 @@ class TestCli(object):
         ),
         # multiple --var-file option, dictionaries merged, complex example, with overrides.
         (
-            ["--merge-keys", "--var-file", "common.yaml", "--var-file", "dev.yaml", "noop"],
+            ["--merge-vars", "--var-file", "common.yaml", "--var-file", "dev.yaml", "noop"],
             {
                 "common.yaml": {
                     "CommonTags": {
@@ -185,7 +185,7 @@ class TestCli(object):
         ),
         # multiple --var-file option, dictionaries merged, complex example, with lists.
         (
-            ["--merge-keys", "--var-file", "common.yaml", "--var-file", "test.yaml", "noop"],
+            ["--merge-vars", "--var-file", "common.yaml", "--var-file", "test.yaml", "noop"],
             {
                 "common.yaml": {
                     "CommonTags": {
@@ -206,7 +206,7 @@ class TestCli(object):
         ),
         # multiple --var-file option, dictionaries merged, multiple levels.
         (
-            ["--merge-keys", "--var-file", "common.yaml", "--var-file", "test.yaml", "noop"],
+            ["--merge-vars", "--var-file", "common.yaml", "--var-file", "test.yaml", "noop"],
             {
                 "common.yaml": {"a": {"b": {"c": "p", "d": "q"}}},
                 "test.yaml": {"a": {"b": {"c": "r", "e": "s"}}}
@@ -215,9 +215,9 @@ class TestCli(object):
                 "a": {"b": {"c": "r", "d": "q", "e": "s"}}
             }
         ),
-        # multiple --var-file and --var combined.
+        # a --var-file and --var combined.
         (
-            ["--merge-keys", "--var-file", "common.yaml", "--var", "CommonTags.Version=1.0.0", "noop"],
+            ["--merge-vars", "--var-file", "common.yaml", "--var", "CommonTags.Version=1.0.0", "noop"],
             {
                 "common.yaml": {
                     "CommonTags": {
@@ -236,6 +236,32 @@ class TestCli(object):
                 }
             }
         ),
+        # multiple --var-file and --var combined.
+        (
+            ["--merge-vars", "--var-file", "common.yaml", "--var-file", "test.yaml", "--var", "CommonTags.Project=Unboxing", "noop"],
+            {
+                "common.yaml": {
+                    "CommonTags": {
+                        "Organization": "Parts Unlimited",
+                        "Department": "IT Operations",
+                        "Envlist": ["sandbox", "dev"]
+                    }
+                },
+                "test.yaml": {
+                    "CommonTags": {
+                        "Project": "Boxing"
+                    }
+                }
+            },
+            {
+                "CommonTags": {
+                    "Organization": "Parts Unlimited",
+                    "Department": "IT Operations",
+                    "Envlist": ["sandbox", "dev"],
+                    "Project": "Unboxing"
+                }
+            }
+        )
     ])
     def test_user_variables(self, command, files, output):
         @cli.command()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -131,6 +131,90 @@ class TestCli(object):
             },
             {"key1": "file1", "key2": "var2"}
         ),
+        # multiple --var-file option, dictionaries merged.
+        (
+            ["--merge-keys", "--var-file", "foo.yaml", "--var-file", "bar.yaml", "noop"],
+            {
+                "foo.yaml": {"key1": {"a": "b"}},
+                "bar.yaml": {"key1": {"c": "d"}}
+            },
+            {
+                "key1": {"a": "b", "c": "d"}
+            }
+        ),
+        # multiple --var-file option, dictionaries merged, complex example.
+        (
+            ["--merge-keys", "--var-file", "common.yaml", "--var-file", "dev.yaml", "noop"],
+            {
+                "common.yaml": {
+                    "CommonTags": {
+                        "Organization": "Parts Unlimited",
+                        "Department": "IT Operations"
+                    }
+                },
+                "dev.yaml": {"CommonTags": {"Environment": "dev"}}
+            },
+            {
+                "CommonTags": {
+                    "Organization": "Parts Unlimited",
+                    "Department": "IT Operations",
+                    "Environment": "dev"
+                }
+            }
+        ),
+        # multiple --var-file option, dictionaries merged, complex example, with overrides.
+        (
+            ["--merge-keys", "--var-file", "common.yaml", "--var-file", "dev.yaml", "noop"],
+            {
+                "common.yaml": {
+                    "CommonTags": {
+                        "Organization": "Parts Unlimited",
+                        "Department": "IT Operations",
+                        "Environment": "sandbox"
+                    }
+                },
+                "dev.yaml": {"CommonTags": {"Environment": "dev"}},
+            },
+            {
+                "CommonTags": {
+                    "Organization": "Parts Unlimited",
+                    "Department": "IT Operations",
+                    "Environment": "dev"
+                }
+            }
+        ),
+        # multiple --var-file option, dictionaries merged, complex example, with lists.
+        (
+            ["--merge-keys", "--var-file", "common.yaml", "--var-file", "test.yaml", "noop"],
+            {
+                "common.yaml": {
+                    "CommonTags": {
+                        "Organization": "Parts Unlimited",
+                        "Department": "IT Operations",
+                        "Envlist": ["sandbox", "dev"]
+                    }
+                },
+                "test.yaml": {"CommonTags": {"Envlist": ["test"]}},
+            },
+            {
+                "CommonTags": {
+                    "Organization": "Parts Unlimited",
+                    "Department": "IT Operations",
+                    "Envlist": ["test"]  # May not be what we ultimately want!
+                }
+            }
+        ),
+        # multiple --var-file option, dictionaries merged, multiple levels.
+        (
+            ["--merge-keys", "--var-file", "common.yaml", "--var-file", "test.yaml", "noop"],
+            {
+                "common.yaml": {"a": {"b": {"c": "p", "d": "q"}}},
+                "test.yaml": {"a": {"b": {"c": "r", "e": "s"}}}
+            },
+            {
+                "a": {"b": {"c": "r", "d": "q", "e": "s"}}
+            }
+        ),
     ])
     def test_user_variables(self, command, files, output):
         @cli.command()


### PR DESCRIPTION
Adds CLI option --merge-keys. Dictionaries in multiple var files are
merged instead of overwritten. Test cases added.
    
I have added flake8 noqa in `sceptre/cli/__init__.py` to avoid C901 code
complexity in the cli function.

## PR Checklist

- [X] Wrote a good commit message & description [see guide below].
- [X] Commit message starts with `[Resolve #issue-number]`.
- [X] Added/Updated unit tests.
- [X] Added/Updated integration tests (if applicable).
- [X] All unit tests (`make test`) are passing.
- [X] Used the same coding conventions as the rest of the project.
- [X] The new code passes flake8 (`make lint`) checks.
- [X] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
