### PR TITLE
[Resolves #1194] Docs: "know"->"knows"

### DIFF
--- a/docs/_source/docs/terminology.rst
+++ b/docs/_source/docs/terminology.rst
@@ -72,7 +72,7 @@ SceptrePlanExecutor
 You won’t be able to interact with the ``SceptrePlanExecutor`` directly but
 this part of the code is responsible for taking a ``SceptrePlan`` and ensuring
 all commands on every stack, are executed in the correct order, concurrently.
-The executor algorithm focuses on correctness over maximal concurrency. It know
+The executor algorithm focuses on correctness over maximal concurrency. It knows
 what to execute and when based on a ``StackGraph`` which is created when a
 ``SceptrePlan`` is created.
 


### PR DESCRIPTION
This change corrects a spelling error in the Terminology section of the documentation.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
