### PR TITLE
[Resolves #937] Reset Jinja2 variable cache between config files

### DIFF
--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -384,6 +384,13 @@ class ConfigReader(object):
                 undefined=StrictUndefined
             )
             template = jinja_env.get_template(basename)
+
+            # Reset the template cache to avoid leakage between StackGroups (#937)
+            template_vars = {'var': self.templating_vars['var']}
+            if 'stack_group_config' in self.templating_vars:
+                template_vars['stack_group_config'] = self.templating_vars['stack_group_config']
+            self.templating_vars = template_vars
+
             self.templating_vars.update(stack_group_config)
             rendered_template = template.render(
                 self.templating_vars,


### PR DESCRIPTION
Fix for: https://github.com/Sceptre/sceptre/issues/937

This resets the Jinja2 `templating_vars` in `config/reader.py` to prevent variables leaking across StackGroups.


## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
