### PR TITLE
remove circleci context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,11 +240,9 @@ workflows:
   version: 2.1
   build-test-and-deploy:
     jobs:
-      - build:
-          context: sceptre-core
+      - build
 
       - lint-and-unit-tests:
-          context: sceptre-core
           requires:
             - build
 
@@ -308,7 +306,6 @@ workflows:
               ignore: /.*/
 
       - build-docker-image:
-          context: sceptre-core
           requires:
             - lint-and-unit-tests
 #            - integration-tests


### PR DESCRIPTION
CircleCi reported `build` job as unauthorized[1] because it had a context
applied to it.  PR builds do not require a context for build,
lint-and-unt-tests, and build-docker-image jobs.

[1] https://support.circleci.com/hc/en-us/articles/360050273651-Builds-Unauthorized-due-to-contexts