### PR TITLE
[Resolve #683] Fixing diff command to handle (and not create) invalid templates

### DIFF
--- a/sceptre/diffing/stack_differ.py
+++ b/sceptre/diffing/stack_differ.py
@@ -327,7 +327,9 @@ class StackDiffer(Generic[DiffType]):
             try:
                 attr[key] = value.resolve()
             except Exception:
-                attr[key] = self._represent_unresolvable_resolver(value)
+                explicit_resolver_repr = self._represent_unresolvable_resolver(value)
+                only_alphanumeric = ''.join(c for c in explicit_resolver_repr if c.isalnum())
+                attr[key] = only_alphanumeric
 
         # Because the name is mangled, we cannot access the user data normally, so we need to access
         # it directly out of the __dict__.

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -979,8 +979,11 @@ class StackActions(object):
             )
             return template_summary
         except botocore.exceptions.ClientError as e:
-            # AWS returns a ValidationError if the stack doesn't exist
-            if e.response['Error']['Code'] == 'ValidationError':
+            error_response = e.response['Error']
+            if (
+                error_response['Code'] == 'ValidationError'
+                and 'does not exist' in error_response['Message']
+            ):
                 return None
             raise
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1246,7 +1246,6 @@ class TestStackActions(object):
         result = self.actions.fetch_remote_template_summary()
         assert result is None
 
-
     def test_diff__invokes_diff_method_on_injected_differ_with_self(self):
         differ = Mock()
         self.actions.diff(differ)

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1217,7 +1217,21 @@ class TestStackActions(object):
         result = self.actions.fetch_local_template_summary()
         assert result == {'template': 'summary'}
 
-    def test_fetch_remote_template_summary__cloudformation_returns_validation_error__returns_none(self):
+    def test_fetch_local_template_summary__cloudformation_returns_validation_error_invalid_stack__raises_it(self):
+        self.actions.connection_manager.call.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "ValidationError",
+                    "Message": "Template format error: Resource name {Invalid::Resource} is "
+                               "non alphanumeric.'"
+                }
+            },
+            sentinel.operation
+        )
+        with pytest.raises(ClientError):
+            self.actions.fetch_local_template_summary()
+
+    def test_fetch_remote_template_summary__cloudformation_returns_validation_error_for_no_stack__returns_none(self):
         self.actions.connection_manager.call.side_effect = ClientError(
             {
                 "Error": {
@@ -1231,6 +1245,7 @@ class TestStackActions(object):
         )
         result = self.actions.fetch_remote_template_summary()
         assert result is None
+
 
     def test_diff__invokes_diff_method_on_injected_differ_with_self(self):
         differ = Mock()

--- a/tests/test_diffing/test_stack_differ.py
+++ b/tests/test_diffing/test_stack_differ.py
@@ -511,7 +511,7 @@ class TestStackDiffer:
 
         self.differ.diff(self.actions)
 
-        assert self.sceptre_user_data['unresolvable'] == '{ !Mock(test) }'
+        assert self.sceptre_user_data['unresolvable'] == 'Mocktest'
 
     def test_diff__local_generation_raises_an_error__resolves_resolvable_sceptre_user_data(self):
         has_raised = False


### PR DESCRIPTION
Some testing on the recent diff command made a couple things evident:
* The way we were generating the placeholder values for sceptre_user_data was not fully safe for rendering templates. A safer approach is to only use alphanumeric values.
* When retrieving a local template summary, if the template is invalid (such as invalid yaml or having invalid characters), we were currently interpreting that as the stack not existing... which wasn't true. This would happen specifically when getting a template summary for the LOCALLY generated template, so that didn't make sense.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
