### PR TITLE
[Resolve #1114] Project Dependencies part 3: Resolvable iam_role

### DIFF
--- a/docs/_source/docs/permissions.rst
+++ b/docs/_source/docs/permissions.rst
@@ -1,0 +1,472 @@
+Sceptre and IAM
+===============
+
+Inevitably, when working with CloudFormation (or anything in AWS, really), IAM permissions are
+relevant. **By default, Sceptre uses the permissions of the user executing Sceptre commands when
+performing any of its actions.** Also, by default, CloudFormation uses the permissions of the user
+executing its actions when performing any of the actions on individual resources that it performs.
+
+This means that, by default, if the user executing Sceptre has admin-level permissions, there won't
+be any issue executing any actions. But this is often not a viable option. Organizations usually have
+few users with these permissions. Furthermore, there are legitimate reasons for not wanting to grant
+users (or CI/CD systems) admin-level permissions.
+
+Of course, admin-level AWS permissions aren't essential; At the end of the day, Sceptre and
+CloudFormation actually only need the permissions necessary to perform the required actions for a
+given project on the resources that will be managed by Sceptre/CloudFormation. The actual range of
+permissions required tends to be a much narrower scope than admin-level. Using Sceptre can indeed
+align with the "Principle of Least Privilege".
+
+Permissions Configurations
+--------------------------
+
+There are two main configurations for Sceptre that can modify default permissions behavior to
+provide more flexibility, control, and safety within an organization: **role_arn** and **iam_role**
+These can be applied in a very targeted way, on a stack by stack basis or can be applied broadly to a
+whole StackGroup.
+
+
+role_arn
+^^^^^^^^
+This is the **CloudFormation service role** that will be attached to a given CloudFormation stack.
+This IAM role needs to be able to be assumed by **CloudFormation**, and must provide all the
+necessary permissions for all create/read/update/delete operations for all resources defined in that
+stack. If CloudFormation can assume this role, the user executing Sceptre does not need those
+permissions.
+
+There are a few very important things to note about using a CloudFormation service role:
+
+* You cannot remove a role from a stack once you've added it. You'd have to delete and rebuild the
+  stack without it if you wanted to remove it. You *may*, however, replace one role with another on
+  the stack.
+* Once the role has been added to a stack, it will *always* be used for all actions; It doesn't matter
+  who is executing them; those permission cannot be overridden.
+* You cannot delete a stack with a service role unless that role has permissions to do so. This means
+  that an admin might need to add deletion permissions to that role before that stack can be removed.
+
+Applying a service role to a stack is a very effective way to grant (and limit) the scope of permissions
+that a stack can utilize, but the rigidity of using it might prove overly burdensome, depending on
+the use case.
+
+For more information on using CloudFormation service roles, see the `AWS documentation <https://docs.aws
+.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html>`_.
+
+As a resolvable property, Sceptre allows you to use a resolver to populate the ``role_arn`` for a
+Stack or StackGroup Config. This means you could define that role within your project, output its
+ARN, and then reference it using `!stack_output`.
+
+
+iam_role
+^^^^^^^^
+
+This is a **role that Sceptre will assume** when taking any actions on the Stack. It is not a service
+role for CloudFormation. Instead, this is simply a role that the current user assumes to execute
+any Sceptre actions on that stack. This has some benefits over a CloudFormation service role:
+
+* This is not permanently attached to the Stack after you've used it once. If you ever *don't* want
+  to assume this role, you could comment it out or remove it from the Stack Config and Sceptre simply
+  won't use it. This is useful if the user executing Sceptre already has the right permissions to
+  take those actions. In other words, it doesn't lock you in (unlike using ``role_arn``).
+* CloudFormation can continue to use it's default behavior of executing Stack actions with the
+  permissions of the current user, but it interprets the current user to be the indicated ``iam_role``,
+  which could grant additional permissions.
+
+Using the ``iam_role`` configuration on a Stack or StackGroup Config allows the user to temporarily
+"step into" a different set of permissions in order to execute Sceptre actions on Stack(s) in the
+project without having to permanently grant those permissions to that user.
+
+In order to use an ``iam_role`` on a Sceptre Stack Config, that role needs to have an
+AssumeRolePolicyDocument that allows the current user to assume it.
+
+As a resolvable property, Sceptre allows you to use a resolver to populate the ``iam_role`` for a
+Stack or StackGroup Config. This means you could define that role within your project, output its
+ARN, and then reference it using `!stack_output`.
+
+Configuring CI/CD Systems without Admin access
+----------------------------------------------
+
+One of the most useful ways to employ Sceptre is via an automated deployment pipeline powered by a
+tool like Jenkins or CircleCI. However, there are often organizational policies against giving such
+systems admin-level access to an AWS account. Sceptre *can* operate under these sorts of policies
+(with some careful planning).
+
+While requirements differ from use case to use case, the following might be a viable strategy could
+work for your organization. It can be entirely implemented using Sceptre.
+
+* **The permissions boundary**: Your organization defines a managed policy to use as a `permissions boundary
+  <https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html>`_ that defines the
+  maximum range of permissions that could possibly be assumed by a "deployment role" (see below).
+
+  * A permissions boundary can require that any IAM roles created also possess a given permissions
+    boundary, so if your project needs to create other IAM roles, the boundary could constrain the
+    scope of permissions those other roles could create. If this is the case, you might want to create
+    two separate permissions boundaries; One of the deployment role and one for roles created by the
+    deployment role.
+  * **Remember: A permissions boundary doesn't actually *grant* any permissions; it only defines the
+    maximum range of permissions that *could* be granted.** You can use it to protect your
+    "untouchable" resources that you don't want the CI/CD system to affect.
+  * You should set the path on the permissions boundary to a special namespace,
+    like "deployment" and the expressly prohibit any role with this permissions boundary from taking
+    any create/update/delete action on any IAM resources on that path. This will prevent the CI/CD
+    system from being able to escalate or alter its own permissions.
+* **The deployment role**: This is the role that will be **assumed** (not possessed) by the CI/CD
+  system, empowering it to deploy your Sceptre project.
+
+  * It must have an AssumeRolePolicyDocument that *only* permits the user/role of the CI/CD system
+    to assume it. Thus you can prevent anyone else in the organization from assuming it.
+  * This role should have all the permissions Sceptre requires to perform its deployments on all the
+    sorts of resources it needs. So long as the permissions boundary guards against unwanted actions,
+    permissions on the deployment role can be rather broad since it will be constrained by the
+    permissions boundary.
+  * You should set the path on the deployment role to the same path as the permissions boundary.
+* **Set the ``iam_role``** on all Sceptre Stacks *that are not the permissions boundary or deployment
+  role* as the ARN of the `deployment_role`. This means that the CI/CD system will be instructed to
+  step into the deployment role to execute the actions on all stacks except the deployment role or
+  permissions boundary stack.
+* **Have an AWS Admin user *manually* deploy** the permissions boundary and deployment role with
+  Sceptre.
+* **The CI/CD system will be able to assume the deployment role** to launch the rest of your project
+  safely within the bounds of that role, but will not be able to deploy any changes to that role or
+  its permissions boundary.
+
+Example
+^^^^^^^
+
+.. code-block:: yaml
+
+    AWSTemplateFormatVersion: "2010-09-09"
+
+    Parameters:
+        DeployerArn:
+            Type: String
+            Description: The ARN of the IAM user/role to allow the role to be assumed by
+        CreatedResourcesPath:
+            Type: String
+            Description: >-
+                The Path that the Deployment Role will need to create IAM resources on. This is
+                effectively the namespace that all IAM resources created by the CI/CD will be under.
+                This will prevent naming conflicts as well as prevent the CI/CD system from being
+                able to operate on OTHER resources not in this namespace. This path cannot be
+                "deployment" and cannot include slashes.
+            AllowedPattern: '(?!deployment)[a-z_]*'
+
+    Resources:
+        # This is the permissions boundary that MUST be on all roles CREATED BY the Deployment
+        # Role. In other words, the Deployment Role can only create roles that have fewer
+        # permissions than itself. As a permissions boundary, this provides the maximum set
+        # of permissions that can possibly be added to a given role created by the Deployment
+        # Role. It currently does not allow any create/update IAM permissions and has some explicit
+        CreatedRolePermissionsBoundary:
+            Type: AWS::IAM::ManagedPolicy
+            Properties:
+                Description: The permissions boundary that MUST be on all roles created by deployment roles
+                # This is on the DEPLOYMENT path, not the created resources path, so it cannot be
+                # tinkered with by the CI/CD system
+                Path: /deployment/
+                PolicyDocument:
+                    Version: "2012-10-17"
+                    Statement:
+                        # Because this is a permissions boundary, we don't want to unnecessarily exclude
+                        # any actions. Remember: Permissions boundaries don't GRANT permissions, they
+                        # only define the full range of permissions that CAN be granted by a given role's
+                        # policies. In this case, we'll allow anything NOT related to iam.
+                        -   Sid: AllowNonIAMActions
+                            Effect: Allow
+                            NotAction: "iam:*"
+                            Resource: "*"
+                        # This statement allows created roles Read-only permissions on IAM resources
+                        -   Sid: AllowIAMReadActions
+                            Effect: Allow
+                            Resource: "*"
+                            Action:
+                                - iam:Get*
+                                - iam:List*
+                        # This is an explicit denial on any actions performed on resources tagged
+                        # with the "Environment" tag and the value of "Protected". So long
+                        # as you have been diligent with tagging, this will work just fine. But you
+                        # can deny any number of things you want to protect. This is just an example
+                        -   Sid: DenyProtectedActions
+                            Effect: Deny
+                            Action: "*"
+                            Resource: "*"
+                            Condition:
+                                StringLike
+                                    aws:ResourceTag/Environment:
+                                        - Protected
+
+        # This role will be assumed by the CI/CD system temporarily in order to deploy the CloudFormation
+        # changes. As a permissions boundary, this does not actually GRANT the role any permissions,
+        # but rather defines the maximum range of permissions that can be granted to that role.
+        DeploymentRolePermissionsBoundary:
+            Type: AWS::IAM::ManagedPolicy
+            Properties:
+                Description: The Permissions Boundary to be used for deployment.
+                # This is on the DEPLOYMENT path, not the created resources path, so it cannot be
+                # tinkered with by the CI/CD system.
+                Path: /deployment/
+                PolicyDocument:
+                    Version: "2012-10-17"
+                    Statement:
+                        # This statement ALLOWS the DeploymentRole to create roles and attach policies
+                        # to roles, but ONLY roles that (1) are namespaced with the CreatedResources path
+                        # and (2) have the CreatedRolePermissionsBoundary on them.
+                        -   Sid: IAMRoleUpdationActions
+                            Effect: Allow
+                            Action:
+                                - iam:CreateRole
+                                - iam:PutRolePolicy
+                                - iam:UpdateRole
+                                - iam:UpdateRoleDescription
+                                - iam:DeleteRolePolicy
+                                - iam:AttachRolePolicy
+                                - iam:DetachRolePolicy
+                                - iam:PutRolePermissionsBoundary
+                            # These operations are only allowed on the created resources path, NOT on
+                            # the deployment path, which means the Deployment Role cannot expand its own
+                            # permissions. It's also relevant to note that this assumes the created role
+                            # is TAGGED with the CreatedResourcesPath tag, which must have a valid value
+                            # in order to be allowed to utilize these permissions.
+                            Resource: !Sub "arn:aws:iam::${AWS::AccountId}:role/${!aws:PrincipalTag/CreatedResourcesPath}/*"
+                            Condition:
+                                # This condition is SUPER important. It means that the only roles that can
+                                # be created or updated with policies are those that have the permissions
+                                # boundary listed above.
+                                StringEquals:
+                                    "iam:PermissionsBoundary": !Ref CreatedRolePermissionsBoundary
+                                # This means that the only way that any of these actions can be allowed
+                                # are if CloudFormation is directly invoking these. The Deployer cannot
+                                # execute these actions directly, even if they've assumed the right role
+                                # with the right permissions.
+                                "ForAnyValue:StringEquals":
+                                    "aws:CalledVia": [ 'cloudformation.amazonaws.com' ]
+                        # This controls other IAM actions and ensures that they can ONLY be enacted upon
+                        # roles that are on the CreatedResourcesPath, NOT the Deployment path.
+                        -   Sid: IamRoleActions
+                            Effect: Allow
+                            Action:
+                                - iam:DeleteRole
+                                - iam:DeleteServiceLinkedRole
+                                - iam:PassRole
+                                - iam:TagRole
+                                - iam:UntagRole
+                            # These actions are only allowed within the configured CreatedResourcesPath,
+                            # as indicated by that tag on the deploying role.
+                            Resource: !Sub "arn:aws:iam::${AWS::AccountId}:role/${!aws:PrincipalTag/CreatedResourcesPath}/*"
+                            Condition:
+                                # These actions cannot happen unless they were directly invoked by
+                                # CloudFormation. A deployer cannot trigger these actions directly.
+                                "ForAnyValue:StringEquals":
+                                    "aws:CalledVia": [ 'cloudformation.amazonaws.com' ]
+                        # Similarly, The only policies that can be managed are those namespaced by the
+                        # CreatedResourcesPath. The Deployment role cannot mess with other roles.
+                        -   Sid: IAMPolicyUpdateActions
+                            Effect: Allow
+                            Action:
+                                - iam:CreatePolicy
+                                - iam:CreatePolicyVersion
+                                - iam:DeletePolicy
+                                - iam:DeletePolicyVersion
+                                - iam:TagPolicy
+                                - iam:UntagPolicy
+                            # These actions are only allowed within the configured CreatedResourcesPath,
+                            # as indicated by that tag on the deploying role.
+                            Resource: !Sub "arn:aws:iam::${AWS::AccountId}:policy/${!aws:PrincipalTag/CreatedResourcesPath}/*"
+                            Condition:
+                                "ForAnyValue:StringEquals":
+                                    "aws:CalledVia": [ 'cloudformation.amazonaws.com' ]
+                        # We will allow all read operations for the Deployment role on all resources.
+                        # This shouldn't actually involve any real risk, since it is read-only.
+                        -   Sid: AllowIAMReadAccess
+                            Effect: Allow
+                            Action:
+                                - iam:Get*
+                                - iam:List*
+                            Resource: "*"
+                        # In order to restrict operations that are done to only those originating with
+                        # CloudFormation, we then need to allow operations on CloudFormation directly
+                        # from this permissions boundary.
+                        -   Sid: AllowCloudFormationActions
+                            Effect: Allow
+                            Action: "cloudformation:*"
+                            Resource: "*"
+                        # All other actions are allowed in this permissions boundary except IAM actions
+                        # that haven't already been allowed for elsewhere within this boundary. In other
+                        # words, you couldn't set up a new SAML provider or create an IAM user, but you
+                        # CAN create an IAM Role (under certain circumstances), since that permission is
+                        # allowed above. Remember: Permissions boundaries don't GRANT permissions, they
+                        # only define the maximum range of permissions that CAN be granted.
+                        -   Sid: AllowEverythingElseButIAMFromCloudFormation
+                            Effect: Allow
+                            # Meaning everything EXCEPT iam operations not otherwise accounted for or
+                            # denied.
+                            NotAction: "iam:*"
+                            Resource: "*"
+                            Condition:
+                                # While we might allow the POSSIBILITY of broad permissions not otherwise
+                                # accounted for or denied, we only want to allow those permissions to be
+                                # executed via CloudFormation (or at least set off by CloudFormation).
+                                # By using CalledViaFirst, we allow the possibility of a passed role from
+                                # CloudFormation to some other service to execute actions, but
+                                # CloudFormation must ultimately be responsible for that execution.
+                                "ForAnyValue:StringEquals":
+                                    "aws:CalledViaFirst": [ 'cloudformation.amazonaws.com' ]
+                        # Some operations need to precede CloudFormation operations, such as putting a
+                        # cloudformation template or other sort of artifact onto S3 prior to triggering
+                        # deployment via CloudFormation.
+                        -   Sid: AllowS3PutObjectToPutTemplates
+                            Effect: Allow
+                            Resource: "*"
+                            Action:
+                                - "s3:PutObject"
+                                - "s3:GetBucketLocation"
+                                - "s3:ListBucket"
+                        # This is an explicit denial on any actions performed on resources tagged
+                        # with the "Environment" tag and the value of "Protected". You
+                        # can deny any number of things you want to protect. This is just an example
+                        -   Sid: DenyProtectedActions
+                            Effect: Deny
+                            Action: "*"
+                            Resource: "*"
+                            Condition:
+                                StringLike
+                                    aws:ResourceTag/Environment:
+                                        - Protected
+
+        # This is the role that will be ASSUMED by the CI/CD system in order to deploy the all cloudformation
+        # resources for this project, including any IAM-based resources. It will be constrained by the
+        # DeploymentRolePermissionsBoundary, which will limit the scope of its permissions.
+        DeploymentRole:
+            Type: AWS::IAM::Role
+            Properties:
+                Description: >-
+                    This is the role Jenkins will use in order to deploy changes using Sceptre. It
+                    has broad permissions, but it's important to note that it also has a defined
+                    permissions boundary that limits the range and scope of those permissions. This
+                    role DOES have the ability to effect IAM changes, but only those within the right
+                    path and explicitly allowed for within the permissions boundary.
+                # We use a permissions boundary to define the maximum range of permissions that could
+                # possibly be assumed by this role. This makes it safer to provide more generic permissions
+                # on this role, like "PowerUserAccess".
+                PermissionsBoundary: !Ref DeploymentRolePermissionsBoundary
+                AssumeRolePolicyDocument:
+                    Version: "2012-10-17"
+                    Statement:
+                        -   Effect: "Allow"
+                            Principal:
+                                # This role can ONLY be assumed by the configured deployer, which
+                                # should be your CI/CD system's role.
+                                AWS:
+                                    - !Ref DeployerArn
+                            Action: "sts:AssumeRole"
+                # Because this is on the DEPLOYMENT path, not the created resources path, this role is
+                # unable to alter itself, due to the permissions boundary on it.
+                Path: !Sub "/deployment/${CreatedResourcesPath}/"
+                ManagedPolicyArns:
+                    # These permissions are pretty broad, but remember, they cannot go beyond the
+                    # defined permissions boundary, so they are always going to be constrained by that.
+                    # PowerUserAccess has the ability to update MOST things, but has no IAM permissions
+                    - "arn:aws:iam::aws:policy/PowerUserAccess"
+                    - "arn:aws:iam::aws:policy/IAMReadOnlyAccess"
+                Tags:
+                    # This tag is required by the permissions boundary to ensure that this role can only
+                    # operate on resources on that path.
+                    -   Key: "CreatedResourcesPath"
+                        Value: !Ref CreatedResourcesPath
+
+        # This is a special inline policy we'll add to the managed policies above. It lets the deployment
+        # role perform the required IAM operations within the created resources path. Remember, the
+        # permissions boundary set on the deployment role will constrain these permissions further.
+        IamCreationPolicy:
+            Type: AWS::IAM::Policy
+            Properties:
+                PolicyName: IAMCreationPolicy
+                Roles:
+                    - !Ref DeploymentRole
+                PolicyDocument:
+                    Version: "2012-10-17"
+                    Statement:
+                        # This statement allows IAM role Create/update/delete permissions for the
+                        # Deployment role, but only on those roles that are namespaced with the Created
+                        # Resources path. Note: The role's permission boundary will constrain these
+                        # Permissions further.
+                        -   Sid: AllowIAMRoleActions
+                            Effect: Allow
+                            Action:
+                                - iam:CreateRole
+                                - iam:CreateServiceLinkedRole
+                                - iam:PutRolePolicy
+                                - iam:UpdateRole
+                                - iam:UpdateRoleDescription
+                                - iam:DeleteRole
+                                - iam:DeleteServiceLinkedRole
+                                - iam:DeleteRolePolicy
+                                - iam:AttachRolePolicy
+                                - iam:DetachRolePolicy
+                                - iam:TagRole
+                                - iam:UntagRole
+                                - iam:PutRolePermissionsBoundary
+                                - iam:PassRole
+                            Resource: !Sub "arn:aws:iam::${AWS::AccountId}:role/${CreatedResourcesPath}/*"
+                        # This statement allows for IAM Policy create/update/delete permissions for the
+                        # Deployment role, but only those policies that are namespaced with the Created
+                        # Resources path. Note: The permissions boundary on the role will constraint these
+                        # permissions further.
+                        -   Sid: IAMPolicyActions
+                            Effect: Allow
+                            Action:
+                                - iam:CreatePolicy
+                                - iam:CreatePolicyVersion
+                                - iam:DeletePolicy
+                                - iam:DeletePolicyVersion
+                                - iam:TagPolicy
+                                - iam:UntagPolicy
+                            Resource: !Sub "arn:aws:iam::${AWS::AccountId}:policy/${CreatedResourcesPath}/*"
+
+
+
+Basic permissions that Sceptre requires
+---------------------------------------
+
+There are certain permissions that Sceptre requires to perform even its most basic operations. These
+include:
+
+Basic operations:
+
+* cloudformation:CreateStack
+* cloudformation:DeleteStack
+* cloudformation:DescribeStackEvents
+* cloudformation:DescribeStackResource
+* cloudformation:DescribeStackResources
+* cloudformation:DescribeStacks
+* cloudformation:GetStackPolicy
+* cloudformation:GetTemplate
+* cloudformation:GetTemplateSummary
+* cloudformation:ListStackResources
+* cloudformation:ListStacks
+* cloudformation:SetStackPolicy
+* cloudformation:TagResource
+* cloudformation:UntagResource
+* cloudformation:UpdateStack
+* cloudformation:UpdateTerminationProtection
+* cloudformation:ValidateTemplate
+
+If using change sets:
+
+* cloudformation:CreateChangeSet
+* cloudformation:DeleteChangeSet
+* cloudformation:DescribeChangeSet
+* cloudformation:ExecuteChangeSet
+* cloudformation:ListChangeSets
+
+If using a template bucket:
+
+* s3:CreateBucket
+* s3:PutObject
+
+If using ``role_arn``:
+
+* iam:PassRole
+
+If using ``iam_role``:
+
+* sts:AssumeRole

--- a/docs/_source/docs/permissions.rst
+++ b/docs/_source/docs/permissions.rst
@@ -1,29 +1,28 @@
 Sceptre and IAM
 ===============
 
-Inevitably, when working with CloudFormation (or anything in AWS, really), IAM permissions are
-relevant. **By default, Sceptre uses the permissions of the user executing Sceptre commands when
-performing any of its actions.** Also, by default, CloudFormation uses the permissions of the user
-executing its actions when performing any of the actions on individual resources that it performs.
+Inevitably, when working with CloudFormation, IAM permissions are relevant. **By default, Sceptre
+uses the permissions of the user executing Sceptre commands when performing any of its actions.**
+Also, by default, CloudFormation uses the permissions of the user executing its actions when
+performing actions on individual resources within those stacks.
 
 This means that, by default, if the user executing Sceptre has admin-level permissions, there won't
 be any issue executing any actions. But this is often not a viable option. Organizations usually have
 few users with these permissions. Furthermore, there are legitimate reasons for not wanting to grant
-users (or CI/CD systems) admin-level permissions.
+users (or CI/CD systems like Jenkins) admin-level permissions.
 
 Of course, admin-level AWS permissions aren't essential; At the end of the day, Sceptre and
 CloudFormation actually only need the permissions necessary to perform the required actions for a
-given project on the resources that will be managed by Sceptre/CloudFormation. The actual range of
-permissions required tends to be a much narrower scope than admin-level. Using Sceptre can indeed
-align with the "Principle of Least Privilege".
+given project on the resources that will be managed by them. The actual range of permissions required
+tends to be a much narrower scope than admin-level.
 
 Permissions Configurations
 --------------------------
 
-There are two main configurations for Sceptre that can modify default permissions behavior to
-provide more flexibility, control, and safety within an organization: **role_arn** and **iam_role**
-These can be applied in a very targeted way, on a stack by stack basis or can be applied broadly to a
-whole StackGroup.
+There are three main configurations for Sceptre that can modify default permissions behavior to
+provide more flexibility, control, and safety within an organization: **role_arn**, **iam_role**, and
+**profile**. These can be applied in a very targeted way, on a stack by stack basis or can be applied
+broadly to a whole StackGroup.
 
 
 role_arn
@@ -32,7 +31,7 @@ This is the **CloudFormation service role** that will be attached to a given Clo
 This IAM role needs to be able to be assumed by **CloudFormation**, and must provide all the
 necessary permissions for all create/read/update/delete operations for all resources defined in that
 stack. If CloudFormation can assume this role, the user executing Sceptre does not need those
-permissions.
+permissions, only ``iam:PassRole`` permissions on that role to give it to CloudFormation.
 
 There are a few very important things to note about using a CloudFormation service role:
 
@@ -40,9 +39,11 @@ There are a few very important things to note about using a CloudFormation servi
   stack without it if you wanted to remove it. You *may*, however, replace one role with another on
   the stack.
 * Once the role has been added to a stack, it will *always* be used for all actions; It doesn't matter
-  who is executing them; those permission cannot be overridden.
-* You cannot delete a stack with a service role unless that role has permissions to do so. This means
-  that an admin might need to add deletion permissions to that role before that stack can be removed.
+  who is executing them; those permission cannot be overridden without modifying the role itself or
+  replacing it with another role.
+* You cannot delete a stack with a service role unless that role has permissions to delete those
+  resources. This means that an admin might need to add deletion permissions to that role before that
+  stack can be removed.
 
 Applying a service role to a stack is a very effective way to grant (and limit) the scope of permissions
 that a stack can utilize, but the rigidity of using it might prove overly burdensome, depending on
@@ -68,361 +69,72 @@ any Sceptre actions on that stack. This has some benefits over a CloudFormation 
   won't use it. This is useful if the user executing Sceptre already has the right permissions to
   take those actions. In other words, it doesn't lock you in (unlike using ``role_arn``).
 * CloudFormation can continue to use it's default behavior of executing Stack actions with the
-  permissions of the current user, but it interprets the current user to be the indicated ``iam_role``,
+  permissions of the current user, but it interprets the current user to hold the indicated ``iam_role``,
   which could grant additional permissions.
 
-Using the ``iam_role`` configuration on a Stack or StackGroup Config allows the user to temporarily
+Using the ``iam_role`` configuration on a Stack or StackGroup Config allows the user to *temporarily*
 "step into" a different set of permissions in order to execute Sceptre actions on Stack(s) in the
-project without having to permanently grant those permissions to that user.
+project without having to permanently hold those permissions.
 
 In order to use an ``iam_role`` on a Sceptre Stack Config, that role needs to have an
-AssumeRolePolicyDocument that allows the current user to assume it.
+AssumeRolePolicyDocument that allows the current user to assume it and permissions to perform all
+deployment actions on the stack and all its resources.
 
 As a resolvable property, Sceptre allows you to use a resolver to populate the ``iam_role`` for a
 Stack or StackGroup Config. This means you could define that role within your project, output its
 ARN, and then reference it using `!stack_output`.
 
-Configuring CI/CD Systems without Admin access
-----------------------------------------------
-
-One of the most useful ways to employ Sceptre is via an automated deployment pipeline powered by a
-tool like Jenkins or CircleCI. However, there are often organizational policies against giving such
-systems admin-level access to an AWS account. Sceptre *can* operate under these sorts of policies
-(with some careful planning).
-
-While requirements differ from use case to use case, the following might be a viable strategy could
-work for your organization. It can be entirely implemented using Sceptre.
-
-* **The permissions boundary**: Your organization defines a managed policy to use as a `permissions boundary
-  <https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html>`_ that defines the
-  maximum range of permissions that could possibly be assumed by a "deployment role" (see below).
-
-  * A permissions boundary can require that any IAM roles created also possess a given permissions
-    boundary, so if your project needs to create other IAM roles, the boundary could constrain the
-    scope of permissions those other roles could create. If this is the case, you might want to create
-    two separate permissions boundaries; One of the deployment role and one for roles created by the
-    deployment role.
-  * **Remember: A permissions boundary doesn't actually *grant* any permissions; it only defines the
-    maximum range of permissions that *could* be granted.** You can use it to protect your
-    "untouchable" resources that you don't want the CI/CD system to affect.
-  * You should set the path on the permissions boundary to a special namespace,
-    like "deployment" and the expressly prohibit any role with this permissions boundary from taking
-    any create/update/delete action on any IAM resources on that path. This will prevent the CI/CD
-    system from being able to escalate or alter its own permissions.
-* **The deployment role**: This is the role that will be **assumed** (not possessed) by the CI/CD
-  system, empowering it to deploy your Sceptre project.
-
-  * It must have an AssumeRolePolicyDocument that *only* permits the user/role of the CI/CD system
-    to assume it. Thus you can prevent anyone else in the organization from assuming it.
-  * This role should have all the permissions Sceptre requires to perform its deployments on all the
-    sorts of resources it needs. So long as the permissions boundary guards against unwanted actions,
-    permissions on the deployment role can be rather broad since it will be constrained by the
-    permissions boundary.
-  * You should set the path on the deployment role to the same path as the permissions boundary.
-* **Set the ``iam_role``** on all Sceptre Stacks *that are not the permissions boundary or deployment
-  role* as the ARN of the `deployment_role`. This means that the CI/CD system will be instructed to
-  step into the deployment role to execute the actions on all stacks except the deployment role or
-  permissions boundary stack.
-* **Have an AWS Admin user *manually* deploy** the permissions boundary and deployment role with
-  Sceptre.
-* **The CI/CD system will be able to assume the deployment role** to launch the rest of your project
-  safely within the bounds of that role, but will not be able to deploy any changes to that role or
-  its permissions boundary.
-
-Example
+profile
 ^^^^^^^
 
-.. code-block:: yaml
+This is different from ``role_arn`` and ``iam_role``, as both of those cause CloudFormation or
+Sceptre to *assume* a different role with different permissions than the permissions the current
+user has.
 
-    AWSTemplateFormatVersion: "2010-09-09"
+In contrast, the ``profile`` is simply an instruction for the underlying AWS SDK to reference that
+profile in the user's local AWS configuration. It indicates which set of *credentials* to use when
+operating on a given Stack or StackGroup. There is no call to AWS STS to assume a role temporarily.
 
-    Parameters:
-        DeployerArn:
-            Type: String
-            Description: The ARN of the IAM user/role to allow the role to be assumed by
-        CreatedResourcesPath:
-            Type: String
-            Description: >-
-                The Path that the Deployment Role will need to create IAM resources on. This is
-                effectively the namespace that all IAM resources created by the CI/CD will be under.
-                This will prevent naming conflicts as well as prevent the CI/CD system from being
-                able to operate on OTHER resources not in this namespace. This path cannot be
-                "deployment" and cannot include slashes.
-            AllowedPattern: '(?!deployment)[a-z_]*'
+Utilizing the ``profile`` configuration is identical to setting the ``AWS_PROFILE`` environment
+variable, which has the same effect.
 
-    Resources:
-        # This is the permissions boundary that MUST be on all roles CREATED BY the Deployment
-        # Role. In other words, the Deployment Role can only create roles that have fewer
-        # permissions than itself. As a permissions boundary, this provides the maximum set
-        # of permissions that can possibly be added to a given role created by the Deployment
-        # Role. It currently does not allow any create/update IAM permissions and has some explicit
-        CreatedRolePermissionsBoundary:
-            Type: AWS::IAM::ManagedPolicy
-            Properties:
-                Description: The permissions boundary that MUST be on all roles created by deployment roles
-                # This is on the DEPLOYMENT path, not the created resources path, so it cannot be
-                # tinkered with by the CI/CD system
-                Path: /deployment/
-                PolicyDocument:
-                    Version: "2012-10-17"
-                    Statement:
-                        # Because this is a permissions boundary, we don't want to unnecessarily exclude
-                        # any actions. Remember: Permissions boundaries don't GRANT permissions, they
-                        # only define the full range of permissions that CAN be granted by a given role's
-                        # policies. In this case, we'll allow anything NOT related to iam.
-                        -   Sid: AllowNonIAMActions
-                            Effect: Allow
-                            NotAction: "iam:*"
-                            Resource: "*"
-                        # This statement allows created roles Read-only permissions on IAM resources
-                        -   Sid: AllowIAMReadActions
-                            Effect: Allow
-                            Resource: "*"
-                            Action:
-                                - iam:Get*
-                                - iam:List*
-                        # This is an explicit denial on any actions performed on resources tagged
-                        # with the "Environment" tag and the value of "Protected". So long
-                        # as you have been diligent with tagging, this will work just fine. But you
-                        # can deny any number of things you want to protect. This is just an example
-                        -   Sid: DenyProtectedActions
-                            Effect: Deny
-                            Action: "*"
-                            Resource: "*"
-                            Condition:
-                                StringLike
-                                    aws:ResourceTag/Environment:
-                                        - Protected
+Tips for working with Sceptre, IAM, and a CI/CD system
+------------------------------------------------------
 
-        # This role will be assumed by the CI/CD system temporarily in order to deploy the CloudFormation
-        # changes. As a permissions boundary, this does not actually GRANT the role any permissions,
-        # but rather defines the maximum range of permissions that can be granted to that role.
-        DeploymentRolePermissionsBoundary:
-            Type: AWS::IAM::ManagedPolicy
-            Properties:
-                Description: The Permissions Boundary to be used for deployment.
-                # This is on the DEPLOYMENT path, not the created resources path, so it cannot be
-                # tinkered with by the CI/CD system.
-                Path: /deployment/
-                PolicyDocument:
-                    Version: "2012-10-17"
-                    Statement:
-                        # This statement ALLOWS the DeploymentRole to create roles and attach policies
-                        # to roles, but ONLY roles that (1) are namespaced with the CreatedResources path
-                        # and (2) have the CreatedRolePermissionsBoundary on them.
-                        -   Sid: IAMRoleUpdationActions
-                            Effect: Allow
-                            Action:
-                                - iam:CreateRole
-                                - iam:PutRolePolicy
-                                - iam:UpdateRole
-                                - iam:UpdateRoleDescription
-                                - iam:DeleteRolePolicy
-                                - iam:AttachRolePolicy
-                                - iam:DetachRolePolicy
-                                - iam:PutRolePermissionsBoundary
-                            # These operations are only allowed on the created resources path, NOT on
-                            # the deployment path, which means the Deployment Role cannot expand its own
-                            # permissions. It's also relevant to note that this assumes the created role
-                            # is TAGGED with the CreatedResourcesPath tag, which must have a valid value
-                            # in order to be allowed to utilize these permissions.
-                            Resource: !Sub "arn:aws:iam::${AWS::AccountId}:role/${!aws:PrincipalTag/CreatedResourcesPath}/*"
-                            Condition:
-                                # This condition is SUPER important. It means that the only roles that can
-                                # be created or updated with policies are those that have the permissions
-                                # boundary listed above.
-                                StringEquals:
-                                    "iam:PermissionsBoundary": !Ref CreatedRolePermissionsBoundary
-                                # This means that the only way that any of these actions can be allowed
-                                # are if CloudFormation is directly invoking these. The Deployer cannot
-                                # execute these actions directly, even if they've assumed the right role
-                                # with the right permissions.
-                                "ForAnyValue:StringEquals":
-                                    "aws:CalledVia": [ 'cloudformation.amazonaws.com' ]
-                        # This controls other IAM actions and ensures that they can ONLY be enacted upon
-                        # roles that are on the CreatedResourcesPath, NOT the Deployment path.
-                        -   Sid: IamRoleActions
-                            Effect: Allow
-                            Action:
-                                - iam:DeleteRole
-                                - iam:DeleteServiceLinkedRole
-                                - iam:PassRole
-                                - iam:TagRole
-                                - iam:UntagRole
-                            # These actions are only allowed within the configured CreatedResourcesPath,
-                            # as indicated by that tag on the deploying role.
-                            Resource: !Sub "arn:aws:iam::${AWS::AccountId}:role/${!aws:PrincipalTag/CreatedResourcesPath}/*"
-                            Condition:
-                                # These actions cannot happen unless they were directly invoked by
-                                # CloudFormation. A deployer cannot trigger these actions directly.
-                                "ForAnyValue:StringEquals":
-                                    "aws:CalledVia": [ 'cloudformation.amazonaws.com' ]
-                        # Similarly, The only policies that can be managed are those namespaced by the
-                        # CreatedResourcesPath. The Deployment role cannot mess with other roles.
-                        -   Sid: IAMPolicyUpdateActions
-                            Effect: Allow
-                            Action:
-                                - iam:CreatePolicy
-                                - iam:CreatePolicyVersion
-                                - iam:DeletePolicy
-                                - iam:DeletePolicyVersion
-                                - iam:TagPolicy
-                                - iam:UntagPolicy
-                            # These actions are only allowed within the configured CreatedResourcesPath,
-                            # as indicated by that tag on the deploying role.
-                            Resource: !Sub "arn:aws:iam::${AWS::AccountId}:policy/${!aws:PrincipalTag/CreatedResourcesPath}/*"
-                            Condition:
-                                "ForAnyValue:StringEquals":
-                                    "aws:CalledVia": [ 'cloudformation.amazonaws.com' ]
-                        # We will allow all read operations for the Deployment role on all resources.
-                        # This shouldn't actually involve any real risk, since it is read-only.
-                        -   Sid: AllowIAMReadAccess
-                            Effect: Allow
-                            Action:
-                                - iam:Get*
-                                - iam:List*
-                            Resource: "*"
-                        # In order to restrict operations that are done to only those originating with
-                        # CloudFormation, we then need to allow operations on CloudFormation directly
-                        # from this permissions boundary.
-                        -   Sid: AllowCloudFormationActions
-                            Effect: Allow
-                            Action: "cloudformation:*"
-                            Resource: "*"
-                        # All other actions are allowed in this permissions boundary except IAM actions
-                        # that haven't already been allowed for elsewhere within this boundary. In other
-                        # words, you couldn't set up a new SAML provider or create an IAM user, but you
-                        # CAN create an IAM Role (under certain circumstances), since that permission is
-                        # allowed above. Remember: Permissions boundaries don't GRANT permissions, they
-                        # only define the maximum range of permissions that CAN be granted.
-                        -   Sid: AllowEverythingElseButIAMFromCloudFormation
-                            Effect: Allow
-                            # Meaning everything EXCEPT iam operations not otherwise accounted for or
-                            # denied.
-                            NotAction: "iam:*"
-                            Resource: "*"
-                            Condition:
-                                # While we might allow the POSSIBILITY of broad permissions not otherwise
-                                # accounted for or denied, we only want to allow those permissions to be
-                                # executed via CloudFormation (or at least set off by CloudFormation).
-                                # By using CalledViaFirst, we allow the possibility of a passed role from
-                                # CloudFormation to some other service to execute actions, but
-                                # CloudFormation must ultimately be responsible for that execution.
-                                "ForAnyValue:StringEquals":
-                                    "aws:CalledViaFirst": [ 'cloudformation.amazonaws.com' ]
-                        # Some operations need to precede CloudFormation operations, such as putting a
-                        # cloudformation template or other sort of artifact onto S3 prior to triggering
-                        # deployment via CloudFormation.
-                        -   Sid: AllowS3PutObjectToPutTemplates
-                            Effect: Allow
-                            Resource: "*"
-                            Action:
-                                - "s3:PutObject"
-                                - "s3:GetBucketLocation"
-                                - "s3:ListBucket"
-                        # This is an explicit denial on any actions performed on resources tagged
-                        # with the "Environment" tag and the value of "Protected". You
-                        # can deny any number of things you want to protect. This is just an example
-                        -   Sid: DenyProtectedActions
-                            Effect: Deny
-                            Action: "*"
-                            Resource: "*"
-                            Condition:
-                                StringLike
-                                    aws:ResourceTag/Environment:
-                                        - Protected
+* Rather than giving your CI/CD system blanket, admin-level permissions, you can define an IAM role
+  with Sceptre to use for deploying the rest of your infrastructure, outputing its ARN in the template.
+  Then, in the rest of your project's stacks, you can set the ``iam_role`` using ``!stack_output``
+  to get that role's arn. This will mean your CI/CD system will temporarily "step into" that role
+  when using Sceptre to interact with those specific stacks. It will also establish a dependency on
+  your deployment role stack with every other stack in your project.
 
-        # This is the role that will be ASSUMED by the CI/CD system in order to deploy the all cloudformation
-        # resources for this project, including any IAM-based resources. It will be constrained by the
-        # DeploymentRolePermissionsBoundary, which will limit the scope of its permissions.
-        DeploymentRole:
-            Type: AWS::IAM::Role
-            Properties:
-                Description: >-
-                    This is the role Jenkins will use in order to deploy changes using Sceptre. It
-                    has broad permissions, but it's important to note that it also has a defined
-                    permissions boundary that limits the range and scope of those permissions. This
-                    role DOES have the ability to effect IAM changes, but only those within the right
-                    path and explicitly allowed for within the permissions boundary.
-                # We use a permissions boundary to define the maximum range of permissions that could
-                # possibly be assumed by this role. This makes it safer to provide more generic permissions
-                # on this role, like "PowerUserAccess".
-                PermissionsBoundary: !Ref DeploymentRolePermissionsBoundary
-                AssumeRolePolicyDocument:
-                    Version: "2012-10-17"
-                    Statement:
-                        -   Effect: "Allow"
-                            Principal:
-                                # This role can ONLY be assumed by the configured deployer, which
-                                # should be your CI/CD system's role.
-                                AWS:
-                                    - !Ref DeployerArn
-                            Action: "sts:AssumeRole"
-                # Because this is on the DEPLOYMENT path, not the created resources path, this role is
-                # unable to alter itself, due to the permissions boundary on it.
-                Path: !Sub "/deployment/${CreatedResourcesPath}/"
-                ManagedPolicyArns:
-                    # These permissions are pretty broad, but remember, they cannot go beyond the
-                    # defined permissions boundary, so they are always going to be constrained by that.
-                    # PowerUserAccess has the ability to update MOST things, but has no IAM permissions
-                    - "arn:aws:iam::aws:policy/PowerUserAccess"
-                    - "arn:aws:iam::aws:policy/IAMReadOnlyAccess"
-                Tags:
-                    # This tag is required by the permissions boundary to ensure that this role can only
-                    # operate on resources on that path.
-                    -   Key: "CreatedResourcesPath"
-                        Value: !Ref CreatedResourcesPath
+* You can constrain the permissions of that deployment role by using:
 
-        # This is a special inline policy we'll add to the managed policies above. It lets the deployment
-        # role perform the required IAM operations within the created resources path. Remember, the
-        # permissions boundary set on the deployment role will constrain these permissions further.
-        IamCreationPolicy:
-            Type: AWS::IAM::Policy
-            Properties:
-                PolicyName: IAMCreationPolicy
-                Roles:
-                    - !Ref DeploymentRole
-                PolicyDocument:
-                    Version: "2012-10-17"
-                    Statement:
-                        # This statement allows IAM role Create/update/delete permissions for the
-                        # Deployment role, but only on those roles that are namespaced with the Created
-                        # Resources path. Note: The role's permission boundary will constrain these
-                        # Permissions further.
-                        -   Sid: AllowIAMRoleActions
-                            Effect: Allow
-                            Action:
-                                - iam:CreateRole
-                                - iam:CreateServiceLinkedRole
-                                - iam:PutRolePolicy
-                                - iam:UpdateRole
-                                - iam:UpdateRoleDescription
-                                - iam:DeleteRole
-                                - iam:DeleteServiceLinkedRole
-                                - iam:DeleteRolePolicy
-                                - iam:AttachRolePolicy
-                                - iam:DetachRolePolicy
-                                - iam:TagRole
-                                - iam:UntagRole
-                                - iam:PutRolePermissionsBoundary
-                                - iam:PassRole
-                            Resource: !Sub "arn:aws:iam::${AWS::AccountId}:role/${CreatedResourcesPath}/*"
-                        # This statement allows for IAM Policy create/update/delete permissions for the
-                        # Deployment role, but only those policies that are namespaced with the Created
-                        # Resources path. Note: The permissions boundary on the role will constraint these
-                        # permissions further.
-                        -   Sid: IAMPolicyActions
-                            Effect: Allow
-                            Action:
-                                - iam:CreatePolicy
-                                - iam:CreatePolicyVersion
-                                - iam:DeletePolicy
-                                - iam:DeletePolicyVersion
-                                - iam:TagPolicy
-                                - iam:UntagPolicy
-                            Resource: !Sub "arn:aws:iam::${AWS::AccountId}:policy/${CreatedResourcesPath}/*"
+  * An ``AssumeRolePolicyDocument`` that only allows the CI/CD system to assume it (instead of just
+    anyone in your organization).
+  * A ``PermissionsBoundary`` that guards sensitive/critical infrastructure and which must be on
+    any roles created/updated by the deployment role. See `AWS documentation on permission boundaries
+    <https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html>`_ for more
+    information.
+  * The ``Path`` on IAM roles and managed policies to namespace your resources. Since that path is
+    a part of the ARN structure on roles and managed policies, you can constrain the IAM-related
+    permissions of the deployment role to only certain paths, preventing the deployment role from
+    elevating its own permissions or modifying unrelated roles and policies.
+  * Using ``aws:CalledVia`` and ``aws:CalledViaFirst`` conditions matching against
+    ``"cloudformation.amazonaws.com"`` on non-cloudformation actions to ensure that the deployment
+    role can only execute changes via CloudFormation and not on its own. Note: Some actions are
+    taken by Sceptre directly and not via cloudformation (see the section below on this). Those
+    actions should *not* have a CalledVia condition applied.
 
-
+* If you define your deployment role (and any other related resources) using Sceptre and then
+  reference it on all *other* stacks using ``iam_role: !stack_output ...``, this means that your
+  CI/CD system will not be able to deploy changes to the deployment role or its resources, but that
+  every deployment will depend on those. This is good! It means that, so long as those resources
+  remain unchanged, automated deployment can proceed without issue. It also means that the scope of
+  powers held by the deployment role needs to be reviewed by and **manually deployed by a user with
+  admin-level permissions.** But after that manual deployment, your CI/CD system should be empowered
+  to deploy all the other stacks in your project (so long as the deployment role has the full scope of
+  permissions needed to do those deployments).
 
 Basic permissions that Sceptre requires
 ---------------------------------------
@@ -430,7 +142,7 @@ Basic permissions that Sceptre requires
 There are certain permissions that Sceptre requires to perform even its most basic operations. These
 include:
 
-Basic operations:
+**For Basic operations:**
 
 * cloudformation:CreateStack
 * cloudformation:DeleteStack
@@ -450,7 +162,7 @@ Basic operations:
 * cloudformation:UpdateTerminationProtection
 * cloudformation:ValidateTemplate
 
-If using change sets:
+**If using change sets:**
 
 * cloudformation:CreateChangeSet
 * cloudformation:DeleteChangeSet
@@ -458,15 +170,11 @@ If using change sets:
 * cloudformation:ExecuteChangeSet
 * cloudformation:ListChangeSets
 
-If using a template bucket:
+**If using a template bucket:**
 
 * s3:CreateBucket
 * s3:PutObject
 
-If using ``role_arn``:
+**If using ``role_arn``:**
 
 * iam:PassRole
-
-If using ``iam_role``:
-
-* sts:AssumeRole

--- a/docs/_source/docs/permissions.rst
+++ b/docs/_source/docs/permissions.rst
@@ -175,6 +175,6 @@ include:
 * s3:CreateBucket
 * s3:PutObject
 
-**If using ``role_arn``:**
+**If using a cloudformation service role:**
 
 * iam:PassRole

--- a/docs/_source/docs/permissions.rst
+++ b/docs/_source/docs/permissions.rst
@@ -24,6 +24,7 @@ provide more flexibility, control, and safety within an organization: **role_arn
 **profile**. These can be applied in a very targeted way, on a stack by stack basis or can be applied
 broadly to a whole StackGroup.
 
+.. _role_arn_permissions:
 
 role_arn
 ^^^^^^^^
@@ -56,6 +57,7 @@ As a resolvable property, Sceptre allows you to use a resolver to populate the `
 Stack or StackGroup Config. This means you could define that role within your project, output its
 ARN, and then reference it using `!stack_output`.
 
+.. _iam_role_permissions:
 
 iam_role
 ^^^^^^^^
@@ -83,6 +85,8 @@ deployment actions on the stack and all its resources.
 As a resolvable property, Sceptre allows you to use a resolver to populate the ``iam_role`` for a
 Stack or StackGroup Config. This means you could define that role within your project, output its
 ARN, and then reference it using `!stack_output`.
+
+.. _profile_permissions:
 
 profile
 ^^^^^^^

--- a/docs/_source/docs/stack_config.rst
+++ b/docs/_source/docs/stack_config.rst
@@ -212,7 +212,7 @@ to create, update or delete resources.
 
 iam_role
 ~~~~~~~~
-* Resolvable: No
+* Resolvable: Yes
 * Can be inherited from StackGroup: Yes
 * Inheritance strategy: Overrides parent if set
 
@@ -234,6 +234,13 @@ CI/CD system like Jenkins.
 
 In order to use this argument, however, the role needs to have an AssumeRolePolicyDocument that
 permits the user to assume that role.
+
+.. warning::
+
+   If you use set the value of ``iam_role`` with ``!stack_output``, that ``iam_role``
+   will not actually be used to obtain the stack_output, but it *WILL* be used for all subsequent stack
+   actions. Therefore, it is important that the user executing the stack action have permissions to get
+   stack outputs for the stack outputting the ``iam_role``.
 
 sceptre_user_data
 ~~~~~~~~~~~~~~~~~

--- a/docs/_source/docs/stack_config.rst
+++ b/docs/_source/docs/stack_config.rst
@@ -237,7 +237,7 @@ permits the user to assume that role.
 
 .. warning::
 
-   If you use set the value of ``iam_role`` with ``!stack_output``, that ``iam_role``
+   If you set the value of ``iam_role`` with ``!stack_output``, that ``iam_role``
    will not actually be used to obtain the stack_output, but it *WILL* be used for all subsequent stack
    actions. Therefore, it is important that the user executing the stack action have permissions to get
    stack outputs for the stack outputting the ``iam_role``.

--- a/docs/_source/docs/stack_config.rst
+++ b/docs/_source/docs/stack_config.rst
@@ -208,7 +208,8 @@ role_arn
 * Inheritance strategy: Overrides parent if set
 
 The ARN of a `CloudFormation Service Role`_ that is assumed by *CloudFormation* (not Sceptre)
-to create, update or delete resources.
+to create, update or delete resources. For more information on this configuration, its implications,
+and its uses see :ref:`Sceptre and IAM: role_arn <role_arn_permissions>`.
 
 iam_role
 ~~~~~~~~
@@ -222,25 +223,15 @@ on the Stack.
 This is different from the ``role_arn`` option, which sets a CloudFormation service role for the
 stack. The ``iam_role`` configuration does not configure anything on the stack itself.
 
-This is also different from the ``profile`` StackGroup configuration, though there are similarities.
-``profile`` references the name of a locally-defined profile configured using the AWS CLI. This is
-the *"user"* that Sceptre is operating as. However, `iam_role` is a defined role ARN (typically one
-with elevated permissions the user doesn't otherwise have access to) that the user will assume in
-order to execute the actions on a specific stack group.
-
-Using ``iam_role`` can be useful if the user or system executing Sceptre needs an alternative
-permissions set to perform the required actions on that stack, such as might be the case with a
-CI/CD system like Jenkins.
-
-In order to use this argument, however, the role needs to have an AssumeRolePolicyDocument that
-permits the user to assume that role.
-
 .. warning::
 
    If you set the value of ``iam_role`` with ``!stack_output``, that ``iam_role``
    will not actually be used to obtain the stack_output, but it *WILL* be used for all subsequent stack
    actions. Therefore, it is important that the user executing the stack action have permissions to get
    stack outputs for the stack outputting the ``iam_role``.
+
+For more information on this configuration, its implications, and its uses, see
+:ref:`Sceptre and IAM: iam_role <iam_role_permissions>`.
 
 sceptre_user_data
 ~~~~~~~~~~~~~~~~~

--- a/docs/_source/docs/stack_group_config.rst
+++ b/docs/_source/docs/stack_group_config.rst
@@ -31,9 +31,11 @@ profile
 * Resolvable: No
 * Inheritance strategy: Overrides parent if set by child
 
-The name of the profile as defined in ``~/.aws/config`` and
-``~/.aws/credentials``. Use the `aws configure --profile <profile_id>` command
-form the AWS CLI to add profiles to these files.
+The name of the profile as defined in ``~/.aws/config`` and ``~/.aws/credentials``. Use the
+`aws configure --profile <profile_id>` command form the AWS CLI to add profiles to these files.
+
+For more information on this configuration, its implications, and its uses, see
+:ref:`Sceptre and IAM: profile <profile_permissions>`.
 
 Reference: `AWS_CLI_Configure`_
 

--- a/docs/_source/index.rst
+++ b/docs/_source/index.rst
@@ -20,6 +20,7 @@
    docs/hooks.rst
    docs/resolvers.rst
    docs/architecture.rst
+   docs/permissions.rst
 
 .. toctree::
    :maxdepth: 3

--- a/integration-tests/sceptre-project/config/project-deps/dependencies/assumed-role.yaml
+++ b/integration-tests/sceptre-project/config/project-deps/dependencies/assumed-role.yaml
@@ -1,0 +1,2 @@
+template:
+  path: "project-dependencies/assumed-role.yaml"

--- a/integration-tests/sceptre-project/config/project-deps/main-project/config.yaml
+++ b/integration-tests/sceptre-project/config/project-deps/main-project/config.yaml
@@ -1,5 +1,7 @@
 template_bucket_name: !stack_output project-deps/dependencies/bucket.yaml::BucketName
 notifications:
   - !stack_output project-deps/dependencies/topic.yaml::TopicArn
+
+iam_role: !stack_output project-deps/dependencies/assumed-role.yaml::RoleArn
 stack_tags:
   greeting: !rcmd echo "hello"

--- a/integration-tests/sceptre-project/templates/project-dependencies/assumed-role.yaml
+++ b/integration-tests/sceptre-project/templates/project-dependencies/assumed-role.yaml
@@ -1,0 +1,30 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Resources:
+  Role:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: /service/
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              AWS: !Ref AWS::AccountId
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AWSCloudFormationFullAccess
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess
+        - arn:aws:iam::aws:policy/AmazonSNSFullAccess
+      Policies:
+        - PolicyName: "PassRolePermissions"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Action: "iam:PassRole"
+                Effect: Allow
+                Resource: "*"
+
+Outputs:
+  RoleArn:
+    Value: !GetAtt Role.Arn

--- a/sceptre/connection_manager.py
+++ b/sceptre/connection_manager.py
@@ -153,11 +153,11 @@ class ConnectionManager(object):
 
                 if iam_role:
                     sts_client = session.client("sts")
+                    # maximum session name length is 64 chars. 56 + "-session" = 64
+                    session_name = f'{iam_role.split("/")[-1][:56]}-session'
                     sts_response = sts_client.assume_role(
                         RoleArn=iam_role,
-                        RoleSessionName="{0}-session".format(
-                            iam_role.split("/")[-1]
-                        )
+                        RoleSessionName=session_name
                     )
 
                     credentials = sts_response["Credentials"]

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -172,6 +172,43 @@ class TestStack(object):
         assert isinstance(evaluated_stack, Stack)
         assert evaluated_stack.__eq__(self.stack)
 
+    def test_configuration_manager__iam_role_raises_recursive_resolve__returns_connection_manager_with_no_role(self):
+        class FakeResolver(Resolver):
+            def resolve(self):
+                return self.stack.iam_role
+
+        self.stack.iam_role = FakeResolver()
+
+        connection_manager = self.stack.connection_manager
+        assert connection_manager.iam_role is None
+
+    def test_configuration_manager__iam_role_returns_value_second_access__returns_value_on_second_access(self):
+
+        class FakeResolver(Resolver):
+            access_count = 0
+
+            def resolve(self):
+                if self.access_count == 0:
+                    self.access_count += 1
+                    return self.stack.iam_role
+                else:
+                    return 'role'
+
+        self.stack.iam_role = FakeResolver()
+
+        assert self.stack.connection_manager.iam_role is None
+        assert self.stack.connection_manager.iam_role == 'role'
+
+    def test_configuration_manager__iam_role_returns_value__returns_connection_manager_with_that_role(self):
+        class FakeResolver(Resolver):
+            def resolve(self):
+                return 'role'
+
+        self.stack.iam_role = FakeResolver()
+
+        connection_manager = self.stack.connection_manager
+        assert connection_manager.iam_role == 'role'
+
 
 class TestStackSceptreUserData(object):
     def test_user_data_is_accessible(self):


### PR DESCRIPTION
This is the third in a series of pull requests that addresses #1114 , allowing Sceptre to manage its own dependencies.

## In this PR:
* iam_role becomes a resolvable property
* The temporary circular dependency that happens when a resolving an iam_role requires using the iam_role is handled gracefully.
* Integration tests and docs to clarify the resolvability of the IAM role are added.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
