### PR TITLE
Fix typo in CDK doc

### DIFF
--- a/docs/_source/docs/templates.rst
+++ b/docs/_source/docs/templates.rst
@@ -228,7 +228,7 @@ This example generates a cloudformation template from `AWS CDK`_ code.
 
 Generate cloudformation:
 
-``sceptre generate dev/S3CdkStack.yaml``
+``sceptre generate dev/S3CdkStack.py``
 
 .. code-block:: yaml
 


### PR DESCRIPTION
CDK files are .py files not .yaml files.

