### PR TITLE
Fix circleci tag workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,7 @@ workflows:
             branches:
               ignore: /^pull\/.*/
 
-  tag:
+  publish:
     jobs:
       - build:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,6 +286,13 @@ workflows:
 
   tag:
     jobs:
+      - deploy-pypi:
+          context: sceptre-core
+          filters:
+            tags:
+              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
+            branches:
+              ignore: /.*/
       - deploy-docs-tag:
           context: sceptre-core
           filters:
@@ -294,15 +301,6 @@ workflows:
             branches:
               ignore: /.*/
       - build-docker-image:
-          filters:
-            tags:
-              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
-            branches:
-              ignore: /.*/
-      - deploy-latest-dockerhub:
-          context: sceptre-core
-          requires:
-            - build-docker-image
           filters:
             tags:
               only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,8 +286,16 @@ workflows:
 
   tag:
     jobs:
+      - build:
+          filters:
+            tags:
+              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
+            branches:
+              ignore: /.*/
       - deploy-pypi:
           context: sceptre-core
+          requires:
+            - build
           filters:
             tags:
               only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
@@ -295,12 +303,16 @@ workflows:
               ignore: /.*/
       - deploy-docs-tag:
           context: sceptre-core
+          requires:
+            - deploy-pypi
           filters:
             tags:
               only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
             branches:
               ignore: /.*/
       - build-docker-image:
+          requires:
+            - deploy-pypi
           filters:
             tags:
               only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/


### PR DESCRIPTION
The tag workflow was not deploying to sceptre to pypi automatically.
Fix to automatically deploy sceptre to pypi automatically.  Also run
the correct targets to publish docs and docker image.