### PR TITLE
[Resolves  #961]: Hook.stack is not necessarily the stack actually being updated

### DIFF
--- a/docs/_source/docs/hooks.rst
+++ b/docs/_source/docs/hooks.rst
@@ -116,10 +116,10 @@ integrate additional functionality into Sceptre projects.
 A hook is a Python class which inherits from abstract base class ``Hook`` found
 in the ``sceptre.hooks module``.
 
-Hooks are require to implement a ``run()`` function that takes no parameters
-and to call the base class initializer.
+Hooks are require to implement a ``run(stack)`` function that takes a single parameter
+``stack`` and to call the base class initializer.
 
-Hooks may have access to ``argument``, and ``stack`` as object attributes. For example ``self.stack``.
+Hooks may have access to the ``argument`` object attribute. For example ``self.argument``.
 
 Sceptre uses the ``sceptre.hooks`` entry point to locate hook classes. Your
 custom hook can be written anywhere and is installed as Python package.
@@ -152,26 +152,28 @@ custom_hook.py
         argument: str
             The argument is available from the base class and contains the
             argument defined in the Sceptre config file (see below)
-        stack: sceptre.stack.Stack
-             The associated stack of the hook.
-        connection_manager: sceptre.connection_manager.ConnectionManager
-            Boto3 Connection Manager - can be used to call boto3 api.
 
         """
         def __init__(self, *args, **kwargs):
             super(CustomHook, self).__init__(*args, **kwargs)
 
-        def run(self):
+        def run(self, stack):
             """
             run is the method called by Sceptre. It should carry out the work
             intended by this hook.
+
+            Parameters
+            ----------
+            stack: sceptre.stack.Stack
+                The associated stack of the hook.
+            stack.connection_manager: sceptre.connection_manager.ConnectionManager
+                Boto3 Connection Manager - can be used to call boto3 api.
 
             To use instance attribute self.<attribute_name>.
 
             Examples
             --------
             self.argument
-            self.stack_config
 
             """
             print(self.argument)

--- a/sceptre/hooks/cmd.py
+++ b/sceptre/hooks/cmd.py
@@ -11,7 +11,7 @@ class Cmd(Hook):
     def __init__(self, *args, **kwargs):
         super(Cmd, self).__init__(*args, **kwargs)
 
-    def run(self):
+    def run(self, stack):
         """
         Runs the argument string in a subprocess.
 

--- a/tests/test_hooks/test_cmd.py
+++ b/tests/test_hooks/test_cmd.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 
-import pytest
-from mock import patch
 import subprocess
 
-from sceptre.hooks.cmd import Cmd
+import pytest
+from mock import patch
+
 from sceptre.exceptions import InvalidHookArgumentTypeError
+from sceptre.hooks.cmd import Cmd
 
 
 class TestCmd(object):
@@ -15,12 +16,12 @@ class TestCmd(object):
     def test_run_with_non_str_argument(self):
         self.cmd.argument = None
         with pytest.raises(InvalidHookArgumentTypeError):
-            self.cmd.run()
+            self.cmd.run(None)
 
     @patch('sceptre.hooks.cmd.subprocess.check_call')
     def test_run_with_str_argument(self, mock_call):
         self.cmd.argument = u"echo hello"
-        self.cmd.run()
+        self.cmd.run(None)
         mock_call.assert_called_once_with(u"echo hello", shell=True)
 
     @patch('sceptre.hooks.cmd.subprocess.check_call')
@@ -28,4 +29,4 @@ class TestCmd(object):
         mock_call.side_effect = subprocess.CalledProcessError(1, "echo")
         self.cmd.argument = u"echo hello"
         with pytest.raises(subprocess.CalledProcessError):
-            self.cmd.run()
+            self.cmd.run(None)

--- a/tests/test_hooks/test_hooks.py
+++ b/tests/test_hooks/test_hooks.py
@@ -52,14 +52,14 @@ class TestHooksFunctions(object):
     def test_execute_hooks_with_single_hook(self):
         hook = MagicMock(spec=Hook)
         execute_hooks([hook], self.stack)
-        hook.run.called_once_with()
+        hook.run.assert_called_once_with(self.stack)
 
     def test_execute_hooks_with_multiple_hook(self):
         hook_1 = MagicMock(spec=Hook)
         hook_2 = MagicMock(spec=Hook)
         execute_hooks([hook_1, hook_2], self.stack)
-        hook_1.run.called_once_with()
-        hook_2.run.called_once_with()
+        hook_1.run.assert_called_once_with(self.stack)
+        hook_2.run.assert_called_once_with(self.stack)
 
 
 class TestHook(object):
@@ -91,15 +91,7 @@ class TestHookPropertyDescriptor(object):
         assert self.mock_object.hook_property == self.mock_object
 
 
-class MultipleHook(Hook):
-    def __init__(self, *args, **kwargs):
-        super(MultipleHook, self).__init__(*args, **kwargs)
-
-    def run(self, stack):
-        pass
-
-
-class TestHooksMultipleConfig(object):
+class TestHooksMultipleStacks(object):
     def setup_method(self, test_method):
         pass
 
@@ -110,8 +102,8 @@ class TestHooksMultipleConfig(object):
         sub_stack_two = MagicMock(spec=StackActions)
         sub_stack_two.stack = MagicMock(spec=Stack)
         sub_stack_two.name = 'sub_stack_two'
-        hook_before = MagicMock(MultipleHook)
-        hook_after = MagicMock(MultipleHook)
+        hook_before = MagicMock(MockHook)
+        hook_after = MagicMock(MockHook)
 
         sub_stack_one.stack.hooks = sub_stack_two.stack.hooks = {
             'before_mock_function': [hook_before],

--- a/tests/test_hooks/test_hooks.py
+++ b/tests/test_hooks/test_hooks.py
@@ -2,6 +2,8 @@
 from mock import MagicMock
 
 from sceptre.hooks import Hook, HookProperty, add_stack_hooks, execute_hooks
+from sceptre.plan.actions import StackActions
+from sceptre.stack import Stack
 
 
 class MockHook(Hook):
@@ -14,7 +16,7 @@ class MockHook(Hook):
 
 class TestHooksFunctions(object):
     def setup_method(self, test_method):
-        pass
+        self.stack = MagicMock(spec=Stack)
 
     def test_add_stack_hooks(self):
         mock_hook_before = MagicMock(spec=Hook)
@@ -39,23 +41,23 @@ class TestHooksFunctions(object):
         assert mock_hook_after.run.call_count == 1
 
     def test_execute_hooks_with_not_a_list(self):
-        execute_hooks(None)
+        execute_hooks(None, self.stack)
 
     def test_execute_hooks_with_empty_list(self):
-        execute_hooks([])
+        execute_hooks([], self.stack)
 
     def test_execute_hooks_with_list_with_non_hook_objects(self):
-        execute_hooks([None, "string", 1, True])
+        execute_hooks([None, "string", 1, True], self.stack)
 
     def test_execute_hooks_with_single_hook(self):
         hook = MagicMock(spec=Hook)
-        execute_hooks([hook])
+        execute_hooks([hook], self.stack)
         hook.run.called_once_with()
 
     def test_execute_hooks_with_multiple_hook(self):
         hook_1 = MagicMock(spec=Hook)
         hook_2 = MagicMock(spec=Hook)
-        execute_hooks([hook_1, hook_2])
+        execute_hooks([hook_1, hook_2], self.stack)
         hook_1.run.called_once_with()
         hook_2.run.called_once_with()
 
@@ -87,3 +89,45 @@ class TestHookPropertyDescriptor(object):
     def test_getting_hook_property(self):
         self.mock_object._hook_property = self.mock_object
         assert self.mock_object.hook_property == self.mock_object
+
+
+class MultipleHook(Hook):
+    def __init__(self, *args, **kwargs):
+        super(MultipleHook, self).__init__(*args, **kwargs)
+
+    def run(self, stack):
+        pass
+
+
+class TestHooksMultipleConfig(object):
+    def setup_method(self, test_method):
+        pass
+
+    def test_add_stack_hooks(self):
+        sub_stack_one = MagicMock(spec=StackActions)
+        sub_stack_one.stack = MagicMock(spec=Stack)
+        sub_stack_one.name = 'sub_stack_one'
+        sub_stack_two = MagicMock(spec=StackActions)
+        sub_stack_two.stack = MagicMock(spec=Stack)
+        sub_stack_two.name = 'sub_stack_two'
+        hook_before = MagicMock(MultipleHook)
+        hook_after = MagicMock(MultipleHook)
+
+        sub_stack_one.stack.hooks = sub_stack_two.stack.hooks = {
+            'before_mock_function': [hook_before],
+            'after_mock_function': [hook_after]
+        }
+
+        def mock_function(self):
+            pass
+
+        sub_stack_one.mock_function = sub_stack_two.mock_function = mock_function
+        sub_stack_one.mock_function.__name__ = sub_stack_two.mock_function.__name__ = 'mock_function'
+
+        add_stack_hooks(sub_stack_one.mock_function)(sub_stack_one)
+        hook_before.run.assert_called_with(sub_stack_one.stack)
+        hook_after.run.assert_called_with(sub_stack_one.stack)
+
+        add_stack_hooks(sub_stack_two.mock_function)(sub_stack_two)
+        hook_before.run.assert_called_with(sub_stack_two.stack)
+        hook_after.run.assert_called_with(sub_stack_two.stack)


### PR DESCRIPTION
[Resolves #961]: Hook.stack is not necessarily the stack actually being updated.

Please note this request introduces a breaking change for custom Hooks. `Hook.stack` has been removed. `Hook.run` now accepts a single parameter `stack`.

## PR Checklist

- [ X ] Wrote a good commit message & description [see guide below].
- [ X ] Commit message starts with `[Resolve #issue-number]`.
- [ X ] Added/Updated unit tests.
- [ NA ] Added/Updated integration tests (if applicable).
- [ X ] All unit tests (`make test`) are passing.
- [ X ] Used the same coding conventions as the rest of the project.
- [ X ] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [ X ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
