### PR TITLE
fix: Do not open a web browser during test

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -189,7 +189,8 @@ class TestCli(object):
         }
 
         args = ["estimate-cost", "dev/vpc.yaml"]
-        result = self.runner.invoke(cli, args)
+        with patch('webbrowser.open', return_value=None):  # Do not open a web browser
+            result = self.runner.invoke(cli, args)
 
         self.mock_stack_actions.estimate_cost.assert_called_with()
 


### PR DESCRIPTION
The cost estimate command opens a web browser as part of the command
call. This patch overrides that to prevent tests from actually starting
a real browser window while running tests.

Signed-off-by: Thanh Ha <zxiiro@gmail.com>

[Your PR description here]

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
