### PR TITLE
Remove duplicate install of twine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,6 @@ jobs:
           name: 'Upload Distributions'
           command: |
             . ./venv/bin/activate
-            pip install twine
             twine upload -u $PYPI_USERNAME -p $PYPI_PASSWORD dist/*
 
   deploy-latest-dockerhub:


### PR DESCRIPTION
Twine is already installed by `pip intall requirements/dev.txt"
therefore it doesn't need to be install again.