### PR TITLE
Fix pre-commit cfn-python-lint

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -1,8 +1,0 @@
-ignore_checks: [E0000, E3012, E1001, W6001]
-ignore_templates:
-  - integration-tests/sceptre-project/config/**/*
-  - integration-tests/sceptre-project/templates/jinja/**/*
-  - tests/fixtures-vpc/config/**/*
-  - tests/fixtures/config/**/*
-  - .circleci/**/*
-  - .pre-commit-config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ Session.vim
 tags
 # Persistent undo
 [._]*.un~
+
+# temp files
+temp/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,5 @@ repos:
             ^tests/fixtures/config/|
             ^temp/|
             ^.circleci/|
-            ^.cfnlintrc|
             ^.pre-commit-config.yaml
           )

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,8 +17,22 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/awslabs/cfn-python-lint
-    # newer versions conflict with pre-commit
-    # https://github.com/aws-cloudformation/cfn-python-lint/issues/1427
-    rev: v0.42.0
+    rev: v0.49.0
     hooks:
       - id: cfn-python-lint
+        args:
+          - "-i=E0000"
+          - "-i=E1001"
+          - "-i=E3012"
+          - "-i=W6001"
+        exclude: |
+          (?x)(
+            ^integration-tests/sceptre-project/config/|
+            ^integration-tests/sceptre-project/templates/jinja/|
+            ^tests/fixtures-vpc/config/|
+            ^tests/fixtures/config/|
+            ^temp/|
+            ^.circleci/|
+            ^.cfnlintrc|
+            ^.pre-commit-config.yaml
+          )


### PR DESCRIPTION
Passing in cfn-python-lint options with .cfnlintrc file doesn't seem to work
when used with pre-commit.  However passing options from the pre-commit
config file does work.  We change to pass in the options with the prec-commit
config file which will allow us to use the latest version of cfn-python-lint.