### PR TITLE
Add new badges & clean up README structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Sceptre organises Stacks into "Stack Groups". Each Stack is represented by a
 YAML configuration file stored in a directory which represents the Stack Group.
 Here, we have two Stacks, `vpc` and `subnets`, in a Stack Group named `dev`:
 
-```
+```sh
 $ tree
 .
 ├── config
@@ -114,7 +114,7 @@ $ tree
 We can create a Stack with the `create` command. This `vpc` Stack contains a
 VPC.
 
-```
+```sh
 $ sceptre create dev/vpc.yaml
 
 dev/vpc - Creating stack dev/vpc
@@ -128,7 +128,7 @@ this, we need to pass the VPC ID, which is exposed as a Stack output of the
 `vpc` Stack, to a parameter of the `subnets` Stack. Sceptre automatically
 resolves this dependency for us.
 
-```
+```sh
 $ sceptre create dev/subnets.yaml
 dev/subnets - Creating stack
 dev/subnets Subnet AWS::EC2::Subnet CREATE_IN_PROGRESS
@@ -139,7 +139,7 @@ dev/subnets sceptre-demo-dev-subnets AWS::CloudFormation::Stack CREATE_COMPLETE
 Sceptre implements meta-operations, which allow us to find out information about
 our Stacks:
 
-```
+```sh
 $ sceptre list resources dev/subnets.yaml
 
 - LogicalResourceId: Subnet
@@ -153,7 +153,7 @@ Sceptre provides Stack Group level commands. This one deletes the whole `dev`
 Stack Group. The subnet exists within the vpc, so it must be deleted first.
 Sceptre handles this automatically:
 
-```
+```sh
 $ sceptre delete dev
 
 Deleting stack
@@ -171,7 +171,7 @@ dev/vpc - Stack deleted
 Sceptre can also handle cross Stack Group dependencies, take the following
 example project:
 
-```
+```sh
 $ tree
 .
 ├── config
@@ -210,7 +210,7 @@ Sceptre can be used from the CLI, or imported as a Python package.
 
 ## CLI
 
-```
+```sh
 Usage: sceptre [OPTIONS] COMMAND [ARGS]...
 
   Sceptre is a tool to manage your cloud native infrastructure deployments.
@@ -276,7 +276,7 @@ Full API reference documentation can be found in the
 ## Communication
 
 The Sceptre community uses a Slack channel #sceptre on the og-aws Slack for
-discussion. To join use this link http://slackhatesthe.cloud/ to create an
+discussion. To join use this link <http://slackhatesthe.cloud/> to create an
 account and join the #sceptre channel.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # Sceptre
 
-![image](https://circleci.com/gh/Sceptre/sceptre.png?style=shield)
-![image](https://badge.fury.io/py/sceptre.svg)
+[![CircleCI](https://img.shields.io/circleci/build/github/Sceptre/sceptre?logo=circleci)](https://app.circleci.com/pipelines/github/Sceptre)
+[![Docker Image Version (latest semver)](https://img.shields.io/docker/v/cloudreach/sceptre?logo=docker&sort=semver)](https://hub.docker.com/r/cloudreach/sceptre)
+[![PyPI](https://img.shields.io/pypi/v/sceptre?logo=pypi)](https://pypi.org/project/sceptre/)
+[![PyPI - Status](https://img.shields.io/pypi/status/sceptre?logo=pypi)](https://pypi.org/project/sceptre/)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/sceptre?logo=pypi)](https://pypi.org/project/sceptre/)
+[![PyPI - Downloads](https://img.shields.io/pypi/dm/sceptre?logo=pypi)](https://pypi.org/project/sceptre/)
+[![License](https://img.shields.io/pypi/l/sceptre?logo=apache)](https://github.com/Sceptre/sceptre/blob/main/LICENSE)
 
 # About
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/sceptre?logo=pypi)](https://pypi.org/project/sceptre/)
 [![License](https://img.shields.io/pypi/l/sceptre?logo=apache)](https://github.com/Sceptre/sceptre/blob/main/LICENSE)
 
-# About
+## About
 
 Sceptre is a tool to drive
 [AWS CloudFormation](https://aws.amazon.com/cloudformation). It automates the
 mundane, repetitive and error-prone tasks, enabling you to concentrate on
 building better infrastructure.
 
-# Features
+## Features
 
 - Code reuse by separating a Stack's template and its configuration
 - Support for templates written in JSON, YAML, Jinja2 or Python DSLs such as
@@ -33,7 +33,7 @@ building better infrastructure.
 - Support for inserting dynamic values in templates via customisable Resolvers
 - Support for running arbitrary code as Hooks before/after Stack builds
 
-# Benefits
+## Benefits
 
 - Utilises cloud-native Infrastructure as Code engines (CloudFormation)
 - You do not need to manage state
@@ -43,16 +43,16 @@ building better infrastructure.
 - Simple CLI and API
 - Unopinionated - Sceptre does not force a specific project structure
 
-# Install
+## Install
 
-## Using pip
+### Using pip
 
 `$ pip install sceptre`
 
 More information on installing sceptre can be found in our
 [Installation Guide](https://sceptre.cloudreach.com/latest/docs/install.html)
 
-## Using Docker Image
+### Using Docker Image
 
 View our [Docker repository](https://hub.docker.com/r/cloudreach/sceptre).
 Images available from version 2.0.0 onward.
@@ -80,19 +80,19 @@ If you have any other environment variables in your non-docker shell you will
 need to pass these in on the Docker CLI using the `-e` flag. See Docker
 documentation on how to achieve this.
 
-# Migrate v1 to v2
+## Migrate v1 to v2
 
 We have tried to make the migration to Sceptre v2 as simple as possible. For
 information about how to migration your v1 project please see our
 [Migration Guide](https://github.com/sceptre/project/wiki/Migration-Guide:-V1-to-V2)
 
-# V1 End of Life Notice
+## V1 End of Life Notice
 
 Support for Version 1 will
 [end on June 1 2019](https://github.com/sceptre/sceptre/issues/593). For new
 projects we recommend using Version 2.
 
-# Example
+## Example
 
 Sceptre organises Stacks into "Stack Groups". Each Stack is represented by a
 YAML configuration file stored in a directory which represents the Stack Group.


### PR DESCRIPTION
The main goal here was just to add some more informational badges to the README. Since we're not currently using any kind of "code quality" service, none of those are available right now. But those can easily be added in the future if that situation changes.

While I was in the README, I fixed the few `markdownlint` warnings that popped up. I debated on adding `markdownlint` to the `pre-commit` toolchain, but I hesitated as there is not an active project written in Python and I did not want to add another language to the build toolchain. If that is wanted however, we have the following options:

* [Run the canonical Ruby linter](https://github.com/markdownlint/markdownlint/blob/master/.pre-commit-hooks.yaml#L1-L6)
* [Run the canonical Ruby linter in Docker](https://github.com/markdownlint/markdownlint/blob/master/.pre-commit-hooks.yaml#L8-L13)
* [Run a Javascript linter](https://github.com/igorshubovych/markdownlint-cli/blob/master/.pre-commit-hooks.yaml)

## PR Checklist

- [X] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [X] All unit tests (`make test`) are passing.
- [X] Used the same coding conventions as the rest of the project.
- [X] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [X] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
