### PR TITLE
[Resolves #1090] Install troposphere as an extra package

### DIFF
--- a/docs/_source/docs/templates.rst
+++ b/docs/_source/docs/templates.rst
@@ -179,8 +179,11 @@ to generate CloudFormation Template as a `json` string.
     def sceptre_handler(sceptre_user_data):
         return vpc(sceptre_user_data)
 
-.. _troposphere: https://github.com/cloudtools/troposphere/
+.. note::
+  To generate templates using Troposphere you must install the
+  Troposphere library by running ``pip install sceptre[troposphere]``
 
+.. _troposphere: https://github.com/cloudtools/troposphere/
 
 AWS CDK
 ^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,11 @@ install_requirements = [
     "networkx>=2.4,<2.6"
 ]
 
+extra_requirements={
+    "troposphere": ["troposphere>=2.0.0,<2.1.0"],
+}
+
+
 setup(
     name="sceptre",
     version=get_version("sceptre/__init__.py"),
@@ -88,4 +93,5 @@ setup(
     ],
     test_suite="tests",
     install_requires=install_requirements,
+    extra_require=extra_requirements,
 )

--- a/setup.py
+++ b/setup.py
@@ -93,5 +93,5 @@ setup(
     ],
     test_suite="tests",
     install_requires=install_requirements,
-    extra_require=extra_requirements,
+    extras_require=extra_requirements,
 )

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ install_requirements = [
     "networkx>=2.4,<2.6"
 ]
 
-extra_requirements={
+extra_requirements = {
     "troposphere": ["troposphere>=2.0.0,<2.1.0"],
 }
 


### PR DESCRIPTION
Scepter supports the deployment of troposphere templates however the
troposphere library does not get installed on a sceptre install because
the library dependency is not setup. This means that troposphere must
be installed separately from sceptre in order to use it. The problem
with that is that users may install a version of troposphere that may
not work with sceptre. To fix this issue I think we should add a versioned
troposphere dependency to sceptre so that users will get a version that
is tested and will most likey work with the installed version of scepter.
