### PR TITLE
[Resolves #1064] Add feature list change-set --url

### DIFF
--- a/sceptre/cli/list.py
+++ b/sceptre/cli/list.py
@@ -93,16 +93,21 @@ def list_outputs(ctx, path, export):
 
 
 @list_group.command(name="change-sets")
+@click.option(
+    "-U", "--url", is_flag=True, help="Instead write a URL."
+)
 @click.argument("path")
 @click.pass_context
 @catch_exceptions
-def list_change_sets(ctx, path):
+def list_change_sets(ctx, path, url):
     """
     List change sets for stack.
     \f
 
     :param path: Path to execute the command on.
     :type path: str
+    :param url: Write out a console URL instead.
+    :type url: bool
     """
     context = SceptreContext(
         command_path=path,
@@ -114,9 +119,10 @@ def list_change_sets(ctx, path):
     )
 
     plan = SceptrePlan(context)
+
     responses = [
         response for response
-        in plan.list_change_sets().values() if response
+        in plan.list_change_sets(url).values() if response
     ]
 
     for response in responses:

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -574,7 +574,6 @@ class StackActions(object):
                     "StackName": self.stack.external_name
                 }
             )
-
             summaries = response.get("Summaries", [])
             if url:
                 summaries = self._convert_to_url(summaries)
@@ -589,21 +588,24 @@ class StackActions(object):
         Convert the list_change_sets response from
         CloudFormation to a URL in the AWS Console.
         """
-        ref = summaries[0]
+        new_summaries = []
 
-        stack_id = ref["StackId"]
-        change_set_id = ref["ChangeSetId"]
+        for summary in summaries:
+            stack_id = summary["StackId"]
+            change_set_id = summary["ChangeSetId"]
 
-        return (
-            "https://{0}.console.aws.amazon.com/cloudformation/home?"
-            "region={0}#/stacks/changesets/changes?{1}".format(
-                self.stack.region,
-                urllib.parse.urlencode({
-                    "stackId": stack_id,
-                    "changeSetId": change_set_id
-                })
+            region = self.stack.region
+            encoded = urllib.parse.urlencode({
+                "stackId": stack_id,
+                "changeSetId": change_set_id
+            })
+
+            new_summaries.append(
+                f"https://{region}.console.aws.amazon.com/cloudformation/home?"
+                f"region={region}#/stacks/changesets/changes?{encoded}"
             )
-        )
+
+        return new_summaries
 
     @add_stack_hooks
     def generate(self):

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -565,21 +565,25 @@ class StackActions(object):
         :returns: The Stack's Change Sets.
         :rtype: dict or list
         """
+        response = self._list_change_sets()
+        summaries = response.get("Summaries", [])
+        #import ipdb; ipdb.set_trace()
+
+        if url:
+            summaries = self._convert_to_url(summaries)
+
+        return {self.stack.name: summaries}
+
+    def _list_change_sets(self):
         self.logger.debug("%s - Listing change sets", self.stack.name)
         try:
