### PR TITLE
merge stack_group_config to sceptre_user_data if sceptre_user_data told to

### DIFF
--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -512,7 +512,7 @@ class ConfigReader(object):
             iam_role=config.get("iam_role"),
             profile=config.get("profile"),
             parameters=config.get("parameters", {}),
-            sceptre_user_data=config.get("sceptre_user_data", {}),
+            sceptre_user_data=self._parsed_sceptre_user_data(config, parsed_stack_group_config),
             hooks=config.get("hooks", {}),
             s3_details=s3_details,
             dependencies=config.get("dependencies", []),
@@ -528,6 +528,22 @@ class ConfigReader(object):
 
         del self.templating_vars["stack_group_config"]
         return stack
+    
+    def _parsed_sceptre_user_data(self, config, stack_group_config):
+        """
+        merge `stack_group_config` if `sceptre_user_data` has `merge_config` set True 
+        """
+        sceptre_user_data = config.get("sceptre_user_data", {})
+
+        # ensure sceptre_user_data update the config
+        if sceptre_user_data.get("merge_config") is True:
+            tmp = copy.deepcopy(stack_group_config)
+            tmp.update({'region': config["region"]})
+            tmp.update({'profile': config.get("profile")})
+            tmp.update(sceptre_user_data)
+            sceptre_user_data = tmp
+        
+        return sceptre_user_data
 
     def _parsed_stack_group_config(self, stack_group_config):
         """


### PR DESCRIPTION
This pr is for issues like #604 and #583, sometimes we need to access properties in `stack_conifg` eg: `region` or `profile` or need to add to project scope shared configs

1. If `sceptre_user_data` config the `merge_config` as True, ensure `sceptre_user_data` access the `stack_config` and overwrite the `stack_config` properites
2. if no `merge_config` in sceptre_user_data or as False, ensure on regression

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x ] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [x ] Before merge squash related commits.

