### PR TITLE
[resolves #956] attempt to fix build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ jobs:
           name: 'Installing Requirements'
           command: |
             . ./venv/bin/activate
+            pip install --upgrade pip
             pip install -r requirements/prod.txt
             pip install -r requirements/dev.txt
             pip install awscli


### PR DESCRIPTION
Attempt to fix build failure `error: can't find Rust compiler`.

The docs says try to update pip..
https://cryptography.io/en/latest/faq.html#installing-cryptography-fails-with-error-can-not-find-rust-compiler`