### PR TITLE
[Resolve #1114,#426] Project Dependencies part 1: ResolvableProperty refactor + tags resolvable property

### DIFF
--- a/integration-tests/steps/helpers.py
+++ b/integration-tests/steps/helpers.py
@@ -73,7 +73,7 @@ def get_cloudformation_stack_name(context, stack_name):
 
 
 def retry_boto_call(func, *args, **kwargs):
-    delay = 2
+    delay = 5
     max_retries = 150
     attempts = 0
     while attempts < max_retries:

--- a/sceptre/config/strategies.py
+++ b/sceptre/config/strategies.py
@@ -6,6 +6,7 @@ sceptre.config.strategies
 This module contains the implementations of the strategies used to merge config
 attributes.
 """
+from copy import deepcopy
 
 
 def list_join(a, b):
@@ -21,16 +22,17 @@ def list_join(a, b):
     """
     if a and not isinstance(a, list):
         raise TypeError('{} is not a list'.format(a))
+
     if b and not isinstance(b, list):
         raise TypeError('{} is not a list'.format(b))
 
     if a is None:
-        return b
+        return deepcopy(b)
 
     if b is not None:
-        return a + b
+        return deepcopy(a + b)
 
-    return a
+    return deepcopy(a)
 
 
 def dict_merge(a, b):
@@ -50,13 +52,12 @@ def dict_merge(a, b):
         raise TypeError('{} is not a dict'.format(b))
 
     if a is None:
-        return b
+        return deepcopy(b)
 
     if b is not None:
-        a.update(b)
-        return a
+        return deepcopy({**a, **b})
 
-    return a
+    return deepcopy(a)
 
 
 def child_wins(a, b):

--- a/sceptre/resolvers/__init__.py
+++ b/sceptre/resolvers/__init__.py
@@ -79,7 +79,7 @@ class ResolvableProperty(abc.ABC):
         :param stack: The Stack instance the property is being retrieved for
         :param stack_class: The class of the stack that the property is being retrieved for.
         :return: The attribute stored with the suffix ``name`` in the instance.
-        :rtype: The obtained value, as resolved by the
+        :rtype: The obtained value, as resolved by the property
         """
         with self._lock, self._no_recursive_get(stack):
             if hasattr(stack, self.name):

--- a/sceptre/resolvers/__init__.py
+++ b/sceptre/resolvers/__init__.py
@@ -3,30 +3,32 @@ import abc
 import logging
 from contextlib import contextmanager
 from threading import RLock
+from typing import Any, TYPE_CHECKING, Type, Union, TypeVar
 
-import six
 from sceptre.helpers import _call_func_on_values
 
+if TYPE_CHECKING:
+    from sceptre import stack
 
-class RecursiveGet(Exception):
+T_Container = TypeVar('T_Container', bound=Union[dict, list])
+
+logger = logging.getLogger(__name__)
+
+
+class RecursiveResolve(Exception):
     pass
 
 
-@six.add_metaclass(abc.ABCMeta)
-class Resolver:
+class Resolver(abc.ABC):
     """
     Resolver is an abstract base class that should be inherited by all
     Resolvers.
 
     :param argument: The argument of the resolver.
-    :type argument: str
     :param stack: The associated stack of the resolver.
-    :type stack: sceptre.stack.Stack
     """
 
-    __metaclass__ = abc.ABCMeta
-
-    def __init__(self, argument=None, stack=None):
+    def __init__(self, argument: Any = None, stack: 'stack.Stack' = None):
         self.logger = logging.getLogger(__name__)
         self.argument = argument
         self.stack = stack
@@ -49,62 +51,234 @@ class Resolver:
         """
         pass  # pragma: no cover
 
+    def clone(self, stack: 'stack.Stack') -> 'Resolver':
+        """
+        Produces a "fresh" copy of the Resolver, with the specified stack.
 
-class ResolvableProperty(object):
+        :param stack: The stack to set on the cloned resolver
+        """
+        return type(self)(self.argument, stack)
+
+
+class ResolvableProperty(abc.ABC):
     """
-    This is a descriptor class used to store an attribute that may contain
-    Resolver objects. When retrieving the dictionary or list, any Resolver
-    objects contains are a value or within a list are resolved to a primitive
-    type. Supports nested dictionary and lists.
+    This is an abstract base class for a descriptor used to store an attribute that have values
+    associated with Resolver objects.
 
     :param name: Attribute suffix used to store the property in the instance.
-    :type name: str
+    :param placeholder_override: If specified, this is the value that will be used as the placeholder
+        rather than the resolver's returned placeholder value, but only when placeholders are allowed
+        via the use_resolver_placeholders_on_error context manager.
     """
 
     def __init__(self, name):
         self.name = "_" + name
         self.logger = logging.getLogger(__name__)
-        self._get_in_progress = False
+
         self._lock = RLock()
 
-    def __get__(self, instance, type):
+    def __get__(self, stack: 'stack.Stack', stack_class: Type['stack.Stack']) -> Any:
         """
-        Attribute getter which resolves any Resolver object contained in the
-        complex data structure.
+        Attribute getter which resolves the resolver(s).
 
+        :param stack: The Stack instance the property is being retrieved for
+        :param stack_class: The class of the stack that the property is being retrieved for.
         :return: The attribute stored with the suffix ``name`` in the instance.
-        :rtype: dict or list
+        :rtype: The obtained value, as resolved by the
         """
-        with self._lock, self._no_recursive_get():
-            def resolve(attr, key, value):
-                try:
-                    attr[key] = value.resolve()
-                except RecursiveGet:
-                    attr[key] = self.ResolveLater(instance, self.name, key,
-                                                  lambda: value.resolve())
+        with self._lock, self._no_recursive_get(stack):
+            if hasattr(stack, self.name):
+                return self.get_resolved_value(stack, stack_class)
 
-            if hasattr(instance, self.name):
-                retval = _call_func_on_values(
-                    resolve, getattr(instance, self.name), Resolver
-                )
-                return retval
-
-    def __set__(self, instance, value):
+    def __set__(self, stack: 'stack.Stack', value: Any):
         """
         Attribute setter which adds a stack reference to any resolvers in the
         data structure `value` and calls the setup method.
 
+        :param stack: The Stack instance the value is being set onto
+        :param value: The value being set on the property
         """
-        def setup(attr, key, value):
-            value.stack = instance
-            value.setup()
+        with self._lock:
+            self.assign_value_to_stack(stack, value)
+
+    @contextmanager
+    def _no_recursive_get(self, stack: 'stack.Stack'):
+        # We don't care about recursive gets on the same property but different Stack instances,
+        # only recursive gets on the same stack. Some Resolvers access the same property on OTHER
+        # stacks and that actually shouldn't be a problem. Remember, these descriptor instances are
+        # set on the CLASS and so instance variables on them are shared across all classes that
+        # access them. Thus, we set this "get_in_progress" attribute on the stack instance rather
+        # than the descriptor instance.
+        get_status_name = f'_{self.name}_get_in_progress'
+        if getattr(stack, get_status_name, False):
+            raise RecursiveResolve(f"Resolving Stack.{self.name[1:]} required resolving itself")
+        setattr(stack, get_status_name, True)
+        try:
+            yield
+        finally:
+            setattr(stack, get_status_name, False)
+
+    def get_setup_resolver_for_stack(self, stack: 'stack.Stack', resolver: Resolver) -> Resolver:
+        """Obtains a clone of the resolver with the stack set on it and the setup method having
+        been called on it.
+
+        :param stack: The stack to set on the Resolver
+        :param resolver: The Resolver to clone and set up
+        :return: The cloned resolver.
+        """
+        # We clone the resolver when we assign the value so that every stack gets its own resolver
+        # rather than potentially having one resolver instance shared in memory across multiple
+        # stacks.
+        clone = resolver.clone(stack)
+        clone.setup()
+        return clone
+
+    @abc.abstractmethod
+    def get_resolved_value(self, stack: 'stack.Stack', stack_class: Type['stack.Stack']) -> Any:
+        """Implement this method to return the value of the resolvable_property."""
+        pass
+
+    @abc.abstractmethod
+    def assign_value_to_stack(self, stack: 'stack.Stack', value: Any):
+        """Implement this method to assign the value to the resolvable property."""
+        pass
+
+    def resolve_resolver_value(self, resolver: 'Resolver') -> Any:
+        """Returns the resolved parameter value.
+
+        :param resolver: The resolver to resolve.
+        :return: The resolved value (or placeholder, in certain circumstances)
+        """
+        return resolver.resolve()
+
+    def __repr__(self) -> str:
+        return f'<{self.__class__.__name__}({self.name[1:]})>'
+
+
+class ResolvableContainerProperty(ResolvableProperty):
+    """
+    This is a descriptor class used to store an attribute that may CONTAIN
+    Resolver objects. Resolvers will be resolved upon access of this property.
+    When resolvers are resolved, they will be replaced in the container with their
+    resolved value, in order to avoid redundant resolutions.
+
+    Supports nested dictionary and lists.
+
+    :param name: Attribute suffix used to store the property in the instance.
+    :type name: str
+    """
+
+    def __get__(self, stack: 'stack.Stack', stack_class: Type['stack.Stack']) -> T_Container:
+        container = super().__get__(stack, stack_class)
 
         with self._lock:
-            _call_func_on_values(setup, value, Resolver)
-            setattr(instance, self.name, value)
+            # Resolve any deferred resolvers, now that the recursive get lock has been released.
+            self._resolve_deferred_resolvers(stack, container)
 
-    class ResolveLater(object):
+        return container
+
+    def get_resolved_value(self, stack: 'stack.Stack', stack_class: Type['stack.Stack']) -> T_Container:
+        """Obtains the resolved value for this property.
+
+        :param stack: The Stack instance to obtain the value for
+        :param stack_class: The class of the Stack instance.
+        :return: The fully resolved container.
+        """
+
+        def resolve(attr: Union[dict, list], key: Union[int, str], value: Resolver):
+            # Update the container key's value with the resolved value, if possible...
+            try:
+                result = self.resolve_resolver_value(value)
+                attr[key] = result
+            except RecursiveResolve:
+                # It's possible that resolving the resolver might attempt to access another
+                # resolvable property's value in this same container. In this case, we'll delay
+                # resolution and instead return a ResolveLater so the value can be resolved outside
+                # this recursion.
+                attr[key] = self.ResolveLater(
+                    stack,
+                    self.name,
+                    key,
+                    lambda: value.resolve(),
+                )
+
+        container = getattr(stack, self.name)
+        _call_func_on_values(
+            resolve, container, Resolver
+        )
+
+        return container
+
+    def assign_value_to_stack(self, stack: 'stack.Stack', value: Union[dict, list]):
+        """Assigns a COPY of the specified value to the stack instance. This method copies the value
+        rather than directly assigns it to avoid bugs related to shared objects in memory.
+
+        :param stack: The stack to assign the value to
+        :param value: The value to assign
+        """
+        cloned = self._clone_container_with_resolvers(value, stack)
+        setattr(stack, self.name, cloned)
+
+    def _clone_container_with_resolvers(
+        self,
+        container: T_Container,
+        stack: 'stack.Stack'
+    ) -> T_Container:
+        """Recurses into the container, cloning and setting up resolvers and creating a copy of all
+        nested containers.
+
+        :param container: The container being recursed into and cloned
+        :param stack: The stack the container is being copied for
+        :return: The fully copied container with resolvers fully set up.
+        """
+        def recurse(obj):
+            if isinstance(obj, Resolver):
+                return self.get_setup_resolver_for_stack(stack, obj)
+            if isinstance(obj, list):
+                return [
+                    recurse(item)
+                    for item in obj
+                ]
+            elif isinstance(obj, dict):
+                return {
+                    key: recurse(val)
+                    for key, val in obj.items()
+                }
+            return obj
+
+        return recurse(container)
+
+    def _resolve_deferred_resolvers(self, stack: 'stack.Stack', container: T_Container):
+        def raise_if_not_resolved(attr, key, value):
+            # If this function has been hit, it means that after attempting to resolve all the
+            # ResolveLaters, there STILL are ResolveLaters left in the container. Rather than
+            # continuing to try to resolve (possibly infinitely), we'll raise a RecursiveGet to
+            # break that infinite loop. This situation would happen if a resolver accesses a resolver
+            # in the same container, which then accesses another resolver (possibly the same one) in
+            # the same container.
+            raise RecursiveResolve(f"Resolving Stack.{self.name[1:]} required resolving itself")
+
+        has_been_resolved_attr_name = f'{self.name}_is_resolved'
+        if not getattr(stack, has_been_resolved_attr_name, False):
+            # We set it first rather than after to avoid entering this block again on this property
+            # for this stack.
+            setattr(stack, has_been_resolved_attr_name, True)
+            _call_func_on_values(
+                lambda attr, key, value: value(),
+                container,
+                self.ResolveLater
+            )
+            # Search the container to see if there are any ResolveLaters left;
+            # Raise a RecursiveResolve if there are.
+            _call_func_on_values(
+                raise_if_not_resolved,
+                container,
+                self.ResolveLater
+            )
+
+    class ResolveLater:
         """Represents a value that could not yet be resolved but can be resolved in the future."""
+
         def __init__(self, instance, name, key, resolution_function):
             self._instance = instance
             self._name = name
@@ -115,13 +289,3 @@ class ResolvableProperty(object):
             """Resolve the value."""
             attr = getattr(self._instance, self._name)
             attr[self._key] = self._resolution_function()
-
-    @contextmanager
-    def _no_recursive_get(self):
-        if self._get_in_progress:
-            raise RecursiveGet()
-        self._get_in_progress = True
-        try:
-            yield
-        finally:
-            self._get_in_progress = False

--- a/sceptre/resolvers/__init__.py
+++ b/sceptre/resolvers/__init__.py
@@ -66,9 +66,6 @@ class ResolvableProperty(abc.ABC):
     associated with Resolver objects.
 
     :param name: Attribute suffix used to store the property in the instance.
-    :param placeholder_override: If specified, this is the value that will be used as the placeholder
-        rather than the resolver's returned placeholder value, but only when placeholders are allowed
-        via the use_resolver_placeholders_on_error context manager.
     """
 
     def __init__(self, name):

--- a/sceptre/resolvers/__init__.py
+++ b/sceptre/resolvers/__init__.py
@@ -144,7 +144,7 @@ class ResolvableProperty(abc.ABC):
         """Returns the resolved parameter value.
 
         :param resolver: The resolver to resolve.
-        :return: The resolved value (or placeholder, in certain circumstances)
+        :return: The resolved value
         """
         return resolver.resolve()
 

--- a/sceptre/resolvers/__init__.py
+++ b/sceptre/resolvers/__init__.py
@@ -12,8 +12,6 @@ if TYPE_CHECKING:
 
 T_Container = TypeVar('T_Container', bound=Union[dict, list])
 
-logger = logging.getLogger(__name__)
-
 
 class RecursiveResolve(Exception):
     pass

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -108,11 +108,6 @@ class Stack(object):
             will result in no timeout. Supports only positive integer value.
     :type stack_timeout: int
 
-    :param is_project_dependency: Indicates whether or not the the stack is a\
-            special dependency of the stack. If True, disables all dependencies\
-            on the the current stack.
-    :type is_project_dependency: bool
-
     :param stack_group_config: The StackGroup config for the Stack
     :type stack_group_config: dict
 

--- a/tests/test_resolvers/test_resolver.py
+++ b/tests/test_resolvers/test_resolver.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from unittest.mock import call, Mock
+from unittest.mock import call
 
 import pytest
 from mock import sentinel, MagicMock

--- a/tests/test_resolvers/test_resolver.py
+++ b/tests/test_resolvers/test_resolver.py
@@ -310,3 +310,22 @@ class TestResolvableContainerPropertyDescriptor(object):
         }
         with pytest.raises(RecursiveResolve):
             self.mock_object.resolvable_container_property
+
+    def test_get__resolvable_container_property_references_same_property_of_other_stack__resolves(self):
+        stack1 = MockClass()
+        stack1.resolvable_container_property = {
+            'testing': 'stack1'
+        }
+
+        class OtherStackResolver(Resolver):
+            def resolve(self):
+                return stack1.resolvable_container_property['testing']
+
+        stack2 = MockClass()
+        stack2.resolvable_container_property = {
+            'resolver': OtherStackResolver()
+        }
+
+        assert stack2.resolvable_container_property == {
+            'resolver': 'stack1'
+        }

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -206,7 +206,7 @@ class TestStackSceptreUserData(object):
                 return self.stack.sceptre_user_data['primitive']
 
         stack = stack_factory()
-        stack._sceptre_user_data = {
+        stack.sceptre_user_data = {
             'primitive': sentinel.primitive_value,
             'resolved': TestResolver(stack=stack),
         }


### PR DESCRIPTION
This is the first in a series of pull requests that addresses #1114 , allowing Sceptre to manage its own dependencies.

## In this PR:
* **ResolvableProperty is refactored into a base class with a single subclass (for now): ResolvableContainerProperty.** _This refactor will be necessary so we can build on that base class to make a ResolvableValueProperty in a later PR so we can resolve single values like template_bucket_name, etc..._. 
* **The merge strategies list_join and dict_merge now perform deepcopy on the product of those joins,** preventing changes in child stack configs from modifying the same dict/list in memory that has been inherited by other child stack configs. This change is necessary so inheriting mutable values from parent configs becomes a lot safer.
* **A few bugs have been fixed in ResolvableProperty** in this refactor in preparation for changes that are to come in future Pull requests. These all have to do with being able to inherit resolvers and having more resolvers on stack configurations. 
    - Previously, the `_no_recursive_get` method was effectively blocking access to the same property on a DIFFERENT stack. If a resolver accesses the same property on another stack, there shouldn't be a problem with this. This is relevant in cases like the StackOutput resolver that accesses _another_ stack's attributes. This bug has been fixed now. `_no_recursive_get` specifically disallows recursive gets on the _current stack only_.
    - If a resolver was set on a StackGroup config and then "inherited" by multiple stack groups, the _exact same_ object in memory would now be on two stacks. Worse, they would both have the same Stack object assigned to them... which means that Stack A could use a resolver that was referencing Stack B. This has now been solved by resolvers being cloned when they are assigned to a stack, guaranteeing that every stack has an independent resolver in memory.
    - Deferred resolution is properly handled _within_ the property. Previously it wasn't, so we needed a weird double-layer property on the Stack class to handle sceptre_user_data. This is now no longer necessary and is handled where it should have been handled all along: in the property itself.
* **stack_tags is now a ResolvableProperty**, ultimately finishing what #847 attempted but never finished.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
