### PR TITLE
Fetch remote template from cloudformation

### DIFF
--- a/sceptre/cli/__init__.py
+++ b/sceptre/cli/__init__.py
@@ -25,7 +25,7 @@ from sceptre.cli.describe import describe_group
 from sceptre.cli.list import list_group
 from sceptre.cli.policy import set_policy_command
 from sceptre.cli.status import status_command
-from sceptre.cli.template import (validate_command, generate_command,
+from sceptre.cli.template import (validate_command, generate_command, fetch_remote_template_command,
                                   estimate_cost_command)
 from sceptre.cli.helpers import setup_logging, catch_exceptions
 
@@ -107,6 +107,7 @@ cli.add_command(execute_command)
 cli.add_command(validate_command)
 cli.add_command(estimate_cost_command)
 cli.add_command(generate_command)
+cli.add_command(fetch_remote_template_command)
 cli.add_command(set_policy_command)
 cli.add_command(status_command)
 cli.add_command(list_group)

--- a/sceptre/cli/__init__.py
+++ b/sceptre/cli/__init__.py
@@ -25,7 +25,8 @@ from sceptre.cli.describe import describe_group
 from sceptre.cli.list import list_group
 from sceptre.cli.policy import set_policy_command
 from sceptre.cli.status import status_command
-from sceptre.cli.template import (validate_command, generate_command, fetch_remote_template_command,
+from sceptre.cli.template import (validate_command, generate_command,
+                                  fetch_remote_template_command,
                                   estimate_cost_command)
 from sceptre.cli.helpers import setup_logging, catch_exceptions
 

--- a/sceptre/cli/template.py
+++ b/sceptre/cli/template.py
@@ -66,6 +66,7 @@ def generate_command(ctx, path):
     output = [template for template in responses.values()]
     write(output, context.output_format)
 
+
 @click.command(name="fetch-remote-template", short_help="Prints the remote template.")
 @click.argument("path")
 @click.pass_context

--- a/sceptre/cli/template.py
+++ b/sceptre/cli/template.py
@@ -66,6 +66,32 @@ def generate_command(ctx, path):
     output = [template for template in responses.values()]
     write(output, context.output_format)
 
+@click.command(name="fetch-remote-template", short_help="Prints the remote template.")
+@click.argument("path")
+@click.pass_context
+@catch_exceptions
+def fetch_remote_template_command(ctx, path):
+    """
+    Prints the remote template used for stack in PATH.
+    \f
+
+    :param path: Path to execute the command on.
+    :type path: str
+    """
+    context = SceptreContext(
+        command_path=path,
+        project_path=ctx.obj.get("project_path"),
+        user_variables=ctx.obj.get("user_variables"),
+        options=ctx.obj.get("options"),
+        output_format=ctx.obj.get("output_format"),
+        ignore_dependencies=ctx.obj.get("ignore_dependencies")
+    )
+
+    plan = SceptrePlan(context)
+    responses = plan.fetch_remote_template()
+    output = [template for template in responses.values()]
+    write(output, context.output_format)
+
 
 @click.command(name="estimate-cost", short_help="Estimates the cost of the template.")
 @click.argument("path")

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -579,7 +579,7 @@ class StackActions(object):
         Returns the Template for the Stack
         """
         return self.stack.template.body
-    
+
     @add_stack_hooks
     def fetch_remote_template(self):
         """
@@ -594,7 +594,6 @@ class StackActions(object):
             }
         )
         return response.get("TemplateBody")
-
 
     @add_stack_hooks
     def validate(self):

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -579,6 +579,22 @@ class StackActions(object):
         Returns the Template for the Stack
         """
         return self.stack.template.body
+    
+    @add_stack_hooks
+    def fetch_remote_template(self):
+        """
+        Returns the Template for the remote Stack
+        """
+        self.logger.debug("%s - Fetching remote template", self.stack.name)
+        response = self.connection_manager.call(
+            service="cloudformation",
+            command="get_template",
+            kwargs={
+                "StackName": self.stack.external_name
+            }
+        )
+        return response.get("TemplateBody")
+
 
     @add_stack_hooks
     def validate(self):

--- a/sceptre/plan/plan.py
+++ b/sceptre/plan/plan.py
@@ -347,6 +347,16 @@ class SceptrePlan(object):
         self.resolve(command=self.generate.__name__)
         return self._execute(*args)
 
+    def fetch_remote_template(self, *args):
+        """
+        Returns a generated Template for a given Stack
+
+        :returns: A dictionary of Stacks and their template body.
+        :rtype: dict
+        """
+        self.resolve(command=self.fetch_remote_template.__name__)
+        return self._execute(*args)
+
     def _valid_stack_paths(self):
         return [
             sceptreise_path(path.relpath(path.join(dirpath, f), self.context.config_path))


### PR DESCRIPTION
Adds the `fetch-remote-template` command that fetches the template body of the remote cloudformation stack.

Intended to be used to perform better diffs against local and remote templates.

## PR Checklist

- [ ] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes flake8 (`make lint`) checks.
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
