### PR TITLE
re-enable integration tests

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -7,6 +7,8 @@
 * `GITHUB_EMAIL` - email which is associated with commit message and github account
 * `GITHUB_TOKEN` - access token with push rights to the target repository `/docs`
 * `CIRCLE_USERNAME` - built in variable in CIRCLE CI - should be same as user who pushes to repository
+* `CI_SERVICE_AWS_ACCESS_KEY_ID` - The CI service user's AWS access key ID
+* `CI_SERVICE_AWS_SECRET_ACCESS_KEY` - The CI service user's AWS secret access key
 
 ##### Optional evn variables
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,31 +138,31 @@ jobs:
 #            . venv/bin/activate
 #            make sonar
 
-# Disable integration tests because we don't have access to the
-# AWS account it depends on.  We'll need to get an account before
-# we can run these tests again.
-#  integration-tests:
-#    parallelism: 2
-#    docker:
-#      - image: cloudreach/sceptre-circleci:0.6.0
-#        environment:
-#          AWS_DEFAULT_REGION: eu-west-1
-#    steps:
-#      - attach_workspace:
-#          at: /home/circleci
-#      - run:
-#          name: 'Integration Testing'
-#          command: |
-#            . ./venv/bin/activate
-#            behave --junit \
-#                   --junit-directory build/behave \
-#                   $(circleci tests glob "integration-tests/features/*.feature" | circleci tests split --split-by=timings)
-#      - store_test_results:
-#          path: build/behave
-#          destination: build/behave
-#      - store_artifacts:
-#          path: build/behave
-#          destination: build/behave
+  integration-tests:
+    parallelism: 1
+    docker:
+      - image: cloudreach/sceptre-circleci:0.7.0
+        environment:
+          AWS_DEFAULT_REGION: eu-west-1
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+      - run:
+          name: 'Integration Testing'
+          command: |
+            . ./venv/bin/activate
+            mkdir -p ~/.aws
+            echo -e "[default]\nregion=eu-west-1\nsource_profile=default\nrole_arn=arn:aws:iam::582448526747:role/bootstrap-ci-service-access-ServiceRole-13M4IKJRFUISQ" > ~/.aws/config
+            echo -e "[default]\nregion=eu-west-1\naws_access_key_id=$CI_SERVICE_AWS_ACCESS_KEY_ID\naws_secret_access_key=$CI_SERVICE_AWS_SECRET_ACCESS_KEY" > ~/.aws/credentials
+            behave --junit \
+                   --junit-directory build/behave \
+                   $(circleci tests glob "integration-tests/features/*.feature" | circleci tests split --split-by=timings)
+      - store_test_results:
+          path: build/behave
+          destination: build/behave
+      - store_artifacts:
+          path: build/behave
+          destination: build/behave
 
   build-docker-image:
     executor: docker-publisher
@@ -252,21 +252,21 @@ workflows:
 #            - build
 #            - lint-and-unit-tests
 
-#      - integration-tests:
-#          context: sceptre-core
-#          requires:
-#            - build
-#          filters:
-#            tags:
-#              only: /.*/
-#            branches:
-#              ignore: /^pull\/.*/
+      - integration-tests:
+          context: sceptre-core
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /^pull\/.*/
 
       - deploy-docs-branch:
           context: sceptre-core
           requires:
             - lint-and-unit-tests
-#            - integration-tests
+            - integration-tests
           filters:
             branches:
               only: master
@@ -275,7 +275,7 @@ workflows:
           context: sceptre-core
           requires:
             - lint-and-unit-tests
-#            - integration-tests
+            - integration-tests
           filters:
             tags:
               only: /^v.*/
@@ -287,7 +287,7 @@ workflows:
           type: approval
           requires:
             - lint-and-unit-tests
-#            - integration-tests
+            - integration-tests
 #            - sonar
           filters:
             tags:
@@ -308,7 +308,7 @@ workflows:
       - build-docker-image:
           requires:
             - lint-and-unit-tests
-#            - integration-tests
+            - integration-tests
 #            - sonar
 
       - deploy-latest-dockerhub:

--- a/integration-tests/features/stack-output-external-resolver.feature
+++ b/integration-tests/features/stack-output-external-resolver.feature
@@ -1,8 +1,7 @@
 Feature: Stack output external resolver
 
   Scenario: launch a stack referencing the external output of an existing stack
-    Given stack_group "9" has AWS config "aws-config" set
-    and stack "9/A" exists using "dependencies/independent_template.json"
+    Given stack "9/A" exists using "dependencies/independent_template.json"
     and stack "9/B" does not exist
     When the user launches stack "9/B"
     Then stack "9/B" exists in "CREATE_COMPLETE" state

--- a/integration-tests/sceptre-project/config/9/aws-config
+++ b/integration-tests/sceptre-project/config/9/aws-config
@@ -1,2 +1,0 @@
-[default]
-region = us-east-1


### PR DESCRIPTION
Fix up the CI and re-enable integration tests to run against a temporary
AWS account.