### PR TITLE
[Partially Resolve #1193] Automatically adding Sceptre tags to all stacks

### DIFF
--- a/integration-tests/features/create-stack.feature
+++ b/integration-tests/features/create-stack.feature
@@ -2,50 +2,50 @@ Feature: Create stack
 
   Scenario: create new stack
     Given stack "1/A" does not exist
-    and the template for stack "1/A" is "valid_template.json"
+    And the template for stack "1/A" is "valid_template.json"
     When the user creates stack "1/A"
     Then stack "1/A" exists in "CREATE_COMPLETE" state
 
   Scenario: create a stack that already exists
     Given stack "1/A" exists in "CREATE_COMPLETE" state
-    and the template for stack "1/A" is "valid_template.json"
+    And the template for stack "1/A" is "valid_template.json"
     When the user creates stack "1/A"
     Then stack "1/A" exists in "CREATE_COMPLETE" state
 
   Scenario: create new stack that has previously failed
     Given stack "1/A" exists in "CREATE_FAILED" state
-    and the template for stack "1/A" is "valid_template.json"
+    And the template for stack "1/A" is "valid_template.json"
     When the user creates stack "1/A"
     Then stack "1/A" exists in "CREATE_FAILED" state
 
   Scenario: create new stack that is rolled back on failure
     Given stack "8/A" does not exist
-    and the template for stack "8/A" is "invalid_template.json"
+    And the template for stack "8/A" is "invalid_template.json"
     When the user creates stack "8/A"
     Then stack "8/A" exists in "ROLLBACK_COMPLETE" state
 
   Scenario: create new stack that is retained on failure
     Given stack "8/B" does not exist
-    and the template for stack "8/B" is "invalid_template.json"
+    And the template for stack "8/B" is "invalid_template.json"
     When the user creates stack "8/B"
     Then stack "8/B" exists in "CREATE_FAILED" state
 
   Scenario: create new stack that is rolled back after timeout
     Given stack "8/C" does not exist
-    and the template for stack "8/C" is "valid_template_wait_300.json"
-    and the stack_timeout for stack "8/C" is "1"
+    And the template for stack "8/C" is "valid_template_wait_300.json"
+    And the stack_timeout for stack "8/C" is "1"
     When the user creates stack "8/C"
     Then stack "8/C" exists in "ROLLBACK_COMPLETE" state
 
   Scenario: create new stack that ignores dependencies
     Given stack "1/A" does not exist
-    and the template for stack "1/A" is "valid_template.json"
+    And the template for stack "1/A" is "valid_template.json"
     When the user creates stack "1/A" with ignore dependencies
     Then stack "1/A" exists in "CREATE_COMPLETE" state
 
   Scenario: create new stack containing a SAM template transform
     Given stack "10/A" does not exist
-    and the template for stack "10/A" is "sam_template.yaml"
+    And the template for stack "10/A" is "sam_template.yaml"
     When the user creates stack "10/A"
     Then stack "10/A" exists in "CREATE_COMPLETE" state
 
@@ -53,9 +53,16 @@ Feature: Create stack
     Given stack_group "12/1" does not exist
     When the user launches stack_group "12/1"
     Then all the stacks in stack_group "12/1" are in "CREATE_COMPLETE"
-    and stack "12/1/A" has "Project" tag with "A" value
-    and stack "12/1/A" has "Key" tag with "A" value
-    and stack "12/1/2/B" has "Project" tag with "B" value
-    and stack "12/1/2/B" has "Key" tag with "A-B" value
-    and stack "12/1/2/3/C" has "Project" tag with "C" value
-    and stack "12/1/2/3/C" has "Key" tag with "A-B-C" value
+    And stack "12/1/A" has "Project" tag with "A" value
+    And stack "12/1/A" has "Key" tag with "A" value
+    And stack "12/1/2/B" has "Project" tag with "B" value
+    And stack "12/1/2/B" has "Key" tag with "A-B" value
+    And stack "12/1/2/3/C" has "Project" tag with "C" value
+    And stack "12/1/2/3/C" has "Key" tag with "A-B-C" value
+
+  Scenario: Created stacks have sceptre tags
+    Given stack "1/A" does not exist
+    And the template for stack "1/A" is "valid_template.json"
+    When the user creates stack "1/A"
+    Then stack "1/A" has "sceptre_name" tag with "1/A" value
+    And stack "1/A" has "sceptre_project_code" tag with "${context.project_code}" value

--- a/integration-tests/steps/stacks.py
+++ b/integration-tests/steps/stacks.py
@@ -1,3 +1,4 @@
+import re
 from ast import literal_eval
 from copy import deepcopy
 from io import StringIO
@@ -367,6 +368,11 @@ def step_impl(context, stack_name, desired_status):
 
 @then('stack "{stack_name}" has "{tag_name}" tag with "{desired_tag_value}" value')
 def step_impl(context, stack_name, tag_name, desired_tag_value):
+    # If you can reference context attributes like ${context.attribute_name}
+    match = re.match(r'\$\{context\.([a-z_]{1,})}', desired_tag_value)
+    if match:
+        desired_tag_value = str(getattr(context, match.group(1)))
+
     full_name = get_cloudformation_stack_name(context, stack_name)
 
     tags = get_stack_tags(context, full_name)

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -315,7 +315,10 @@ class TestConfigReader(object):
             iam_role=None,
             role_arn=None,
             protected=False,
-            tags={},
+            tags={
+                'sceptre_name': 'account/stack-group/region/vpc',
+                'sceptre_project_code': 'account_project_code'
+            },
             external_name=None,
             notifications=None,
             on_failure=None,


### PR DESCRIPTION
This PR adds some basic Sceptre stack metadata to every stack, namely:
* sceptre_name: This is the "sceptre name", that will look like "outer-stack-group/inner-group/stack-name". Regardless of whether the real stack's name has been set via the "stack_name" attribute or automatically by Sceptre by default, this name will be consistent with the actual directory/StackGroup structure of the sceptre project that launched it.
* sceptre_project_code: This is the project_code of the sceptre project that launched the stack.

This is the **first step** toward accomplishing the goals of #1193, namely providing the _means_ for Sceptre to locate stacks that were _previously_ associated with the project but whose stack configs have been deleted. We will need further code changes to fully implement #1193, but they will build on these changes.

## PR Checklist

- [ ] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
