### PR TITLE
[Resolve #1050] Update click version

### DIFF
--- a/docs/docs_requirements.txt
+++ b/docs/docs_requirements.txt
@@ -1,3 +1,4 @@
-sphinx>=1.8.2<2.0
-sphinx_click>=1.4.1<=3.0
-sphinx_rtd_theme==0.4.3
+Sphinx>=1.6.5,<5.0.0
+sphinx-click>=2.0.1,<4.0.0
+sphinx_rtd_theme==0.5.2
+docutils<0.17 # temporary fix for sphinx-rtd-theme==0.5.2, it depends on docutils<0.17

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,9 +14,10 @@ pytest-cov>=2.11.1,<3.0.0
 pytest-sugar>=0.9.4,<1.0.0
 readme-renderer>=24.0,<25.0
 setuptools>=40.6.2,<41.0.0
-Sphinx>=1.6.5,<2.0.0
-sphinx-click>=2.0.1,<3.0.0
-sphinx-rtd-theme==0.4.3
+Sphinx>=1.6.5,<5.0.0
+sphinx-click>=2.0.1,<4.0.0
+sphinx-rtd-theme==0.5.2
+docutils<0.17 # temporary fix for sphinx-rtd-theme==0.5.2, it depends on docutils<0.17
 tox>=3.23.0,<4.0.0
 troposphere>=2.0.0,<2.1.0
 twine>=1.12.1,<2.0.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,5 +1,5 @@
 boto3>=1.3.0,<2
-click>=7.0,<8.0
+click>=7.0,<9.0
 colorama>=0.2.5,<0.4.4
 Jinja2>=2.8,<3
 networkx>=2.4,<3

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def get_version(rel_path):
 
 install_requirements = [
     "boto3>=1.3,<2.0",
-    "click>=7.0,<8.0",
+    "click>=7.0,<9.0",
     "PyYaml>=5.1,<6.0",
     "Jinja2>=2.8,<3",
     "colorama>=0.3.9",


### PR DESCRIPTION
This PR adds click==8.0+ support 

To support click=>8.0 we needed to update Sphinx, sphinx-click 
and sphinx_rtd_theme libraties since sphinx-click depends on a specific version of click.


## PR Checklist

- [X] Wrote a good commit message & description [see guide below].
- [X] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [X] All unit tests (`make test`) are passing.
- [X] Used the same coding conventions as the rest of the project.
- [X] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [X] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
