### PR TITLE
[Resolves #1013] Fix virtual-hosted-style uri

### DIFF
--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -454,16 +454,13 @@ class ConfigReader(object):
                 )
             ])
 
-            bucket_region = config.get("region", None)
-
             if "template_key_prefix" in config:
                 prefix = config["template_key_prefix"]
                 template_key = "/".join([prefix.strip("/"), template_key])
 
             s3_details = {
                 "bucket_name": config["template_bucket_name"],
-                "bucket_key": template_key,
-                "bucket_region": bucket_region
+                "bucket_key": template_key
             }
         return s3_details
 

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -207,7 +207,7 @@ class Template(object):
         # Remove any leading or trailing slashes the user may have added.
         bucket_name = self.s3_details["bucket_name"]
         bucket_key = self.s3_details["bucket_key"]
-        bucket_region = self.s3_details["bucket_region"]
+        bucket_region = self._bucket_region(bucket_name)
 
         self.logger.debug(
             "%s - Uploading template to: 's3://%s/%s'",
@@ -224,16 +224,9 @@ class Template(object):
             }
         )
 
-        china_regions = ["cn-north-1", "cn-northwest-1"]
-
-        if bucket_region in china_regions:
-            url = "https://{0}.s3.{1}.amazonaws.com.cn/{2}".format(
-                bucket_name, bucket_region, bucket_key
-            )
-        else:
-            url = "https://{0}.s3.amazonaws.com/{1}".format(
-                bucket_name, bucket_key
-            )
+        url = "https://{}.s3.{}.amazonaws.{}/{}".format(
+            bucket_name, bucket_region, self._domain_from_region(bucket_region), bucket_key
+        )
 
         self.logger.debug("%s - Template URL: '%s'", self.name, url)
 
@@ -318,6 +311,18 @@ class Template(object):
             return {"TemplateURL": url}
         else:
             return {"TemplateBody": self.body}
+
+    def _bucket_region(self, bucket_name):
+        region = self.connection_manager.call(
+            service="s3",
+            command="get_bucket_location",
+            kwargs={"Bucket": bucket_name}
+        ).get("LocationConstraint")
+        return region if region else "us-east-1"
+
+    @staticmethod
+    def _domain_from_region(region):
+        return "com.cn" if region.startswith("cn-") else "com"
 
     @staticmethod
     def _render_jinja_template(template_dir, filename, jinja_vars):

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -186,8 +186,7 @@ class TestConfigReader(object):
             },
             {
                 "bucket_name": "bucket-name",
-                "bucket_key": "prefix/name/2012-01-01-00-00-00-000000Z.json",
-                "bucket_region": "eu-west-1",
+                "bucket_key": "prefix/name/2012-01-01-00-00-00-000000Z.json"
             }
         ),
         (
@@ -198,8 +197,7 @@ class TestConfigReader(object):
             },
             {
                 "bucket_name": "bucket-name",
-                "bucket_key": "name/2012-01-01-00-00-00-000000Z.json",
-                "bucket_region": "eu-west-1",
+                "bucket_key": "name/2012-01-01-00-00-00-000000Z.json"
             }
         ),
         (
@@ -209,8 +207,7 @@ class TestConfigReader(object):
             },
             {
                 "bucket_name": "bucket-name",
-                "bucket_key": "name/2012-01-01-00-00-00-000000Z.json",
-                "bucket_region": None,
+                "bucket_key": "name/2012-01-01-00-00-00-000000Z.json"
             }
         ),
         (


### PR DESCRIPTION
S3 virutal-hosted-style urls include the region name.
Currently, template.py only properly formats urls in
the China region. This commit adds the region to the url.
In doing so, gov cloud becomes supported.

## PR Checklist

- [X] Wrote a good commit message & description [see guide below].
- [X] Commit message starts with `[Resolve #issue-number]`.
- [X] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [X] All unit tests (`make test`) are passing.
- [X] Used the same coding conventions as the rest of the project.
- [X] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [X] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
