### PR TITLE
[Resolve Sceptre#1143] "create" command existing stack handling fix

### DIFF
--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -95,7 +95,7 @@ class StackActions(object):
                     "%s - Stack already exists", self.stack.name
                 )
 
-                status = "COMPLETE"
+                status = StackStatus.COMPLETE
             else:
                 raise
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -187,6 +187,26 @@ class TestStackActions(object):
         mock_wait_for_completion.assert_called_once_with()
 
     @patch("sceptre.plan.actions.StackActions._wait_for_completion")
+    def test_create_stack_already_exists(
+            self, mock_wait_for_completion
+    ):
+        self.actions.stack._template = Mock(spec=Template)
+        self.actions.stack._template.get_boto_call_parameter.return_value = {
+            "Template": sentinel.template
+        }
+        mock_wait_for_completion.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "AlreadyExistsException",
+                    "Message": "Stack already [{}] exists".format(self.actions.stack.name)
+                }
+            },
+            sentinel.operation
+        )
+        response = self.actions.create()
+        assert response == StackStatus.COMPLETE
+
+    @patch("sceptre.plan.actions.StackActions._wait_for_completion")
     def test_update_sends_correct_request(self, mock_wait_for_completion):
         self.actions.stack._template = Mock(spec=Template)
         self.actions.stack._template.get_boto_call_parameter.return_value = {


### PR DESCRIPTION
"create" command returns 1 if stack exists while it should return 0.
It happens, due to invalud return valid in actions.py and that is not recognized as a successful stack state
(https://github.com/Sceptre/sceptre/blob/master/sceptre/cli/create.py#L48 validates is all stacks are finished with "complete" status, while create commands returns capitalized "COMPLETE")

## PR Checklist

- [X] Wrote a good commit message & description [see guide below].
- [X] Commit message starts with `[Resolve #issue-number]`.
- [X] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [X] All unit tests (`make test`) are passing.
- [X] Used the same coding conventions as the rest of the project.
- [X] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
