### PR TITLE
[Resolve #1175] Adding commas for cfn-flip dependency

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,7 +1,7 @@
 boto3>=1.3.0,<2
 click>=7.0,<9.0
 colorama>=0.2.5,<0.4.4
-cfn-flip>=1.2.3<2.0
+cfn-flip>=1.2.3,<2.0
 deepdiff>=5.5.0,<6.0
 Jinja2>=2.8,<3
 jsonschema>=3.2,<3.3

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def get_version(rel_path):
 install_requirements = [
     "boto3>=1.3,<2.0",
     "click>=7.0,<9.0",
-    "cfn-flip>=1.2.3<2.0",
+    "cfn-flip>=1.2.3,<2.0",
     "deepdiff>=5.5.0,<6.0",
     "PyYaml>=5.1,<6.0",
     "Jinja2>=2.8,<3",


### PR DESCRIPTION
See #1175 for more information, but the bottom line is that the lack of comma in our setup file is triggering a cascade of DeprecationWarnings when using the latest version of Sceptre.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [x] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
