### PR TITLE
[Resolves #1042] Fix Dependency Path Resolution

### DIFF
--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -14,6 +14,7 @@ import fnmatch
 import logging
 from os import environ, path, walk
 from pkg_resources import iter_entry_points
+from pathlib import Path
 import yaml
 
 from jinja2 import Environment
@@ -226,7 +227,7 @@ class ConfigReader(object):
 
             stack = self._construct_stack(rel_path, stack_group_config)
             for dep in stack.dependencies:
-                full_dep = path.join(self.context.full_config_path(), dep)
+                full_dep = str(Path(self.context.full_config_path(), dep))
                 if not path.exists(full_dep):
                     raise DependencyDoesNotExistError(
                             "{stackname}: Dependency {dep} not found. "


### PR DESCRIPTION
I raised PR https://github.com/Sceptre/sceptre/pull/1043 one month ago and my team and I have been testing this change internally since then. We have found a bug related to that change in the Windows environment.

## Issue Log

```text
Do you want to launch 'dev/randc/spa' [y/N]: y
Traceback (most recent call last):
  File "c:\users\heathes\appdata\local\programs\python\python38\lib\runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "c:\users\heathes\appdata\local\programs\python\python38\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Users\HEATHES\.local\bin\sceptre.exe\__main__.py", line 7, in <module>
  File "c:\users\heathes\.local\pipx\venvs\sceptre\lib\site-packages\click\core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "c:\users\heathes\.local\pipx\venvs\sceptre\lib\site-packages\click\core.py", line 782, in main
    rv = self.invoke(ctx)
  File "c:\users\heathes\.local\pipx\venvs\sceptre\lib\site-packages\click\core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "c:\users\heathes\.local\pipx\venvs\sceptre\lib\site-packages\click\core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "c:\users\heathes\.local\pipx\venvs\sceptre\lib\site-packages\click\core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "c:\users\heathes\.local\pipx\venvs\sceptre\lib\site-packages\click\decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "c:\users\heathes\.local\pipx\venvs\sceptre\lib\site-packages\sceptre\cli\helpers.py", line 37, in decorated
    return func(*args, **kwargs)
  File "c:\users\heathes\.local\pipx\venvs\sceptre\lib\site-packages\sceptre\cli\launch.py", line 38, in launch_command
    responses = plan.launch()
  File "c:\users\heathes\.local\pipx\venvs\sceptre\lib\site-packages\sceptre\plan\plan.py", line 129, in launch
    self.resolve(command=self.launch.__name__)
  File "c:\users\heathes\.local\pipx\venvs\sceptre\lib\site-packages\sceptre\plan\plan.py", line 75, in resolve
    self.launch_order = self._generate_launch_order(reverse)
  File "c:\users\heathes\.local\pipx\venvs\sceptre\lib\site-packages\sceptre\plan\plan.py", line 46, in _generate_launch_order
    graph = self.graph.filtered(self.command_stacks, reverse)
  File "c:\users\heathes\.local\pipx\venvs\sceptre\lib\site-packages\sceptre\config\graph.py", line 44, in filtered
    relevant |= nx.algorithms.dag.ancestors(graph, stack)
  File "c:\users\heathes\.local\pipx\venvs\sceptre\lib\site-packages\networkx\algorithms\dag.py", line 78, in ancestors
    if not G.has_node(source):
  File "c:\users\heathes\.local\pipx\venvs\sceptre\lib\site-packages\networkx\classes\graph.py", line 816, in has_node
    return n in self._node
  File "c:\users\heathes\.local\pipx\venvs\sceptre\lib\site-packages\sceptre\stack.py", line 219, in __eq__
    self.parameters == stack.parameters and
  File "c:\users\heathes\.local\pipx\venvs\sceptre\lib\site-packages\sceptre\resolvers\__init__.py", line 87, in __get__
    retval = _call_func_on_values(
  File "c:\users\heathes\.local\pipx\venvs\sceptre\lib\site-packages\sceptre\helpers.py", line 63, in _call_func_on_values
    func_on_instance(key)
  File "c:\users\heathes\.local\pipx\venvs\sceptre\lib\site-packages\sceptre\helpers.py", line 57, in func_on_instance
    func(attr, key, value)
  File "c:\users\heathes\.local\pipx\venvs\sceptre\lib\site-packages\sceptre\resolvers\__init__.py", line 81, in resolve
    attr[key] = value.resolve()
  File "c:\users\heathes\.local\pipx\venvs\sceptre\lib\site-packages\sceptre\resolvers\stack_output.py", line 127, in resolve
    stack = next(
  File "c:\users\heathes\.local\pipx\venvs\sceptre\lib\site-packages\sceptre\resolvers\stack_output.py", line 128, in <genexpr>
    stack for stack in self.stack.dependencies if stack.name == friendly_stack_name
AttributeError: 'str' object has no attribute 'name'
```

I have investigated the cause of the issue and it is as follows:
- The change `full_dep = path.join(self.context.full_config_path(), dep)` has different values depending on the operating system.
(e.g Linux/Mac `/user/lucas/project/config/dev/dns.yaml` and Windows `c:\user\lucas\project\config/dev/dns.yaml`)
That difference influences this logic: 
```python
if full_dep not in full_todo and full_dep not in deps_todo:
        todo.add(full_dep)
        deps_todo.add(full_dep)
```
Because the `command_path` stacks in the `todo` set has the OS path resolved, so `c:\user\lucas\project\config\dev\dns.yaml`

## Solution

Use the `pathlib.Path` package to convert the whole path to the OS standard before comparing and adding to the `todo` set.

The result:

- Linux/Mac: `/user/lucas/project/config/dev/dns.yaml`
- Windows: `c:\user\lucas\project\config\dev\dns.yaml`

Making the paths standard based on the operational system.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
