### PR TITLE
[Resolves #921 and #956] Remove Python 2.7 support and fix build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 aliases:
   - &docs-job
     docker:
-      - image: cloudreach/sceptre-circleci:0.5.0
+      - image: cloudreach/sceptre-circleci:0.6.0
         environment:
           REPOSITORY_PATH: '/home/circleci/docs'
           DEPLOYMENT_GIT_SSH: 'git@github.com:Sceptre/sceptre.github.io.git'
@@ -32,7 +32,7 @@ aliases:
 jobs:
   build:
     docker:
-      - image: cloudreach/sceptre-circleci:0.5.0
+      - image: cloudreach/sceptre-circleci:0.6.0
     steps:
       - checkout
       - run:
@@ -47,7 +47,6 @@ jobs:
           name: 'Installing Requirements'
           command: |
             . ./venv/bin/activate
-            pip install --upgrade pip
             pip install -r requirements/prod.txt
             pip install -r requirements/dev.txt
             pip install awscli
@@ -70,7 +69,7 @@ jobs:
 
   lint-and-unit-tests:
     docker:
-      - image: cloudreach/sceptre-circleci:0.5.0
+      - image: cloudreach/sceptre-circleci:0.6.0
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -140,7 +139,7 @@ jobs:
   integration-tests:
     parallelism: 2
     docker:
-      - image: cloudreach/sceptre-circleci:0.5.0
+      - image: cloudreach/sceptre-circleci:0.6.0
         environment:
           AWS_DEFAULT_REGION: eu-west-1
     steps:
@@ -183,7 +182,7 @@ jobs:
 
   deploy-pypi:
     docker:
-      - image: cloudreach/sceptre-circleci:0.5.0
+      - image: cloudreach/sceptre-circleci:0.6.0
     steps:
       - attach_workspace:
           at: /home/circleci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 aliases:
   - &docs-job
     docker:
-      - image: cloudreach/sceptre-circleci:0.4
+      - image: cloudreach/sceptre-circleci:0.5.0
         environment:
           REPOSITORY_PATH: '/home/circleci/docs'
           DEPLOYMENT_GIT_SSH: 'git@github.com:Sceptre/sceptre.github.io.git'
@@ -32,7 +32,7 @@ aliases:
 jobs:
   build:
     docker:
-      - image: cloudreach/sceptre-circleci:0.4
+      - image: cloudreach/sceptre-circleci:0.5.0
     steps:
       - checkout
       - run:
@@ -69,7 +69,7 @@ jobs:
 
   lint-and-unit-tests:
     docker:
-      - image: cloudreach/sceptre-circleci:0.4
+      - image: cloudreach/sceptre-circleci:0.5.0
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -139,7 +139,7 @@ jobs:
   integration-tests:
     parallelism: 2
     docker:
-      - image: cloudreach/sceptre-circleci:0.4
+      - image: cloudreach/sceptre-circleci:0.5.0
         environment:
           AWS_DEFAULT_REGION: eu-west-1
     steps:
@@ -182,7 +182,7 @@ jobs:
 
   deploy-pypi:
     docker:
-      - image: cloudreach/sceptre-circleci:0.4
+      - image: cloudreach/sceptre-circleci:0.5.0
     steps:
       - attach_workspace:
           at: /home/circleci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
           name: 'Installing Requirements'
           command: |
             . ./venv/bin/activate
-            pip install --no-input pip
+            pip install --upgrade pip
             pip install -r requirements/prod.txt
             pip install -r requirements/dev.txt
             pip install awscli

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ jobs:
           name: 'Installing Requirements'
           command: |
             . ./venv/bin/activate
+            pip install --no-input pip
             pip install -r requirements/prod.txt
             pip install -r requirements/dev.txt
             pip install awscli


### PR DESCRIPTION
This PR updates the docker image for the following:

1. Python 2.7 support was removed from `cloudreach/sceptre-circleci` docker image in commit
   https://github.com/Sceptre/sceptre-circleci/commit/975fa092fdd3f005bb4f714f7aa0a736ec1a75a3
   and tagged with https://github.com/Sceptre/sceptre-circleci/releases/tag/v0.5.0

   We removed python 2.7 support from sceptre in PR #922 however we neglected to update
   cicleci to build with the updated docker image.   We update the docker image to use the updated
   sceptre-circleci container with python 2.7 removed.

2. The build is failing due to building in an Alpine 3.7 docker container.  We update to pick up
    PR https://github.com/Sceptre/sceptre-circleci/pull/1 to allow sceptre build to build in a Alpine 3.11
   container.

This PR depends on PR https://github.com/Sceptre/sceptre-circleci/pull/1 and the creation of a
sceptre-circleci:0.6.0 docker image.