### PR TITLE
Warn about duplicate stack config parameters in documentation

### DIFF
--- a/docs/_source/docs/stack_config.rst
+++ b/docs/_source/docs/stack_config.rst
@@ -83,6 +83,11 @@ type as defined in the template.
    that are not required by that template. Resolvers can be used to add
    functionality to this key. Find out more in the :doc:`resolvers` section.
 
+.. warning::
+
+   In case the same parameter key is supplied more than once, the last
+   definition silently overrides the earlier definitions.
+
 A parameter can be specified either as a single value/resolver or a list of
 values/resolvers. Lists of values/resolvers will be formatted into an AWS
 compatible comma separated string e.g. \ ``value1,value2,value3``. Lists can

--- a/docs/_source/docs/stack_config.rst
+++ b/docs/_source/docs/stack_config.rst
@@ -66,7 +66,7 @@ to create. For more information and valid values see the `AWS Documentation`_.
 parameters
 ~~~~~~~~~~
 
-.. container:: alert alert-danger
+.. warning::
 
    Sensitive data such as passwords or secret keys should not be stored in
    plaintext in Stack config files. Instead, they should be passed in from the
@@ -76,6 +76,8 @@ parameters
 A dictionary of key-value pairs to be supplied to a template as parameters. The
 keys must match up with the name of the parameter, and the value must be of the
 type as defined in the template.
+
+.. note::
 
    Note that Boto3 throws an exception if parameters are supplied to a template
    that are not required by that template. Resolvers can be used to add


### PR DESCRIPTION
A warning about error prone handling of duplicate parameters in Stack Config.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`. _Does not resolve any issue, documentation update only_
- [ ] Added/Updated unit tests. _Not applicable, only documentation changes_
- [ ] Added/Updated integration tests (if applicable). _Not applicable, only documentation changes_
- [ ] All unit tests (`make test`) are passing. _Not applicable, only documentation changes_
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
