### PR TITLE
GH template for sceptre issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,17 @@
+### Subject of the issue
+Describe your issue here.
+
+### Your environment
+* version of sceptre (sceptre --version)
+* version of python (python --version)
+* which OS/distro
+
+### Steps to reproduce
+Tell us how to reproduce this issue. Please provide sceptre projct files if possible,
+you can use https://plnkr.co/edit/ANFHm61Ilt4mQVgF as a base.
+
+### Expected behaviour
+Tell us what should happen
+
+### Actual behaviour
+Tell us what happens instead


### PR DESCRIPTION
Setup a github template[1] for sceptre issues to guide people reporting
issues to sceptrw.

[1] https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository
reporting issues to sceptr.e enter the commit message for your changes. Lines starting