### PR TITLE
[Resolve #1197] docs: fix template path in getting-started

### DIFF
--- a/docs/_source/docs/get_started.rst
+++ b/docs/_source/docs/get_started.rst
@@ -107,7 +107,7 @@ Add the following configuration to ``config/dev/vpc.yaml``:
 .. code-block:: yaml
 
    template:
-     path: templates/vpc.yaml
+     path: vpc.yaml
      type: file
    parameters:
      CidrBlock: 10.0.0.0/16


### PR DESCRIPTION
Resovles #1197 

The default path for templates is already `templates` directory. This causes `sceptre create dev/vpc.yaml` command to fail with  the error message below.

```
FileNotFoundError: [Errno 2] No such file or directory: '.../templates/templates/vpc.yaml'
```
## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
