### PR TITLE
Include the sceptre-resolver-cmd

### DIFF
--- a/docs/_source/docs/resolvers.rst
+++ b/docs/_source/docs/resolvers.rst
@@ -65,6 +65,11 @@ Example:
    sceptre_user_data:
      iam_policy: !file_contents /path/to/policy.json
 
+rcmd
+~~~~
+
+Refer to `sceptre-resolver-cmd <https://github.com/Sceptre/sceptre-resolver-cmd/>`_ for documentation.
+
 stack_output
 ~~~~~~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ install_requirements = [
     "Jinja2>=2.8,<3",
     "colorama>=0.3.9",
     "packaging>=16.8,<17.0",
-    "sceptre-file-resolver>=1.0.3,<2",
+    "sceptre-cmd-resolver>=1.1.3,<2",
     "six>=1.11.0,<2.0.0",
     "networkx>=2.4,<2.6"
 ]


### PR DESCRIPTION
This includes the sceptre-resolver-cmd
(https://github.com/Sceptre/sceptre-resolver-cmd) into Sceptre as
a core resolver.

Signed-off-by: Thanh Ha <zxiiro@gmail.com>

depends on https://github.com/Sceptre/sceptre-resolver-cmd/pull/5
