### PR TITLE
[Resolve #1096] Gracefully executing SAM Change sets

### DIFF
--- a/integration-tests/features/execute-change-set.feature
+++ b/integration-tests/features/execute-change-set.feature
@@ -21,8 +21,14 @@ Feature: Execute change set
     Then stack "1/A" does not have change set "A"
     And stack "1/A" was updated with change set "A"
 
-  Scenario: execute a change set for SAM template with no changes
-    Given stack "1/A" exists using "sam_template.yaml"
-    And stack "1/A" has change set "A" using "sam_template.yaml"
-    When the user executes change set "A" for stack "1/A"
-    Then stack "1/A" does not have change set "A"
+  Scenario: execute a change set that failed creation for no changes
+    Given stack "2/A" exists using "valid_template.json"
+    And stack "2/A" has change set "A" using "valid_template.json"
+    When the user executes change set "A" for stack "2/A"
+    Then stack "2/A" has change set "A" in "FAILED" state
+
+  Scenario: execute a change set that failed creation for a SAM template with no changes
+    Given stack "3/A" exists using "sam_template.yaml"
+    And stack "3/A" has change set "A" using "sam_template.yaml"
+    When the user executes change set "A" for stack "3/A"
+    Then stack "3/A" has change set "A" in "FAILED" state

--- a/integration-tests/features/execute-change-set.feature
+++ b/integration-tests/features/execute-change-set.feature
@@ -2,21 +2,27 @@ Feature: Execute change set
 
   Scenario: execute a change set that exists
     Given stack "1/A" exists in "CREATE_COMPLETE" state
-    and stack "1/A" has change set "A" using "updated_template.json"
+    And stack "1/A" has change set "A" using "updated_template.json"
     When the user executes change set "A" for stack "1/A"
     Then stack "1/A" does not have change set "A"
-    and stack "1/A" was updated with change set "A"
+    And stack "1/A" was updated with change set "A"
 
   Scenario: execute a change set that does not exist
     Given stack "1/A" exists in "CREATE_COMPLETE" state
-    and stack "1/A" does not have change set "A"
+    And stack "1/A" does not have change set "A"
     When the user executes change set "A" for stack "1/A"
     Then a "ClientError" is raised
-    and the user is told "change set does not exist"
+    And the user is told "change set does not exist"
 
   Scenario: execute a change set that exists with ignore dependencies
     Given stack "1/A" exists in "CREATE_COMPLETE" state
-    and stack "1/A" has change set "A" using "updated_template.json"
+    And stack "1/A" has change set "A" using "updated_template.json"
     When the user executes change set "A" for stack "1/A" with ignore dependencies
     Then stack "1/A" does not have change set "A"
-    and stack "1/A" was updated with change set "A"
+    And stack "1/A" was updated with change set "A"
+
+  Scenario: execute a change set for SAM template with no changes
+    Given stack "1/A" exists using "sam_template.yaml"
+    And stack "1/A" has change set "A" using "sam_template.yaml"
+    When the user executes change set "A" for stack "1/A"
+    Then stack "1/A" does not have change set "A"

--- a/integration-tests/steps/stacks.py
+++ b/integration-tests/steps/stacks.py
@@ -401,7 +401,13 @@ def get_stack_status(context, stack_name, region_name=None):
 def create_stack(context, stack_name, body, **kwargs):
     retry_boto_call(
         context.client.create_stack,
-        StackName=stack_name, TemplateBody=body, **kwargs
+        StackName=stack_name,
+        TemplateBody=body, **kwargs,
+        Capabilities=[
+            'CAPABILITY_IAM',
+            'CAPABILITY_NAMED_IAM',
+            'CAPABILITY_AUTO_EXPAND'
+        ]
     )
 
     wait_for_final_state(context, stack_name)

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -562,7 +562,7 @@ class StackActions(object):
         reason = reason.lower()
         no_change_substrings = (
             "submitted information didn't contain changes",
-            "no updates are to be performed"  # The reason returned for failed SAM templates
+            "no updates are to be performed"  # The reason returned for SAM templates
         )
 
         for substring in no_change_substrings:

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -676,6 +676,29 @@ class TestStackActions(object):
         )
         mock_wait_for_completion.assert_called_once_with()
 
+    def test_execute_change_set__change_set_is_failed_for_no_changes__returns_0(self):
+        def fake_describe(service, command, kwargs):
+            assert (service, command) == ('cloudformation', 'describe_change_set')
+            return {
+                'Status': 'FAILED',
+                'StatusReason': "The submitted information didn't contain changes",
+            }
+        self.actions.connection_manager.call.side_effect = fake_describe
+        result = self.actions.execute_change_set(sentinel.change_set_name)
+        assert result == 0
+
+    def test_execute_change_set__change_set_is_failed_for_no_updates__returns_0(self):
+        def fake_describe(service, command, kwargs):
+            assert (service, command) == ('cloudformation', 'describe_change_set')
+            return {
+                'Status': 'FAILED',
+                'StatusReason': "No updates are to be performed",
+            }
+
+        self.actions.connection_manager.call.side_effect = fake_describe
+        result = self.actions.execute_change_set(sentinel.change_set_name)
+        assert result == 0
+
     def test_list_change_sets_sends_correct_request(self):
         self.actions.list_change_sets()
         self.actions.connection_manager.call.assert_called_with(


### PR DESCRIPTION
This resolves issue #1096. SAM Templates result in a different failure message when a change set is created with no actual changes. Currently Spectre handles the same situation for _normal_ CloudFormation change sets, but it blows up if there's a SAM template since the StatusReason is a little different.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
