### PR TITLE
[Resolves #1148] Correct path logic

### DIFF
--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -531,7 +531,7 @@ class ConfigReader(object):
         stack = Stack(
             name=stack_name,
             project_code=config["project_code"],
-            template_path=self._get_relative_template_path(config.get("template_path")),
+            template_path=config.get("template_path"),
             template_handler_config=config.get("template"),
             region=config["region"],
             template_bucket_name=config.get("template_bucket_name"),
@@ -570,12 +570,3 @@ class ConfigReader(object):
         }
         parsed_config.pop("stack_group_path")
         return parsed_config
-
-    def _get_relative_template_path(self, template_path):
-        if not template_path:
-            return None
-
-        return path.join(
-            self.context.project_path, self.context.templates_path,
-            sceptreise_path(template_path)
-        )

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -531,7 +531,7 @@ class ConfigReader(object):
         stack = Stack(
             name=stack_name,
             project_code=config["project_code"],
-            template_path=self._get_absolute_template_path(config.get("template_path")),
+            template_path=self._get_relative_template_path(config.get("template_path")),
             template_handler_config=config.get("template"),
             region=config["region"],
             template_bucket_name=config.get("template_bucket_name"),
@@ -571,7 +571,7 @@ class ConfigReader(object):
         parsed_config.pop("stack_group_path")
         return parsed_config
 
-    def _get_absolute_template_path(self, template_path):
+    def _get_relative_template_path(self, template_path):
         if not template_path:
             return None
 

--- a/sceptre/template_handlers/file.py
+++ b/sceptre/template_handlers/file.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from sceptre.exceptions import UnsupportedTemplateFileTypeError
 from sceptre.template_handlers import TemplateHandler
-from sceptre.helpers import sceptreise_path
+from sceptre.helpers import normalise_path
 
 
 class File(TemplateHandler):
@@ -28,7 +28,7 @@ class File(TemplateHandler):
 
     def handle(self):
         input_path = Path(self.arguments["path"])
-        path = self._get_relative_template_path(str(input_path))
+        path = self._resolve_template_path(str(input_path))
 
         if input_path.suffix not in self.supported_template_extensions:
             raise UnsupportedTemplateFileTypeError(
@@ -51,8 +51,15 @@ class File(TemplateHandler):
             helper.print_template_traceback(path)
             raise e
 
-    def _get_relative_template_path(self, template_path):
+    def _resolve_template_path(self, template_path):
+        """
+        Return the project_path joined to template_path as
+        a string.
+
+        Note that os.path.join defers to an absolute path
+        if the input is absolute.
+        """
         return path.join(
-            self.stack_group_config.get("project_path"), "templates",
-            sceptreise_path(template_path)
+            self.stack_group_config["project_path"], "templates",
+            normalise_path(template_path)
         )

--- a/sceptre/template_handlers/file.py
+++ b/sceptre/template_handlers/file.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 import sceptre.template_handlers.helper as helper
 
+from os import path
 from pathlib import Path
+
 from sceptre.exceptions import UnsupportedTemplateFileTypeError
 from sceptre.template_handlers import TemplateHandler
+from sceptre.helpers import sceptreise_path
 
 
 class File(TemplateHandler):
@@ -25,7 +28,7 @@ class File(TemplateHandler):
 
     def handle(self):
         input_path = Path(self.arguments["path"])
-        path = str(input_path)
+        path = self._get_relative_template_path(str(input_path))
 
         if input_path.suffix not in self.supported_template_extensions:
             raise UnsupportedTemplateFileTypeError(
@@ -47,3 +50,9 @@ class File(TemplateHandler):
         except Exception as e:
             helper.print_template_traceback(path)
             raise e
+
+    def _get_relative_template_path(self, template_path):
+        return path.join(
+            self.stack_group_config.get("project_path"), "templates",
+            sceptreise_path(template_path)
+        )

--- a/sceptre/template_handlers/file.py
+++ b/sceptre/template_handlers/file.py
@@ -26,10 +26,7 @@ class File(TemplateHandler):
     def handle(self):
         project_path = self.stack_group_config.get("project_path")
         input_path = Path(self.arguments["path"])
-        if input_path.is_absolute():
-            path = str(input_path)
-        else:
-            path = str(Path(project_path) / 'templates' / input_path)
+        path = str(input_path)
 
         if input_path.suffix not in self.supported_template_extensions:
             raise UnsupportedTemplateFileTypeError(

--- a/sceptre/template_handlers/file.py
+++ b/sceptre/template_handlers/file.py
@@ -24,7 +24,6 @@ class File(TemplateHandler):
         }
 
     def handle(self):
-        project_path = self.stack_group_config.get("project_path")
         input_path = Path(self.arguments["path"])
         path = str(input_path)
 

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -303,9 +303,7 @@ class TestConfigReader(object):
         mock_Stack.assert_any_call(
             name="account/stack-group/region/vpc",
             project_code="account_project_code",
-            template_path=os.path.join(
-                self.context.project_path, "templates/path/to/template"
-            ),
+            template_path="path/to/template",
             template_handler_config=None,
             region="region_region",
             profile="account_profile",


### PR DESCRIPTION
This resolves a bug introduced in 5c0ab39. 

In the case of `--dir`, the `File` handler class's `handle` method has
received a path relative to the `project_path` due to the previously
incorrectly-named method in the `ConfigReader` class
`_get_absolute_template_path` returning the relative path.

This patch renames the incorrectly-named method
`_get_absolute_template_path` as `_get_relative_template_path` and
corrects the logic in the `File` class's `handle` method.


## PR Checklist

- [X] Wrote a good commit message & description [see guide below].
- [X] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [X] All unit tests (`make test`) are passing.
- [X] Used the same coding conventions as the rest of the project.
- [X] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [X] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
