### PR TITLE
[Resolve #1114] Project Dependencies part 4: Identifying stack as project dependency

### DIFF
--- a/sceptre/resolvers/__init__.py
+++ b/sceptre/resolvers/__init__.py
@@ -67,9 +67,6 @@ class ResolvableProperty(abc.ABC):
     associated with Resolver objects.
 
     :param name: Attribute suffix used to store the property in the instance.
-    :param placeholder_override: If specified, this is the value that will be used as the placeholder
-        rather than the resolver's returned placeholder value, but only when placeholders are allowed
-        via the use_resolver_placeholders_on_error context manager.
     """
 
     def __init__(self, name):

--- a/sceptre/resolvers/__init__.py
+++ b/sceptre/resolvers/__init__.py
@@ -7,6 +7,7 @@ from typing import Any, TYPE_CHECKING, Type, Union, TypeVar
 
 from sceptre.helpers import _call_func_on_values
 
+
 if TYPE_CHECKING:
     from sceptre import stack
 
@@ -66,6 +67,9 @@ class ResolvableProperty(abc.ABC):
     associated with Resolver objects.
 
     :param name: Attribute suffix used to store the property in the instance.
+    :param placeholder_override: If specified, this is the value that will be used as the placeholder
+        rather than the resolver's returned placeholder value, but only when placeholders are allowed
+        via the use_resolver_placeholders_on_error context manager.
     """
 
     def __init__(self, name):
@@ -175,18 +179,31 @@ class ResolvableContainerProperty(ResolvableProperty):
         return container
 
     def get_resolved_value(self, stack: 'stack.Stack', stack_class: Type['stack.Stack']) -> T_Container:
-        """Obtains the resolved value for this property.
+        """Obtains the resolved value for this property. Any resolvers that resolve to None will have
+        their key/index removed from their dict/list where they are. Other resolvers will have their
+        key/index's value replace with the resolved value to avoid redundant resolutions.
 
         :param stack: The Stack instance to obtain the value for
         :param stack_class: The class of the Stack instance.
         :return: The fully resolved container.
         """
+        keys_to_delete = []
 
         def resolve(attr: Union[dict, list], key: Union[int, str], value: Resolver):
             # Update the container key's value with the resolved value, if possible...
             try:
                 result = self.resolve_resolver_value(value)
-                attr[key] = result
+                if result is None:
+                    logger.debug(f"Removing item {key} because resolver returned None.")
+                    # We gather up resolvers (and their immediate containers) that resolve to None,
+                    # since that really means the resolver resolves to nothing. This is not common,
+                    # but will be the case when a StackOutput resolver is on a project dependency
+                    # stack. We gather these rather than immediately remove them because this
+                    # function is called in the context of looping over that attr, so we cannot
+                    # alter its size until after the loop is complete.
+                    keys_to_delete.append((attr, key))
+                else:
+                    attr[key] = result
             except RecursiveResolve:
                 # It's possible that resolving the resolver might attempt to access another
                 # resolvable property's value in this same container. In this case, we'll delay
@@ -203,6 +220,9 @@ class ResolvableContainerProperty(ResolvableProperty):
         _call_func_on_values(
             resolve, container, Resolver
         )
+        # Remove keys and indexes from their containers that had resolvers resolve to None.
+        for attr, key in keys_to_delete:
+            del attr[key]
 
         return container
 
@@ -285,7 +305,12 @@ class ResolvableContainerProperty(ResolvableProperty):
         def __call__(self):
             """Resolve the value."""
             attr = getattr(self._instance, self._name)
-            attr[self._key] = self._resolution_function()
+            result = self._resolution_function()
+            if result is None:
+                logger.debug(f"Removing item {self._key} because resolver returned None.")
+                del attr[self._key]
+            else:
+                attr[self._key] = result
 
 
 class ResolvableValueProperty(ResolvableProperty):

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -108,6 +108,11 @@ class Stack(object):
             will result in no timeout. Supports only positive integer value.
     :type stack_timeout: int
 
+    :param is_project_dependency: Indicates whether or not the the stack is a\
+            special dependency of the stack. If True, disables all dependencies\
+            on the the current stack.
+    :type is_project_dependency: bool
+
     :param stack_group_config: The StackGroup config for the Stack
     :type stack_group_config: dict
 
@@ -132,7 +137,7 @@ class Stack(object):
         parameters=None, sceptre_user_data=None, hooks=None, s3_details=None,
         iam_role=None, dependencies=None, role_arn=None, protected=False, tags=None,
         external_name=None, notifications=None, on_failure=None, profile=None,
-        stack_timeout=0, stack_group_config={}
+        stack_timeout=0, is_project_dependency=False, stack_group_config={}
     ):
         self.logger = logging.getLogger(__name__)
 
@@ -149,7 +154,7 @@ class Stack(object):
         self.external_name = external_name or get_external_stack_name(self.project_code, self.name)
         self.template_path = template_path
         self.template_handler_config = template_handler_config
-        self.s3_details = s3_details
+        self.is_project_dependency = is_project_dependency
         self._template = None
         self._connection_manager = None
 

--- a/tests/test_resolvers/test_resolver.py
+++ b/tests/test_resolvers/test_resolver.py
@@ -332,6 +332,50 @@ class TestResolvableContainerPropertyDescriptor:
             'resolver': 'stack1'
         }
 
+    def test_get__resolver_resolves_to_none__value_is_list__deletes_that_item_from_list(self):
+        class MyResolver(Resolver):
+            def resolve(self):
+                return None
+
+        resolver = MyResolver()
+        self.mock_object.resolvable_container_property = [
+            1,
+            resolver,
+            3
+        ]
+        expected = [1, 3]
+        assert self.mock_object.resolvable_container_property == expected
+
+    def test_get__resolver_resolves_to_none__value_is_dict__deletes_that_key_from_dict(self):
+        class MyResolver(Resolver):
+            def resolve(self):
+                return None
+
+        resolver = MyResolver()
+        self.mock_object.resolvable_container_property = {
+            'some key': 'some value',
+            'resolver': resolver
+        }
+        expected = {'some key': 'some value'}
+        assert self.mock_object.resolvable_container_property == expected
+
+    def test_get__value_in_list_is_none__returns_list_with_none(self):
+        self.mock_object.resolvable_container_property = [
+            1,
+            None,
+            3
+        ]
+        expected = [1, None, 3]
+        assert self.mock_object.resolvable_container_property == expected
+
+    def test_get__value_in_dict_is_none__returns_dict_with_none(self):
+        self.mock_object.resolvable_container_property = {
+            'some key': 'some value',
+            'none key': None
+        }
+        expected = {'some key': 'some value', 'none key': None}
+        assert self.mock_object.resolvable_container_property == expected
+
 
 class TestResolvableValueProperty:
     def setup_method(self, test_method):


### PR DESCRIPTION
This is the Fourth in a series of pull requests that addresses #1114 , allowing Sceptre to manage its own dependencies.

## In this PR:
* **Stack Configs can be marked with `is_project_dependency: True`**. This is important, as it allows us to bypass the irreconcilable issue of multiple project dependency stacks depending on each other. with `is_project_dependency: True`, it will have the effects of:
    - Disabling all dependencies on that stack. They cannot be set on the current stack and they can't be inherited from parent StackGroups. In other words, a "project dependency" stack is automatically at the top of the dependency hierarchy.
    - Disabling the StackOutput resolver. It will "resolve to nothing" on project dependency stacks (see below). This means that it can be safely inherited from a StackGroup, but it won't actually do anything.
* **Resolvers that return None "resolve to nothing",** being removed from their container, just like "AWS::NoValue" does in CloudFormation templates. This prevents issues like when every stack in the project "inherits" `template_bucket_name: !stack_output bucket.yaml::BucketName`, and that would include the bucket.yaml stack, which cannot rely on itself.

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
