### PR TITLE
[Resolve #683] Creating a Diff command (Prototype)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ Temporary Items
 
 # User-specific stuff:
 .idea/
+.python-version
 
 ## File-based project format:
 *.iws

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,6 +1,8 @@
 boto3>=1.3.0,<2
+cfn-flip>=1.2.3,<2.0
 click>=7.0,<9.0
 colorama>=0.2.5,<0.4.4
+deepdiff>=5.5.0,<6.0
 Jinja2>=2.8,<3
 networkx>=2.4,<2.6
 packaging>=16.8,<17.0

--- a/sceptre/cli/__init__.py
+++ b/sceptre/cli/__init__.py
@@ -14,6 +14,7 @@ import click
 import colorama
 
 from sceptre import __version__
+from sceptre.cli.diff import diff_command
 from sceptre.cli.new import new_group
 from sceptre.cli.create import create_command
 from sceptre.cli.update import update_command
@@ -82,3 +83,4 @@ cli.add_command(set_policy_command)
 cli.add_command(status_command)
 cli.add_command(list_group)
 cli.add_command(describe_group)
+cli.add_command(diff_command)

--- a/sceptre/cli/diff.py
+++ b/sceptre/cli/diff.py
@@ -1,0 +1,147 @@
+import contextlib
+import json
+import sys
+from datetime import datetime
+from io import StringIO
+from pathlib import Path
+
+import cfn_flip
+import click
+from deepdiff import DeepDiff
+
+from sceptre.cli.helpers import catch_exceptions
+from sceptre.context import SceptreContext
+from sceptre.plan.plan import SceptrePlan
+from sceptre.plan.stack_differ import StackDiff, StackConfiguration
+
+
+@contextlib.contextmanager
+def nullcontext(enter_result=None):
+    yield enter_result
+
+
+@click.command(name="diff", short_help="Prints the template.")
+@click.option(
+    '-f',
+    '--full-templates',
+    is_flag=True,
+    help=(
+        "If there is a difference between deployed and generated, it will print the full generated "
+        "template if this is set to True"
+     )
+)
+@click.option(
+    '-o',
+    '--output-file',
+    type=click.Path(file_okay=True, dir_okay=False, resolve_path=True),
+    help=(
+        "If specified, the filepath that diff results will be printed to; "
+        "Otherwise they will streamed to stdout."
+    )
+)
+@click.argument("path")
+@click.pass_context
+@catch_exceptions
+def diff_command(ctx, path, full_templates, output_file):
+    """
+
+    :param path: Path to execute the command on.
+    :type path: str
+    """
+    context = SceptreContext(
+        command_path=path,
+        project_path=ctx.obj.get("project_path"),
+        user_variables=ctx.obj.get("user_variables"),
+        options=ctx.obj.get("options"),
+        output_format=ctx.obj.get("output_format"),
+        ignore_dependencies=ctx.obj.get("ignore_dependencies")
+    )
+
+    plan = SceptrePlan(context)
+    responses = plan.diff()
+
+    if output_file:
+        path = Path(output_file)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        context = path.open(mode='wt')
+    else:
+        context = nullcontext(sys.stdout)
+    with context as stream:
+        for stack_diff in responses.values():
+            output_diff_results(stack_diff, full_templates, stream)
+
+
+STAR_BAR = '*' * 80
+LINE_BAR = '-' * 80
+
+
+deepdiff_json_defaults = {
+    datetime.date: lambda x: x.isoformat(),
+    StackConfiguration: lambda x: x._asdict()
+}
+
+
+def output_diff_results(
+    diff: StackDiff,
+    print_full_template: bool,
+    output_stream: StringIO
+):
+    def print(text):
+        click.echo(text, file=output_stream)
+
+    stack_name, template_diff, config_diff = diff
+    if not len(template_diff) and not len(config_diff):
+        print(f"No difference to deployed stack {stack_name}")
+        return
+
+    print(STAR_BAR)
+    print(f"--> Difference detected for stack {stack_name}!")
+
+    if len(config_diff):
+        print(LINE_BAR)
+        if config_diff.t1 is None:
+            print("Current stack doesn't exist")
+        else:
+            print('Config difference:')
+            print(config_diff.to_json(default_mapping=deepdiff_json_defaults, indent=4, ))
+
+    else:
+        print("No config difference")
+
+    if len(template_diff):
+        print(LINE_BAR)
+        print("Template difference:")
+        print(template_diff.to_json(default_mapping=deepdiff_json_defaults, indent=4,))
+        if print_full_template:
+            deployed, generated = dump_dict(diff.t1), dump_dict(diff.t2)
+            print(LINE_BAR)
+            print(f'Deployed template:\n{LINE_BAR}\n{deployed}')
+            print(LINE_BAR)
+            print(f'New Template:\n{LINE_BAR}\n{generated}')
+    else:
+        print("No template difference")
+
+    print(STAR_BAR)
+
+
+@click.pass_context
+def dump_dict(ctx: click.Context, template: dict) -> str:
+    output_format = ctx.obj.get('output_format', 'yaml')
+
+    if output_format == 'json':
+        # There's not really a viable way to dump a template as "text" -> YAML is very readable
+        dumper = cfn_flip.dump_json
+    else:
+        dumper = cfn_flip.dump_yaml
+
+    return dumper(template)
+
+
+@click.pass_context
+def dump_diff(ctx: click.Context, diff: DeepDiff) -> str:
+    jsonified = diff.to_json(default_mapping=deepdiff_json_defaults, indent=4)
+    if ctx.obj.get('output_format', 'yaml') == 'json':
+        return jsonified
+
+    loaded = json.loads(jsonified)
+    return cfn_flip.dump_yaml(loaded)

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -19,6 +19,7 @@ from dateutil.tz import tzutc
 
 from sceptre.connection_manager import ConnectionManager
 from sceptre.hooks import add_stack_hooks
+from sceptre.plan.stack_differ import StackDiffer
 from sceptre.stack_status import StackStatus
 from sceptre.stack_status import StackChangeSetStatus
 
@@ -601,6 +602,12 @@ class StackActions(object):
             "%s - Validate Template response: %s", self.stack.name, response
         )
         return response
