### PR TITLE
[Resolves #1087] Add YAML doc markers in generate

### DIFF
--- a/sceptre/cli/template.py
+++ b/sceptre/cli/template.py
@@ -63,7 +63,15 @@ def generate_command(ctx, path):
 
     plan = SceptrePlan(context)
     responses = plan.generate()
-    output = [template for template in responses.values()]
+
+    output = []
+    templates = responses.values()
+    for template in templates:
+        if template.startswith("---"):
+            output.append(template)
+        else:
+            output.append("---\n" + template)
+
     write(output, context.output_format)
 
 


### PR DESCRIPTION
This change adds the YAML document marker to the beginning
of each template body if it doesn't already exist.

The reasoning behind this change can be found here
https://github.com/Sceptre/sceptre/issues/1087.

## PR Checklist

- [X] Wrote a good commit message & description [see guide below].
- [X] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests. TODO
- [ ] Added/Updated integration tests (if applicable). N/A
- [X] All unit tests (`make test`) are passing.
- [X] Used the same coding conventions as the rest of the project.
- [X] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [X] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
