### PR TITLE
Documents and test updates

### DIFF
--- a/docs/_source/docs/stack_group_config.rst
+++ b/docs/_source/docs/stack_group_config.rst
@@ -191,6 +191,23 @@ Will result in the following variables being available to the jinja templating:
    profile: prod
    project_code: api
 
+Note that there is no merging of dictionaries. If the variable appearing in
+the last variable file is a dictionary, and the same variable is defined in an
+earlier variable file, that whole dictionary will be overwritten. For example,
+this would not work as intended:
+
+.. code-block:: yaml
+
+   # default.yaml
+   tags: {"Env": "dev", "Project": "Widget"}
+
+.. code-block:: yaml
+
+   # prod.yaml
+   tags: {"Env": "prod"}
+
+Rather, the final dictionary would only contain the ``Env`` key.
+
 For command line flags, Sceptre splits the string on the first equals sign “=”,
 and sets the key to be the first substring, and the value to be the second. Due
 to the large number of possible user inputs, no error checking is performed on

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -131,6 +131,17 @@ class TestCli(object):
             },
             {"key1": "file1", "key2": "var2"}
         ),
+        # multiple --var-file option, illustrating dictionaries not merged.
+        (
+            ["--var-file", "foo.yaml", "--var-file", "bar.yaml", "noop"],
+            {
+                "foo.yaml": {"key1": {"a": "b"}},
+                "bar.yaml": {"key1": {"c": "d"}}
+            },
+            {
+                "key1": {"c": "d"}
+            }
+        ),
     ])
     def test_user_variables(self, command, files, output):
         @cli.command()


### PR DESCRIPTION
As requested by Khai Do, this patch adds:

- Documentation updates in stack_group_config.rst to clarify the legacy
behaviour of merging dictionaries from successive variable files.

- A test case in test_cli.py to demonstrate that behaviour.

This PR relates to open PR:
https://github.com/Sceptre/sceptre/pull/928

## PR Checklist

- [X] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [X] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [X] All unit tests (`make test`) are passing.
- [X] Used the same coding conventions as the rest of the project.
- [X] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [X] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
