### PR TITLE
Fix spelling of stack_group_config in documentation

### DIFF
--- a/docs/_source/docs/stack_group_config.rst
+++ b/docs/_source/docs/stack_group_config.rst
@@ -24,7 +24,7 @@ Sceptre. The available keys are listed below.
 
 Sceptre will only check for and uses the above keys in StackGroup config files
 and are directly accessible from Stack(). Any other keys added by the user are
-made available via ``stack_group_confg`` attribute on ``Stack()``.
+made available via ``stack_group_config`` attribute on ``Stack()``.
 
 profile
 ~~~~~~~


### PR DESCRIPTION
The documentation stated that keys are available via stack_group_confg. When using stack_group_confg to access keys an error occurs on the validation. When using stack_group_config the validation and deployments of configurations work.

## PR Checklist

- [ ] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