+
+    # Really, we want the generate hooks here...
+    @add_stack_hooks
+    def diff(self):
+        differ = StackDiffer(self.stack, self.connection_manager)
+        return differ.diff()
 
     def estimate_cost(self):
         """

--- a/sceptre/plan/plan.py
+++ b/sceptre/plan/plan.py
@@ -347,6 +347,16 @@ class SceptrePlan(object):
         self.resolve(command=self.generate.__name__)
         return self._execute(*args)
 
+    def diff(self, *args):
+        """
+        Returns a generated Template for a given Stack
+
+        :returns: A dictionary of Stacks and their template body.
+        :rtype: dict
+        """
+        self.resolve(command=self.diff.__name__)
+        return self._execute(*args)
+
     def _valid_stack_paths(self):
         return [
             sceptreise_path(path.relpath(path.join(dirpath, f), self.context.config_path))

--- a/sceptre/plan/stack_differ.py
+++ b/sceptre/plan/stack_differ.py
@@ -1,11 +1,13 @@
-from typing import NamedTuple, Dict, List, Optional
+from typing import NamedTuple, Dict, List, Optional, TYPE_CHECKING
 
 import cfn_flip
 from deepdiff import DeepDiff
 
 from sceptre.exceptions import StackDoesNotExistError
-from sceptre.plan.actions import StackActions
 from sceptre.resolvers import Resolver
+
+if TYPE_CHECKING:
+    from sceptre.plan.actions import StackActions
 
 
 class StackDiff(NamedTuple):
@@ -22,7 +24,7 @@ class StackConfiguration(NamedTuple):
 
 
 class StackDiffer:
-    def __init__(self, stack_actions: StackActions):
+    def __init__(self, stack_actions: 'StackActions'):
         self.stack_actions = stack_actions
 
     @property
@@ -96,6 +98,9 @@ class StackDiffer:
 
     def _create_deployed_stack_config(self) -> Optional[StackConfiguration]:
         description = self.stack_actions.describe()
+        if description is None:
+            return None
+
         stacks = description['Stacks']
         for stack in stacks:
             return StackConfiguration(

--- a/sceptre/plan/stack_differ.py
+++ b/sceptre/plan/stack_differ.py
@@ -1,0 +1,168 @@
+import botocore
+from botocore.exceptions import ClientError
+from cfn_tools import dump_json
+from deepdiff import DeepDiff
+import cfn_flip
+
+from sceptre.connection_manager import ConnectionManager
+from sceptre.exceptions import StackDoesNotExistError
+from sceptre.resolvers import Resolver
+from sceptre.stack import Stack
+from typing import NamedTuple, Dict, List, Optional
+
+
+class StackDiff(NamedTuple):
+    stack_name: str
+    template_diff: DeepDiff
+    config_diff: DeepDiff
+
+
+class StackConfiguration(NamedTuple):
+    parameters: Dict[str, str]
+    tags: Dict[str, str]
+    name: str
+    notification_arns: List[str]
+
+
+class StackDiffer:
+    def __init__(self, stack: Stack, connection_manager: ConnectionManager):
+        self.stack = stack
+        self.connection_manager = connection_manager
+
+    @property
+    def template(self):
+        return self.stack.template.body
+
+    @property
+    def external_name(self):
+        return self.stack.external_name
+
+    @property
+    def tags(self):
+        return self.stack.tags
+
+    @property
+    def notifications(self):
+        return self.stack.notifications
+
+    def diff(self) -> StackDiff:
+        generated_config = self._create_generated_config()
+        deployed_config = self._create_deployed_stack_config()
+        deployed_stack_template = self._get_deployed_template()
+
+        template_diff = self._compare_templates(deployed_stack_template)
+        config_diff = self._compare_configs(generated_config, deployed_config)
+
+        return StackDiff(self.external_name, template_diff, config_diff)
+
+    def _create_generated_config(self):
+        parameters = self._extract_parameters_dict()
+        stack_configuration = StackConfiguration(
+            parameters=parameters,
+            tags=self.tags,
+            name=self.external_name,
+            notification_arns=self.notifications
+        )
+
+        return stack_configuration
+
+    def _extract_parameters_dict(self):
+        parameters = {}
+        # parameters is a ResolvableProperty, but the underlying, pre-resolved parameters are
+        # stored in _parameters. We might not actually be able to resolve values, such as in the
+        # case where it attempts to get a value from a stack that doesn't exist yet. Therefore, this
+        # Resolves the values individually, where they CAN be resolved, and otherwise makes an
+        # alternative placeholder value
+        for key, value in self.stack._parameters.items():
+            if isinstance(value, Resolver):
+                # There might be some resolvers that we can still resolve values for.
+                try:
+                    value_to_use = value.resolve()
+                except StackDoesNotExistError:
+                    # In the end, this value likely won't matter, because if the stack this one is
+                    # dependent upon doesn't exist, this one most likely won't exist either, so
+                    # when deployed version is compared to this one, it will indicate we're creating
+                    # a new stack where one doesn't exist. The only place this value would be shown
+                    # is where the current stack DOES exist, but a new dependency is added that does
+                    # not exist yet. In which case, it will show the most usable output we can
+                    # provide right now.
+                    value_to_use = f'!{type(value).__name__}: {value.argument}'
+            else:
+                value_to_use = value
+            parameters[key] = value_to_use
+
+        return parameters
+
+    def _create_deployed_stack_config(self) -> Optional[StackConfiguration]:
+        try:
+            description = self.connection_manager.call(
+                service="cloudformation",
+                command="describe_stacks",
+                kwargs={"StackName": self.stack.external_name}
+            )
+        except botocore.exceptions.ClientError as e:
+            if e.response["Error"]["Message"].endswith("does not exist"):
+                return
+            raise
+
+        return self._map_stack_description_to_stack_configuration(
+            description
+        )
+
+    def _get_deployed_template(self) -> str:
+        try:
+            template = self.connection_manager.call(
+                service='cloudformation',
+                command='get_template',
+                kwargs={'StackName': self.external_name, 'TemplateStage': 'Original'}
+            )
+            template_body = template['TemplateBody']
+            # Sometimes boto return a string, sometimes a dictionary
+            if not isinstance(template_body, str):
+                template_body = dump_json(template_body)
+            return template_body
+        except ClientError as ex:
+            if ex.response['Error']['Code'] == 'ValidationError':
+                # Template doesn't exist
+                return '{}'
+            raise
+
+    def _map_stack_description_to_stack_configuration(self, description):
+        stacks = description['Stacks']
+        for stack in stacks:
+            return StackConfiguration(
+                parameters={
+                    param['ParameterKey']: param['ParameterValue']
+                    for param in stack.get('Parameters', [])
+                },
+                tags={
+                    tag['Key']: tag['Value']
+                    for tag in stack['Tags']
+                },
+                name=stack['StackName'],
+                notification_arns=stack['NotificationARNs']
+            )
+
+    def _compare_templates(self, deployed_template: str) -> DeepDiff:
+        """Compares the generated templates to the deployed templates using DeepDiff.
+
+        Returns:
+            A dictionary where the keys are the stack names and the values are DeepDiff objects
+        """
+        generated_dict, _ = cfn_flip.load(self.template)
+        deployed_dict, _ = cfn_flip.load(deployed_template)
+        return DeepDiff(
+            deployed_dict,
+            generated_dict,
+            verbose_level=2
+        )
+
+    def _compare_configs(self,
+        generated_config: StackConfiguration,
+        deployed_config: StackConfiguration
+    ):
+        return DeepDiff(
+            deployed_config,
+            generated_config,
+            verbose_level=2
+        )

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -264,7 +264,7 @@ class Stack(object):
         Returns the CloudFormation Template used to create the Stack.
 
         :returns: The Stack's template.
-        :rtype: str
+        :rtype: Template
         """
         if self._template is None:
             self._template = Template(

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,9 @@ install_requirements = [
     "sceptre-cmd-resolver>=1.1.3,<2",
     "sceptre-file-resolver>=1.0.4,<2",
     "six>=1.11.0,<2.0.0",
-    "networkx>=2.4,<2.6"
+    "networkx>=2.4,<2.6",
+    "deepdiff>=5.5.0,<6.0",
+    "cfn-flip>=1.2.3,<2.0"
 ]
 
 setup(


### PR DESCRIPTION
I'm posting this at this point for feedback. It's pretty important for my company's deployment process (and I suspect many others as well) to generate the "diff" on what this set of changes will do to the currently deployed group of stacks.

This creates what has been requested in a few different issues, most notably in #683 

The syntax here is basically `sceptre diff {command path}`

### This is currently in "prototype" stage for feedback. If the core maintainers are interested in this, I will write proper docs, tests, make changes, make this more "production-ready", etc...

## What does this do, exactly?
This compares the CURRENTLY DEPLOYED stacks in the stack group with the current configuration of stacks and templates. 
It both compares configurations and generated templates, indicating the difference.

The heavy-lifting on this is done with the excellent DeepDiff library as well as the cfn-flip library that lets you flip between CF json and yaml.

The output can be directed to a file or dumped to stdout.

## What sort of output does this create?
********************************************************************************
```
--> Difference detected for stack sceptre-dev-jf-demo-bucket-website-http-bucket!
No config difference
--------------------------------------------------------------------------------
Template difference:
values_changed:
  root['Resources']['S3Bucket07682993']['Properties']['BucketName']:
    new_value: changed-environment-sceptre-demo
    old_value: dev-jf-sceptre-demo

********************************************************************************
********************************************************************************
--> Difference detected for stack sceptre-dev-jf-demo-demo-lambda-artifact-bucket!
This stack is not deployed yet!
--------------------------------------------------------------------------------
New config:
name: sceptre-dev-jf-demo-demo-lambda-artifact-bucket
notification_arns: []
parameters:
  ArtifactBucketName: dev-jf-random-artifacts
tags:
  Deployed_Using: Sceptre
  Eng_Business_Product: demo-lambda
  Environment: dev-jf
  Reason_For_Existance: To demonstrate Sceptre

--------------------------------------------------------------------------------
New template:
Parameters:
  ArtifactBucketName:
    Type: String
    Description: The name of the Amazon S3 bucket where uploaded SAM artifacts will
      be stored.
Resources:
  ArtifactBucket7410C9EF:
    Type: AWS::S3::Bucket
    Properties:
      BucketName: !Ref 'ArtifactBucketName'
    UpdateReplacePolicy: Delete
    DeletionPolicy: Delete
    Metadata:
      aws:cdk:path: CdkStack/ArtifactBucket/Resource
  CDKMetadata:
    Type: AWS::CDK::Metadata
    Properties:
      Analytics: >-
        v2:deflate64:H4sIAAAAAAAAEyWNQQrCMBBFz+I+nTYK4lLsASz1BCEZIQ1NZDKji5C727Sr//g8/tegzwMMp7v55c660BebCKG82NigxnecDJkVGUmNKWYmsdzqp/BHdpoxJyGLjTfFefYpVtX28gXKQ2zAXTyoVhWTQ1hy/9VXuG3fS/a+I4nsV4T5yD/OizQKmAAAAA==
    Metadata:
      aws:cdk:path: CdkStack/CDKMetadata/Default
    Condition: CDKMetadataAvailable
Outputs:
  BucketName:
    Description: The ARN of the website bucket
    Value: !Ref 'ArtifactBucket7410C9EF'
Conditions:
  CDKMetadataAvailable: !Or
    - !Or
      - !Equals
        - !Ref 'AWS::Region'
        - af-south-1
      - !Equals
        - !Ref 'AWS::Region'
        - ap-east-1
      - !Equals
        - !Ref 'AWS::Region'
        - ap-northeast-1
      - !Equals
        - !Ref 'AWS::Region'
        - ap-northeast-2
      - !Equals
        - !Ref 'AWS::Region'
        - ap-south-1
      - !Equals
        - !Ref 'AWS::Region'
        - ap-southeast-1
      - !Equals
        - !Ref 'AWS::Region'
        - ap-southeast-2
      - !Equals
        - !Ref 'AWS::Region'
        - ca-central-1
      - !Equals
        - !Ref 'AWS::Region'
        - cn-north-1
      - !Equals
        - !Ref 'AWS::Region'
        - cn-northwest-1
    - !Or
      - !Equals
        - !Ref 'AWS::Region'
        - eu-central-1
      - !Equals
        - !Ref 'AWS::Region'
        - eu-north-1
      - !Equals
        - !Ref 'AWS::Region'
        - eu-south-1
      - !Equals
        - !Ref 'AWS::Region'
        - eu-west-1
      - !Equals
        - !Ref 'AWS::Region'
        - eu-west-2
      - !Equals
        - !Ref 'AWS::Region'
        - eu-west-3
      - !Equals
        - !Ref 'AWS::Region'
        - me-south-1
      - !Equals
        - !Ref 'AWS::Region'
        - sa-east-1
      - !Equals
        - !Ref 'AWS::Region'
        - us-east-1
      - !Equals
        - !Ref 'AWS::Region'
        - us-east-2
    - !Or
      - !Equals
        - !Ref 'AWS::Region'
        - us-west-1
      - !Equals
        - !Ref 'AWS::Region'
        - us-west-2

********************************************************************************
********************************************************************************
--> Difference detected for stack sceptre-dev-jf-demo-bucket-website-http-bucket-policy!
No config difference
--------------------------------------------------------------------------------
Template difference:
type_changes:
  root['Resources']['BucketPolicy']['Properties']['PolicyDocument']['Statement'][0]['Action']:
    new_type: list
    new_value:
      - s3:GetObject
      - s3:PutObject
    old_type: str
    old_value: s3:GetObject

********************************************************************************
No difference to deployed stack sceptre-dev-jf-demo-demo-lambda-demo-lambda

```

## PR Checklist

- [ ] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
