### PR TITLE
Setup to build docs on readthedocs.org

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,21 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/_source/conf.py
+
+# Optionally build your docs in additional formats such as PDF
+formats:
+   - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+   version: "3.8"
+   install:
+   - requirements: requirements/prod.txt
+   - requirements: requirements/dev.txt


### PR DESCRIPTION
This is to partially resolve issue #1098.

We plan to move sceptre docs away from hosting on a
[cloudreach domain](https://sceptre.cloudreach.com/2.6.3/) to
https://readthedocs.org/project/sceptre

This PR adds the file to build the sphinx docs on readthedocs.org
