### PR TITLE
Update cfn-lint to v0.52.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.49.0
+    rev: v0.52.0
     hooks:
       - id: cfn-python-lint
         args:


### PR DESCRIPTION
This resolves "ImportError: cannot import name 'networkx' from 'networkx'"
seen when running the linter.

Signed-off-by: Thanh Ha <zxiiro@gmail.com>

[Your PR description here]

## PR Checklist

- [ ] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
