### PR TITLE
[Resolve #942] Update `networkx` version restriction to allow 2.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ install_requirements = [
     "colorama>=0.3.9",
     "packaging>=16.8,<17.0",
     "six>=1.11.0,<2.0.0",
-    "networkx==2.1",
+    "networkx>=2.1,<3",
     "typing>=3.7.0,<3.8.0"
 ]
 


### PR DESCRIPTION
This change loosen's the `networkx` version restriction from `==2.1` to `>=2.1, <3`.
This is to allow sceptre to be installed on python 3.9 which made a
breaking change to a depricated api that networkx was using
(`fractions.gcd`).

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] ~Added/Updated unit tests.~
- [ ] ~Added/Updated integration tests (if applicable).~
- [ ] All unit tests (`make test`) are passing.
- [x] ~Used the same coding conventions as the rest of the project.~
- [x] The new code passes flake8 (`make lint`) checks.
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
