### PR TITLE
Remove Sceptre V1 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,18 +75,6 @@ If you have any other environment variables in your non-docker shell you will
 need to pass these in on the Docker CLI using the `-e` flag. See Docker
 documentation on how to achieve this.
 
-# Migrate v1 to v2
-
-We have tried to make the migration to Sceptre v2 as simple as possible. For
-information about how to migration your v1 project please see our
-[Migration Guide](https://github.com/sceptre/project/wiki/Migration-Guide:-V1-to-V2)
-
-# V1 End of Life Notice
-
-Support for Version 1 will
-[end on June 1 2019](https://github.com/sceptre/sceptre/issues/593). For new
-projects we recommend using Version 2.
-
 # Example
 
 Sceptre organises Stacks into "Stack Groups". Each Stack is represented by a


### PR DESCRIPTION
Sceptre V1 EOL was on 06/01/2019.  Remove docs for V1