### PR TITLE
[Resolves #582] update imp to importlib

### DIFF
--- a/integration-tests/steps/templates.py
+++ b/integration-tests/steps/templates.py
@@ -4,6 +4,7 @@ import imp
 import yaml
 
 from botocore.exceptions import ClientError
+from importlib.machinery import SourceFileLoader
 from sceptre.plan.plan import SceptrePlan
 from sceptre.context import SceptreContext
 from sceptre.cli.helpers import CfnYamlLoader
@@ -112,7 +113,7 @@ def step_impl(context, filename):
         context.sceptre_dir, "templates", filename
     )
 
-    module = imp.load_source("template", filepath)
+    module = SourceFileLoader("template", filepath).load_module()
     body = module.sceptre_handler({})
     for template in context.output.values():
         assert body == template

--- a/integration-tests/steps/templates.py
+++ b/integration-tests/steps/templates.py
@@ -1,6 +1,5 @@
 from behave import *
 import os
-import imp
 import yaml
 
 from botocore.exceptions import ClientError

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -15,6 +15,7 @@ import threading
 import traceback
 
 import botocore
+from importlib.machinery import SourceFileLoader
 from jinja2 import Environment
 from jinja2 import FileSystemLoader
 from jinja2 import StrictUndefined
@@ -174,7 +175,7 @@ class Template(object):
         if not os.path.isfile(self.path):
             raise IOError("No such file or directory: '%s'", self.path)
 
-        module = imp.load_source(self.name, self.path)
+        module = SourceFileLoader(self.name, path).load_module()
 
         try:
             body = module.sceptre_handler(self.sceptre_user_data)

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -7,7 +7,6 @@ This module implements a Template class, which stores a CloudFormation template
 and implements methods for uploading it to S3.
 """
 
-import imp
 import logging
 import os
 import sys

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -174,7 +174,7 @@ class Template(object):
         if not os.path.isfile(self.path):
             raise IOError("No such file or directory: '%s'", self.path)
 
-        module = SourceFileLoader(self.name, path).load_module()
+        module = SourceFileLoader(self.name, self.path).load_module()
 
         try:
             body = module.sceptre_handler(self.sceptre_user_data)


### PR DESCRIPTION
The imp.py library has been deprecated since ver 3.4 in favor of
importlib[1]. This updates to using importlib.

[1] https://docs.python.org/3/library/imp.html
