### PR TITLE
[Resolves #1100] Fix github.com URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ behaviour to the [Sceptre github discussion](https://github.com/Sceptre/sceptre/
 ## Report Bugs
 
 Before submitting a bug, please check our
-[issues page](https://github.com/cloudreach/sceptre/issues) and
+[issues page](https://github.com/Sceptre/sceptre/issues) and
 [discussion board](https://github.com/Sceptre/sceptre/discussions) to see if it's
 already been reported.
 

--- a/docs/_source/about.rst
+++ b/docs/_source/about.rst
@@ -46,8 +46,8 @@ The Sceptre community uses a Slack channel #sceptre on the og-aws Slack for
 discussion. To join use this link http://slackhatesthe.cloud/ to create an
 account and join the #sceptre channel.
 
-.. _Github: https://github.com/cloudreach/sceptre/
-.. _Issues: https://github.com/cloudreach/sceptre/issues
+.. _Github: https://github.com/Sceptre/sceptre/
+.. _Issues: https://github.com/Sceptre/sceptre/issues
 .. _CloudFormation: https://aws.amazon.com/cloudformation/
 .. _AWS CLI: https://aws.amazon.com/cli/
 .. _Boto3: https://aws.amazon.com/sdk-for-python/

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     author="Cloudreach",
     author_email="sceptre@cloudreach.com",
     license='Apache2',
-    url="https://github.com/cloudreach/sceptre",
+    url="https://github.com/Sceptre/sceptre",
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     package_dir={
         "sceptre": "sceptre"


### PR DESCRIPTION
As per #1100, there are a number of `github.com/cloudreach/` URLs in this repo. To be correct, they should be `github.com/Sceptre/`.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