-            response = self.connection_manager.call(
+            return self.connection_manager.call(
                 service="cloudformation",
                 command="list_change_sets",
                 kwargs={
                     "StackName": self.stack.external_name
                 }
             )
-            summaries = response.get("Summaries", [])
-            if url:
-                summaries = self._convert_to_url(summaries)
-
-            return {self.stack.name: summaries}
-
         except botocore.exceptions.ClientError:
             return []
 

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -567,7 +567,6 @@ class StackActions(object):
         """
         response = self._list_change_sets()
         summaries = response.get("Summaries", [])
-        #import ipdb; ipdb.set_trace()
 
         if url:
             summaries = self._convert_to_url(summaries)

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -690,21 +690,27 @@ class TestStackActions(object):
         self, mock_call, mock_urlencode
     ):
         mock_call.return_value = {
-            "Summaries": [{
-                "ChangeSetId": "mychangesetid",
-                "StackId": "mystackid"
-            }]
+            "Summaries": [
+                {
+                    "ChangeSetId": "mychangesetid1",
+                    "StackId": "mystackid1"
+                },
+                {
+                    "ChangeSetId": "mychangesetid2",
+                    "StackId": "mystackid2"
+                }
+            ]
         }
-        urlencoded = "stackId=mystackid&changeSetId=mychangesetid"
-        mock_urlencode.return_value = urlencoded
+        encoded = "stackId=mystackid&changeSetId=mychangesetid"
+        mock_urlencode.return_value = encoded
 
         expected_url = (
             "https://sentinel.region.console.aws.amazon.com/cloudformation/home?"
-            f"region=sentinel.region#/stacks/changesets/changes?{urlencoded}"
+            f"region=sentinel.region#/stacks/changesets/changes?{encoded}"
         )
 
         response = self.actions.list_change_sets(url=True)
-        assert response == {"prod/app/stack": expected_url}
+        assert response == {"prod/app/stack": [expected_url]}
 
     @patch("sceptre.plan.actions.StackActions.set_policy")
     @patch("os.path.join")

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -714,12 +714,10 @@ class TestStackActions(object):
         expected_urls = []
 
         for num in ["1", "2"]:
-            mock_list_change_sets_return_value["Summaries"].append(
-                {
-                    "ChangeSetId": "mychangesetid{num}",
-                    "StackId": "mystackid{num}"
-                }
-            )
+            mock_list_change_sets_return_value["Summaries"].append({
+                "ChangeSetId": "mychangesetid{num}",
+                "StackId": "mystackid{num}"
+            })
             urlencoded = "stackId=mystackid{num}&changeSetId=mychangesetid{num}"
             mock_urlencode_side_effect.append(urlencoded)
             expected_urls.append(

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -684,33 +684,63 @@ class TestStackActions(object):
             kwargs={"StackName": sentinel.external_name}
         )
 
-    @patch("sceptre.plan.actions.urllib.parse.urlencode")
-    @patch("sceptre.plan.actions.ConnectionManager.connection_manager.call")
-    def test_list_change_sets_url_mode(
-        self, mock_call, mock_urlencode
+    @patch("sceptre.plan.actions.StackActions._list_change_sets")
+    def test_list_change_sets(
+        self, mock_list_change_sets
     ):
-        mock_call.return_value = {
-            "Summaries": [
-                {
-                    "ChangeSetId": "mychangesetid1",
-                    "StackId": "mystackid1"
-                },
-                {
-                    "ChangeSetId": "mychangesetid2",
-                    "StackId": "mystackid2"
-                }
-            ]
-        }
-        encoded = "stackId=mystackid&changeSetId=mychangesetid"
-        mock_urlencode.return_value = encoded
+        mock_list_change_sets_return_value = {"Summaries": []}
+        expected_responses = []
 
-        expected_url = (
-            "https://sentinel.region.console.aws.amazon.com/cloudformation/home?"
-            f"region=sentinel.region#/stacks/changesets/changes?{encoded}"
-        )
+        for num in ["1", "2"]:
+            response = [{
+                "ChangeSetId": "mychangesetid{num}",
+                "StackId": "mystackid{num}"
+            }]
+            mock_list_change_sets_return_value["Summaries"].append(response)
+            expected_responses.append(response)
+
+        mock_list_change_sets.return_value = mock_list_change_sets_return_value
+
+        response = self.actions.list_change_sets(url=False)
+        assert response == {"prod/app/stack": expected_responses}
+
+    @patch("sceptre.plan.actions.urllib.parse.urlencode")
+    @patch("sceptre.plan.actions.StackActions._list_change_sets")
+    def test_list_change_sets_url_mode(
+        self, mock_list_change_sets, mock_urlencode
+    ):
+        mock_list_change_sets_return_value = {"Summaries": []}
+        mock_urlencode_side_effect = []
+        expected_urls = []
+
+        for num in ["1", "2"]:
+            mock_list_change_sets_return_value["Summaries"].append(
+                {
+                    "ChangeSetId": "mychangesetid{num}",
+                    "StackId": "mystackid{num}"
+                }
+            )
+            urlencoded = "stackId=mystackid{num}&changeSetId=mychangesetid{num}"
+            mock_urlencode_side_effect.append(urlencoded)
+            expected_urls.append(
+                "https://sentinel.region.console.aws.amazon.com/cloudformation/home?"
+                f"region=sentinel.region#/stacks/changesets/changes?{urlencoded}"
+            )
+
+        mock_list_change_sets.return_value = mock_list_change_sets_return_value
+        mock_urlencode.side_effect = mock_urlencode_side_effect
 
         response = self.actions.list_change_sets(url=True)
-        assert response == {"prod/app/stack": [expected_url]}
+        assert response == {"prod/app/stack": expected_urls}
+
+    @pytest.mark.parametrize("url_mode", [True, False])
+    @patch("sceptre.plan.actions.StackActions._list_change_sets")
+    def test_list_change_sets_empty(
+        self, mock_list_change_sets, url_mode
+    ):
+        mock_list_change_sets.return_value = {"Summaries": []}
+        response = self.actions.list_change_sets(url=url_mode)
+        assert response == {"prod/app/stack": []}
 
     @patch("sceptre.plan.actions.StackActions.set_policy")
     @patch("os.path.join")

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -684,6 +684,28 @@ class TestStackActions(object):
             kwargs={"StackName": sentinel.external_name}
         )
 
+    @patch("sceptre.plan.actions.urllib.parse.urlencode")
+    @patch("sceptre.plan.actions.ConnectionManager.connection_manager.call")
+    def test_list_change_sets_url_mode(
+        self, mock_call, mock_urlencode
+    ):
+        mock_call.return_value = {
+            "Summaries": [{
+                "ChangeSetId": "mychangesetid",
+                "StackId": "mystackid"
+            }]
+        }
+        urlencoded = "stackId=mystackid&changeSetId=mychangesetid"
+        mock_urlencode.return_value = urlencoded
+
+        expected_url = (
+            "https://sentinel.region.console.aws.amazon.com/cloudformation/home?"
+            f"region=sentinel.region#/stacks/changesets/changes?{urlencoded}"
+        )
+
+        response = self.actions.list_change_sets(url=True)
+        assert response == {"prod/app/stack": expected_url}
+
     @patch("sceptre.plan.actions.StackActions.set_policy")
     @patch("os.path.join")
     def test_lock_calls_set_stack_policy_with_policy(


### PR DESCRIPTION
This adds feature list change-sets -U, --url. This boolean flag if
passed causes the output of list change-sets to display a URL to the AWS
Console for that change-set rather than the change-set details
themselves as a convenience.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
