### PR TITLE
Fix docs about stack group config in templates

### DIFF
--- a/docs/_source/docs/stack_config.rst
+++ b/docs/_source/docs/stack_config.rst
@@ -223,7 +223,7 @@ when using templating.
 .. code-block:: yaml
 
    parameters:
-     sceptre-project-code: {{ stack_group_config.sceptre-project-code }}
+     sceptre-project-code: {{ stack_group_config.project-code }}
 
 Environment Variables
 ---------------------


### PR DESCRIPTION
A [test case](https://github.com/Sceptre/sceptre/blob/40829c0b6de08816a2fc1073101d2da18d88d259/tests/fixtures/config/account/stack-group/region/security_groups.yaml#L5) suggests that change

Simple fix to the docs.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes flake8 (`make lint`) checks.
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [x] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
