### PR TITLE
[Resolves 556] fix incorrect stack_output and stack_output_external examples

### DIFF
--- a/docs/_source/docs/stack_config.rst
+++ b/docs/_source/docs/stack_config.rst
@@ -156,7 +156,7 @@ Example:
        - "subnet-87654321"
      security_group_ids:
        - "sg-12345678"
-       - !stack_output security-groups::BaseSecurityGroupId
+       - !stack_output security-groups.yaml::BaseSecurityGroupId
        - !file_contents /file/with/security_group_id.txt
 
 protected
@@ -204,7 +204,7 @@ e.g:
 .. code-block:: yaml
 
    parameters:
-     VpcID: !stack_output_external <custom-named-vpc-stack>.yaml::VpcID
+     VpcID: !stack_output_external <custom-named-vpc-stack>::VpcID
    dependencies:
      - <environment>/<Stack>
 
@@ -215,7 +215,7 @@ referring to is in a different AWS account or region.
 .. code-block:: yaml
 
    parameters:
-     VpcID: !stack_output_external <custom-named-vpc-stack>.yaml::VpcID my-aws-prod-profile
+     VpcID: !stack_output_external <custom-named-vpc-stack>::VpcID my-aws-prod-profile
    dependencies:
      - <environment>/<Stack>
 
@@ -313,8 +313,8 @@ Examples
            - !cmd "mkdir example"
            - !cmd "touch example.txt"
    parameters:
-       param_1: !stack_output stack_name::output_name
-       param_2: !stack_output_external full_stack_name.yaml::output_name
+       param_1: !stack_output stack_name.yaml::output_name
+       param_2: !stack_output_external full_stack_name::output_name
        param_3: !environment_variable VALUE_3
        param_4:
            {{ var.value4 }}


### PR DESCRIPTION
This PR fixes a number of stack_output and stack_output_external examples that were highlighted in #556

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [x] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
