### PR TITLE
[Resolves #723] Fix update command with change sets for multiple stacks

### DIFF
--- a/sceptre/cli/update.py
+++ b/sceptre/cli/update.py
@@ -57,14 +57,30 @@ def update_command(ctx, path, change_set, verbose, yes):
         try:
             # Wait for change set to be created
             statuses = plan.wait_for_cs_completion(change_set_name)
-            # Exit if change set fails to create
+
+            at_least_one_ready = False
+
             for status in list(statuses.values()):
-                if status != StackChangeSetStatus.READY:
+                # Exit if change set fails to create
+                if status not in (StackChangeSetStatus.READY, StackChangeSetStatus.NO_CHANGES):
+                    write("Failed to create change set", context.output_format)
                     exit(1)
+
+                if status == StackChangeSetStatus.READY:
+                    at_least_one_ready = True
+
+            # If none are ready, and we haven't exited, there are no changes
+            if not at_least_one_ready:
+                write("No changes detected", context.output_format)
+                exit(0)
 
             # Describe changes
             descriptions = plan.describe_change_set(change_set_name)
-            for description in list(descriptions.values()):
+            for stack, description in descriptions.items():
+                # No need to print if there are no changes
+                if statuses[stack] == StackChangeSetStatus.NO_CHANGES:
+                    continue
+
                 if not verbose:
                     description = simplify_change_set_description(description)
                 write(description, context.output_format)
@@ -72,8 +88,7 @@ def update_command(ctx, path, change_set, verbose, yes):
             # Execute change set if happy with changes
             if yes or click.confirm("Proceed with stack update?"):
                 plan.execute_change_set(change_set_name)
-        except Exception as e:
-            raise e
+
         finally:
             # Clean up by deleting change set
             plan.delete_change_set(change_set_name)

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -884,6 +884,7 @@ class StackActions(object):
         cs_description = self.describe_change_set(change_set_name)
 
         cs_status = cs_description["Status"]
+        cs_reason = cs_description.get("StatusReason")
         cs_exec_status = cs_description["ExecutionStatus"]
         possible_statuses = [
             "CREATE_PENDING", "CREATE_IN_PROGRESS",
@@ -915,6 +916,12 @@ class StackActions(object):
                 cs_exec_status in ["UNAVAILABLE", "AVAILABLE"]
         ):
             return StackChangeSetStatus.PENDING
+        elif (
+                cs_status == "FAILED" and
+                cs_reason is not None and
+                self.change_set_creation_failed_due_to_no_changes(cs_reason)
+        ):
+            return StackChangeSetStatus.NO_CHANGES
         elif (
                 cs_status in ["DELETE_COMPLETE", "FAILED"] or
                 cs_exec_status in [

--- a/sceptre/stack_status.py
+++ b/sceptre/stack_status.py
@@ -25,3 +25,4 @@ class StackChangeSetStatus(object):
     PENDING = "pending"
     READY = "ready"
     DEFUNCT = "defunct"
+    NO_CHANGES = "no changes"

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1088,6 +1088,17 @@ class TestStackActions(object):
                 )
                 assert response == returns[i]
 
+        mock_describe_change_set.return_value = {
+            "Status": "FAILED",
+            "StatusReason": "The submitted information didn't contain changes. "
+                            "Submit different information to create a change set.",
+            "ExecutionStatus": "UNAVAILABLE"
+        }
+        response = self.actions._get_cs_status(
+            sentinel.change_set_name
+        )
+        assert response == scss.NO_CHANGES
+
         for status in return_values['Status']:
             mock_describe_change_set.return_value = {
                 "Status": status,


### PR DESCRIPTION
Resolves #723

Previously the update command would exit if any change sets status
was not equal to READY. However, when a stack does not contain
any updates, it will not be READY since there is nothing to execute.
This should not prevent other change sets to be executed.

To get around this, we introduce another change set status, NO_CHANGES,
and handle that gracefully.

To clean up the output a bit, we also pass on describing the changes
for empty change sets.

Continuation of #917. Thanks @henrist for the original PR and @jfalkenstein for the review:

- Fix original PR feedback
- Simplify code for skipping output for empty change set
- Roll back optional delete, we should always clean up
- Add test covering "change set" version of update command

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
