### PR TITLE
[Resolves #1032] Generate text output unnecessary padding

### DIFF
--- a/sceptre/cli/helpers.py
+++ b/sceptre/cli/helpers.py
@@ -135,7 +135,6 @@ def _generate_yaml(stream):
 
 
 def _generate_text(stream):
-    pad = 3
     if isinstance(stream, list):
         items = []
         for item in stream:
@@ -158,8 +157,9 @@ def _generate_text(stream):
         col_widths = [max(len(c) for c in b) for b in zip(*items)]
         rows = []
         for row in items:
-            rows.append(" ".join([field.ljust(width + pad)
-                                  for field, width in zip(row, cycle(col_widths))]))
+            rows.append("".join(
+                [field for field, width in zip(row, cycle(col_widths))]
+            ))
         return "\n".join(rows)
     return stream
 


### PR DESCRIPTION
When running `sceptre generate` the output has extra padding.
This seems to be the difference between:

    R    e    s    o    u    r    c    e    s    :
              S    a    m    A    p    p    :
                        T    y    p    e    :         A    W    S    :    :    S    e    r    v    e    r    l    e    s    s    :    :    A    p    p    l    i    c    a    t    i    o    n

and:

Resources:
  SamApp:
    Type: AWS::Serverless::Application

Signed-off-by: Thanh Ha <zxiiro@gmail.com>

[Your PR description here]

## PR Checklist

- [ ] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
