### PR TITLE
Update troposphere library

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -9,4 +9,4 @@ PyYaml>=5.1,<6.0
 sceptre-cmd-resolver>=1.1.3,<2
 sceptre-file-resolver>=1.0.4,<2
 six>=1.11.0,<2.0.0
-troposphere>=2.0.0,<2.1.0
+troposphere>=2.0,<3

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -9,4 +9,4 @@ PyYaml>=5.1,<6.0
 sceptre-cmd-resolver>=1.1.3,<2
 sceptre-file-resolver>=1.0.4,<2
 six>=1.11.0,<2.0.0
-troposphere>=2.0,<3
+troposphere>=2.7,<3

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ install_requirements = [
 ]
 
 extra_requirements = {
-    "troposphere": ["troposphere>=2,<3"],
+    "troposphere": ["troposphere>=2.7,<3"],
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ install_requirements = [
 ]
 
 extra_requirements = {
-    "troposphere": ["troposphere>=2.0.0,<2.1.0"],
+    "troposphere": ["troposphere>=2,<3"],
 }
 
 


### PR DESCRIPTION
When attempting to deploy troposphere template I get the following error

```
AttributeError: 'Template' object has no attribute 'to_yaml'

```

Accoring to https://github.com/cloudtools/troposphere/issues/759  it
seems like we need to update trophoshere to a version where the
`to_yaml` was added back.  The current dependency to trophosphere (v2.0.2)
is pretty old anyways so we are updating the version to the latest 2.x
release

The latest version is 3.0.3 however updating to 3.x causes sceptre unit
tests to fail so we are sticking to the latest 2.x version.

