### PR TITLE
add cfn-lint to pre-commit checks

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -6,4 +6,3 @@ ignore_templates:
   - tests/fixtures/config/**/*
   - .circleci/**/*
   - .pre-commit-config.yaml
-  - .cfnlintrc.yaml

--- a/.cfnlintrc.yaml
+++ b/.cfnlintrc.yaml
@@ -1,0 +1,9 @@
+ignore_checks: [E0000, E3012, E1001, W6001]
+ignore_templates:
+  - integration-tests/sceptre-project/config/**/*
+  - integration-tests/sceptre-project/templates/jinja/**/*
+  - tests/fixtures-vpc/config/**/*
+  - tests/fixtures/config/**/*
+  - .circleci/**/*
+  - .pre-commit-config.yaml
+  - .cfnlintrc.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.48.3
+    rev: v0.47.2
     hooks:
       - id: cfn-python-lint
         files: .*\.(json|yml|yaml)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.1
+    rev: 3.9.0
     hooks:
       - id: flake8
   - repo: https://github.com/adrienverge/yamllint
@@ -17,6 +17,8 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/awslabs/cfn-python-lint
+    # newer versions conflict with pre-commit
+    # https://github.com/aws-cloudformation/cfn-python-lint/issues/1427
     rev: v0.42.0
     hooks:
       - id: cfn-python-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,12 +8,15 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
-
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.0
+    rev: 3.9.1
     hooks:
       - id: flake8
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.26.1
     hooks:
       - id: yamllint
+  - repo: https://github.com/awslabs/cfn-python-lint
+    rev: v0.48.3
+    hooks:
+      - id: cfn-python-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,4 @@ repos:
     rev: v0.48.3
     hooks:
       - id: cfn-python-lint
+        files: .*\.(json|yml|yaml)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.47.2
+    rev: v0.48.3
     hooks:
       - id: cfn-python-lint
         files: .*\.(json|yml|yaml)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,6 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.48.3
+    rev: v0.42.0
     hooks:
       - id: cfn-python-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,4 +20,3 @@ repos:
     rev: v0.48.3
     hooks:
       - id: cfn-python-lint
-        files: .*\.(json|yml|yaml)$

--- a/integration-tests/sceptre-project/templates/valid_template_func.yaml
+++ b/integration-tests/sceptre-project/templates/valid_template_func.yaml
@@ -1,6 +1,6 @@
 Resources:
   WaitConditionHandle:
-    Type: "AWS:CloudFormation::WaitConditionHandle"
+    Type: "AWS::CloudFormation::WaitConditionHandle"
   WaitCondition:
     Type: "AWS::CloudFormation::WaitCondition"
     Properties:


### PR DESCRIPTION
Run cfn-lint[1] check with pre-ccommit to validate cloudformation
templates.

[1] https://github.com/aws-cloudformation/cfn-python-lint