### PR TITLE
[Resolves #1042] Optimize Sceptre Start Time by only Processing Dependent Configuration Files

### DIFF
--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -230,12 +230,9 @@ class ConfigReader(object):
                 if not path.exists(full_dep):
                     raise DependencyDoesNotExistError(
                             "{stackname}: Dependency {dep} not found. "
-                            "Valid dependency names are: "
-                            "{stackkeys}. "
                             "Please make sure that your dependencies stack_outputs "
                             "have their full path from `config` defined."
-                            .format(stackname=stack.name, dep=dep,
-                                    stackkeys=", ".join(stack_map.keys())))
+                            .format(stackname=stack.name, dep=dep))
 
                 if full_dep not in full_todo and full_dep not in deps_todo:
                     todo.add(full_dep)

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -195,10 +195,7 @@ class ConfigReader(object):
         """
         stack_map = {}
         command_stacks = set()
-        if self.context.ignore_dependencies:
-            root = self.context.full_command_path()
-        else:
-            root = self.context.full_config_path()
+        root = self.context.full_command_path()
 
         if path.isfile(root):
             todo = {root}
@@ -212,6 +209,8 @@ class ConfigReader(object):
                     todo.add(path.join(directory_name, filename))
 
         stack_group_configs = {}
+        full_todo = todo.copy()
+        deps_todo = set()
 
         while todo:
             abs_path = todo.pop()
@@ -226,6 +225,22 @@ class ConfigReader(object):
                     self.read(path.join(directory, self.context.config_file))
 
             stack = self._construct_stack(rel_path, stack_group_config)
+            for dep in stack.dependencies:
+                full_dep = path.join(self.context.full_config_path(), dep)
+                if not path.exists(full_dep):
+                    raise DependencyDoesNotExistError(
+                            "{stackname}: Dependency {dep} not found. "
+                            "Valid dependency names are: "
+                            "{stackkeys}. "
+                            "Please make sure that your dependencies stack_outputs "
+                            "have their full path from `config` defined."
+                            .format(stackname=stack.name, dep=dep,
+                                    stackkeys=", ".join(stack_map.keys())))
+
+                if full_dep not in full_todo and full_dep not in deps_todo:
+                    todo.add(full_dep)
+                    deps_todo.add(full_dep)
+
             stack_map[sceptreise_path(rel_path)] = stack
 
             full_command_path = self.context.full_command_path()

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -299,25 +299,25 @@ class TestConfigReader(object):
         (
             "Abd",
             ["Abc/1.yaml", "Abd/1.yaml"],
-            {"Abd/1", "Abc/1"},
+            {"Abd/1"},
             {"Abd/1"}
         ),
         (
             "Abd",
             ["Abc/1.yaml", "Abd/Abc/1.yaml", "Abd/2.yaml"],
-            {"Abd/2", "Abd/Abc/1", "Abc/1"},
+            {"Abd/2", "Abd/Abc/1"},
             {"Abd/2", "Abd/Abc/1"}
         ),
         (
             "Abd/Abc",
             ["Abc/1.yaml", "Abd/Abc/1.yaml", "Abd/2.yaml"],
-            {"Abd/2", "Abd/Abc/1", "Abc/1"},
+            {"Abd/Abc/1"},
             {"Abd/Abc/1"}
         ),
         (
             "Ab",
             ["Abc/1.yaml", "Abd/1.yaml"],
-            {"Abd/1", "Abc/1"},
+            set(),
             set()
         )
     ])


### PR DESCRIPTION
Fix for: #1042 

This changes the `ConfigReader` to always use the `full_command_path` instead of using `full_config_path` then add the stack dependencies to the `todo` set to be processed.

## Evidences

I tested locally in my environment with over about 2,500 Sceptre configuration files.

**Current version:**
![image](https://user-images.githubusercontent.com/12723594/119000106-2f368300-b961-11eb-91c2-3d2824fc2dc1.png)


**Changed version:**
![image](https://user-images.githubusercontent.com/12723594/118999723-e7176080-b960-11eb-9167-5376aa811e11.png)

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
