### PR TITLE
remove python 3.5 from supported list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,6 @@ setup(
         "Intended Audience :: Developers",
         "Natural Language :: English",
         "Environment :: Console",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7"
     ],


### PR DESCRIPTION
We currently only run tests on python 3.6 and 3.7