### PR TITLE
[Resolve #966] Add support for J2 Environment configuration

### DIFF
--- a/docs/_source/docs/faq.rst
+++ b/docs/_source/docs/faq.rst
@@ -100,32 +100,32 @@ SAM or CFN "package" command to generate the packaged version of the template.
 
 CloudFormation Example:
 
-```yaml
-template_path: generated/lambda-packaged.json
-stack_name: cfn-lambda-example
-hooks:
-  before_launch:
-    - !cmd >
-        aws --profile {{ stack_group_config.profile }} cloudformation package
-        --template-file templates/cfn-lambda.yaml
-        --s3-bucket {{ stack_group_config.template_bucket_name }}
-        --output json
-        --output-template-file templates/generated/lambda-packaged.json
-```
+.. code-block:: yaml
+
+  template_path: generated/lambda-packaged.json
+  stack_name: cfn-lambda-example
+  hooks:
+    before_launch:
+      - !cmd >
+          aws --profile {{ stack_group_config.profile }} cloudformation package
+          --template-file templates/cfn-lambda.yaml
+          --s3-bucket {{ stack_group_config.template_bucket_name }}
+          --output json
+          --output-template-file templates/generated/lambda-packaged.json
 
 SAM Example:
 
-```yaml
-template_path: generated/sam-packaged.yaml
-stack_name: sam-example
-hooks:
-  before_launch:
-    - !cmd >
-        sam package --profile {{ stack_group_config.profile }}
-        --s3-bucket {{ stack_group_config.template_bucket_name }}
-        --template-file templates/sam-app.yaml
-        --output-template-file templates/generated/sam-packaged.yaml
-```
+.. code-block:: yaml
+
+  template_path: generated/sam-packaged.yaml
+  stack_name: sam-example
+  hooks:
+    before_launch:
+      - !cmd >
+          sam package --profile {{ stack_group_config.profile }}
+          --s3-bucket {{ stack_group_config.template_bucket_name }}
+          --template-file templates/sam-app.yaml
+          --output-template-file templates/generated/sam-packaged.yaml
 
 .. _SAM CLI: https://github.com/aws/aws-sam-cli
 .. _Sage-Bionetworks Sceptre lambda github template: https://github.com/Sage-Bionetworks-IT/lambda-template

--- a/docs/_source/docs/stack_group_config.rst
+++ b/docs/_source/docs/stack_group_config.rst
@@ -19,6 +19,7 @@ Sceptre. The available keys are listed below.
 -  `required_version`_ *(optional)*
 -  `template_bucket_name`_ *(optional)*
 -  `template_key_prefix`_ *(optional)*
+-  `j2_environment`_ *(optional)*
 
 Sceptre will only check for and uses the above keys in StackGroup config files
 and are directly accessible from Stack(). Any other keys added by the user are
@@ -73,6 +74,19 @@ Extension can be ``json`` or ``yaml``.
 
 Note that if ``template_bucket_name`` is not supplied, this parameter is
 ignored.
+
+j2_environment
+~~~~~~~~~~~~~~~~~~~
+
+A dictionary that is combined with the default jinja2 environment.
+It's converted to keyword arguments then passed to [jinja2.Environment](https://jinja.palletsprojects.com/en/2.11.x/api/#jinja2.Environment).
+
+```yaml
+j2_environment:
+  extensions:
+    - jinja2.ext.i18n
+    - jinja2.ext.do
+```
 
 require_version
 ~~~~~~~~~~~~~~~

--- a/docs/_source/docs/stack_group_config.rst
+++ b/docs/_source/docs/stack_group_config.rst
@@ -81,12 +81,16 @@ j2_environment
 A dictionary that is combined with the default jinja2 environment.
 It's converted to keyword arguments then passed to [jinja2.Environment](https://jinja.palletsprojects.com/en/2.11.x/api/#jinja2.Environment).
 
-```yaml
-j2_environment:
-  extensions:
-    - jinja2.ext.i18n
-    - jinja2.ext.do
-```
+.. code-block:: yaml
+
+   j2_environment:
+      extensions:
+         - jinja2.ext.i18n
+         - jinja2.ext.do
+      lstrip_blocks: True
+      trim_blocks: True
+      newline_sequence: \n
+
 
 require_version
 ~~~~~~~~~~~~~~~

--- a/docs/_source/docs/stack_group_config.rst
+++ b/docs/_source/docs/stack_group_config.rst
@@ -80,6 +80,7 @@ j2_environment
 
 A dictionary that is combined with the default jinja2 environment.
 It's converted to keyword arguments then passed to [jinja2.Environment](https://jinja.palletsprojects.com/en/2.11.x/api/#jinja2.Environment).
+This will impact :ref:`Templating` of stacks by modifying the behavior of jinja.
 
 .. code-block:: yaml
 

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -388,15 +388,16 @@ class ConfigReader(object):
         config = {}
         abs_directory_path = path.join(self.full_config_path, directory_path)
         if path.isfile(path.join(abs_directory_path, basename)):
-            jinja_env = Environment(
-                autoescape=select_autoescape(
+            default_j2_environment = {
+                "autoescape": select_autoescape(
                     disabled_extensions=('yaml',),
                     default=True,
                 ),
-                loader=FileSystemLoader(abs_directory_path),
-                undefined=StrictUndefined
-            )
-            template = jinja_env.get_template(basename)
+                "loader": FileSystemLoader(abs_directory_path),
+                "undefined": StrictUndefined
+            }
+            j2_env = Environment(**default_j2_environment)
+            template = j2_env.get_template(basename)
             self.templating_vars.update(stack_group_config)
             rendered_template = template.render(
                 self.templating_vars,

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -66,7 +66,8 @@ STACK_GROUP_CONFIG_ATTRIBUTES = ConfigAttributes(
     {
         "template_bucket_name",
         "template_key_prefix",
-        "required_version"
+        "required_version",
+        "j2_environment"
     }
 )
 
@@ -230,10 +231,10 @@ class ConfigReader(object):
                 full_dep = str(Path(self.context.full_config_path(), dep))
                 if not path.exists(full_dep):
                     raise DependencyDoesNotExistError(
-                            "{stackname}: Dependency {dep} not found. "
-                            "Please make sure that your dependencies stack_outputs "
-                            "have their full path from `config` defined."
-                            .format(stackname=stack.name, dep=dep))
+                        "{stackname}: Dependency {dep} not found. "
+                        "Please make sure that your dependencies stack_outputs "
+                        "have their full path from `config` defined."
+                        .format(stackname=stack.name, dep=dep))
 
                 if full_dep not in full_todo and full_dep not in deps_todo:
                     todo.add(full_dep)
@@ -388,7 +389,7 @@ class ConfigReader(object):
         config = {}
         abs_directory_path = path.join(self.full_config_path, directory_path)
         if path.isfile(path.join(abs_directory_path, basename)):
-            default_j2_environment = {
+            default_j2_environment_config = {
                 "autoescape": select_autoescape(
                     disabled_extensions=('yaml',),
                     default=True,
@@ -396,8 +397,11 @@ class ConfigReader(object):
                 "loader": FileSystemLoader(abs_directory_path),
                 "undefined": StrictUndefined
             }
-            j2_env = Environment(**default_j2_environment)
-            template = j2_env.get_template(basename)
+            j2_environment_config = strategies.dict_merge(
+                default_j2_environment_config,
+                stack_group_config.get("j2_environment", {}))
+            j2_environment = Environment(**j2_environment_config)
+            template = j2_environment.get_template(basename)
             self.templating_vars.update(stack_group_config)
             rendered_template = template.render(
                 self.templating_vars,

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -270,6 +270,7 @@ class Stack(object):
             self._template = Template(
                 path=self.template_path,
                 sceptre_user_data=self.sceptre_user_data,
+                stack_group_config=self.stack_group_config,
                 s3_details=self.s3_details,
                 connection_manager=self.connection_manager
             )

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -343,14 +343,15 @@ class Template(object):
         """
         logger = logging.getLogger(__name__)
         logger.debug("%s Rendering CloudFormation template", filename)
-        env = Environment(
-            autoescape=select_autoescape(
-                disabled_extensions=('j2',),
-                default=True,
-            ),
-            loader=FileSystemLoader(template_dir),
-            undefined=StrictUndefined
-        )
-        template = env.get_template(filename)
+        default_j2_environment = {
+                "autoescape": select_autoescape(
+                    disabled_extensions=('j2',),
+                    default=True,
+                ),
+                "loader": FileSystemLoader(template_dir),
+                "undefined": StrictUndefined,
+            }
+        j2_env = Environment(**default_j2_environment)
+        template = j2_env.get_template(filename)
         body = template.render(**jinja_vars)
         return body

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -38,6 +38,9 @@ class Template(object):
             a handler function in an external Python script.
     :type sceptre_user_data: dict
 
+    :param stack_group_config: The StackGroup config for the Stack.
+    :type stack_group_config: dict
+
     :param connection_manager:
     :type connection_manager: sceptre.connection_manager.ConnectionManager
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -40,8 +40,10 @@ class TestStackActions(object):
             stack_timeout=sentinel.stack_timeout
         )
         self.actions = StackActions(self.stack)
+        self.stack_group_config = {}
         self.template = Template(
             "fixtures/templates", self.stack.sceptre_user_data,
+            self.stack_group_config,
             self.actions.connection_manager, self.stack.s3_details
         )
         self.stack._template = self.template
@@ -58,6 +60,7 @@ class TestStackActions(object):
         mock_Template.assert_called_once_with(
             path=sentinel.template_path,
             sceptre_user_data=sentinel.sceptre_user_data,
+            stack_group_config={},
             connection_manager=self.stack.connection_manager,
             s3_details=None
         )


### PR DESCRIPTION
This PR adds support for configuring the Jinja2 Environment.

`j2_environment` can be defined within a stack config and is passed to [jinja2.Environment](https://jinja.palletsprojects.com/en/2.11.x/api/#jinja2.Environment).

E.g

```yaml
j2_environment:
  extensions:
    - jinja2.ext.i18n
    - jinja2.ext.do
  lstrip_blocks: True 
```

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
