### PR TITLE
Use get_stack_by_name() instead of get_stack()

### DIFF
--- a/docs/_source/docs/templates.rst
+++ b/docs/_source/docs/templates.rst
@@ -215,7 +215,7 @@ This example generates a cloudformation template from `AWS CDK`_ code.
   def sceptre_handler(sceptre_user_data):
       app = cdk.App()
       S3CdkStack(app, "S3CdkStack", sceptre_user_data)
-      template = app.synth().get_stack("S3CdkStack").template
+      template = app.synth().get_stack_by_name("S3CdkStack").template
       return yaml.safe_dump(template)
 
 .. _AWS_CDK: https://github.com/aws/aws-cdk


### PR DESCRIPTION
According to CDK documentation the get_stack() API is deprecated and
they recommend switching to get_stack_by_name() instead.

Ref: https://docs.aws.amazon.com/cdk/api/latest/python/aws_cdk.cx_api/CloudAssembly.html#aws_cdk.cx_api.CloudAssembly.get_stack
Signed-off-by: Thanh Ha <zxiiro@gmail.com>

## PR Checklist

- [ ] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
