### PR TITLE
[Resolve #1102] Removing nonexistant parameter from documented Custom Hook

### DIFF
--- a/docs/_source/docs/hooks.rst
+++ b/docs/_source/docs/hooks.rst
@@ -154,9 +154,6 @@ custom_hook.py
             argument defined in the Sceptre config file (see below)
         stack: sceptre.stack.Stack
              The associated stack of the hook.
-        connection_manager: sceptre.connection_manager.ConnectionManager
-            Boto3 Connection Manager - can be used to call boto3 api.
-
         """
         def __init__(self, *args, **kwargs):
             super(CustomHook, self).__init__(*args, **kwargs)


### PR DESCRIPTION
The example documentation for creating custom hooks lists that ConnectionManager is a kwarg. But that's not true. 

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
