### PR TITLE
[RESOLVE #946] Fixing bug preventing StackGroup dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ __pycache__/
 env/
 venv/
 .venv/
-.python-version
 build/
 develop-eggs/
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 env/
 venv/
 .venv/
+.python-version
 build/
 develop-eggs/
 dist/

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -272,7 +272,10 @@ class ConfigReader(object):
             if not self.context.ignore_dependencies:
                 for i, dep in enumerate(stack.dependencies):
                     try:
-                        stack.dependencies[i] = stack_map[sceptreise_path(dep)]
+                        if not isinstance(dep, Stack):
+                            # If the dependency was inherited from a stack group, it might already
+                            # have been mapped and so doesn't need to be mapped again.
+                            stack.dependencies[i] = stack_map[sceptreise_path(dep)]
                     except KeyError:
                         raise DependencyDoesNotExistError(
                             "{stackname}: Dependency {dep} not found. "


### PR DESCRIPTION
This resolves issue #946 by solving the issue of inherited dependencies. Turns out, the problem was just a small bug with inherited objects in memory.

There was a small bug in the ConfigReader that has to do with the way list-joining works on individual stacks and how dependencies are resolved.

The basic situation was this:

* Sceptre uses the "list_join" strategy to combine StackGroup dependencies with Stack dependencies. 
* The list_join strategy creates a NEW list by combining A + B... **but only if both A and B exist**. 
* In the case where the StackGroup dependencies exist _but there are no Stack dependencies_, Sceptre just selects A and passes each stack in that group the exact same dependencies list (i.e. **same object in memory**) from the StackGroup
* The process of resolving stacks replaces the stack string with a Stack object _in place_.
* If two stacks have inherited the exact same dependencies list because neither of them defined their own dependencies lists, the first stack to be resolved will replace those objects in memory with Stack objects and the second stack to be resolved will receive those Stack objects rather than strings.
* In the attempt to resolve the Stack object (believing it's a string), Sceptre will blow up because you cannot call `.replace()` on a Stack instance. But we don't need to do that at all if it's already a Stack.

This PR fixes that bug by skipping resolution for dependencies that are already Stack objects.
## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
