### PR TITLE
Add info to configure Sceptre's API Access

### DIFF
--- a/docs/_source/docs/get_started.rst
+++ b/docs/_source/docs/get_started.rst
@@ -7,6 +7,16 @@ Install
 This tutorial assumes that you have installed Sceptre. Instructions on how to
 do this can be found in the section on :doc:`installing Sceptre <install>`.
 
+AWS CLI Config
+--------------
+
+Sceptre uses the same configuration files as the official AWS CLI and can be
+configured using the `aws configure` command. This command configures 2 files
+`~/.aws/config` and `~/.aws/credentials` to setup the API Keys to access your
+AWS Account.
+
+Reference: `AWS_CLI_Configure`_
+
 Directory Structure
 -------------------
 
@@ -185,3 +195,4 @@ reference to the CLI :doc:`in our CLI guide <cli>`
 
 
 .. _CloudFormation: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/Welcome.html
+.. _AWS_CLI_Configure: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html

--- a/docs/_source/docs/stack_group_config.rst
+++ b/docs/_source/docs/stack_group_config.rst
@@ -28,7 +28,10 @@ profile
 ~~~~~~~
 
 The name of the profile as defined in ``~/.aws/config`` and
-``~/.aws/credentials``.
+``~/.aws/credentials``. Use the `aws configure --profile <profile_id>` command
+form the AWS CLI to add profiles to these files.
+
+Reference: `AWS_CLI_Configure`_
 
 project_code
 ~~~~~~~~~~~~
@@ -261,3 +264,4 @@ Examples
 .. _template_key_prefix: #template_key_prefix
 .. _region which supports CloudFormation: http://docs.aws.amazon.com/general/latest/gr/rande.html#cfn_region
 .. _PEP 440: https://www.python.org/dev/peps/pep-0440/#version-specifiers
+.. _AWS_CLI_Configure: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html


### PR DESCRIPTION
The docs seem to imply that the user knows that Sceptre uses the same
configuration as the AWS CLI and thus does not provide details on how
to set it up for the first time.

This patch clarifies that by explicitly noting to use the AWS CLI to
configure the configuration files and links to the source docs.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
