### PR TITLE
[Resolves #947] make colorama dependency more flexible

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,6 +1,6 @@
 boto3>=1.3.0,<2
 click>=7.0,<8.0
-colorama==0.3.9
+colorama>=0.3.9
 Jinja2>=2.8,<3
 networkx==2.1
 PyYaml>=5.1,<6.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ install_requirements = [
     "click>=7.0,<8.0",
     "PyYaml>=5.1,<6.0",
     "Jinja2>=2.8,<3",
-    "colorama==0.3.9",
+    "colorama>=0.3.9",
     "packaging>=16.8,<17.0",
     "six>=1.11.0,<2.0.0",
     "networkx==2.1",


### PR DESCRIPTION
sceptre fails to install when installed after awscli. make colorama
dependency more flexible so that it will not fail.