### PR TITLE
[Resolves #1072] replace setup.py with pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ RUN apk add --no-cache bash
 WORKDIR /app
 COPY setup.cfg setup.py README.md CHANGELOG.md ./
 COPY sceptre/ ./sceptre
-RUN python setup.py install
+RUN pip install .
 WORKDIR /project
 ENTRYPOINT ["sceptre"]


### PR DESCRIPTION
Sceptre ver 2.6.1 introduced the sceptre-cmd-resolver as a core resolver
however it looks like the setup.py command to install sceptre in the
dockerfile does not seem to install that dependency.

The pip command will install sceptre with dependencies so we switch to
install sceptre with pip.