### PR TITLE
[Resolve #1218] Fixing false-diff reports when parameters end with linebreaks

### DIFF
--- a/sceptre/diffing/stack_differ.py
+++ b/sceptre/diffing/stack_differ.py
@@ -1,7 +1,7 @@
 import difflib
 import logging
 from abc import abstractmethod
-from typing import NamedTuple, Dict, List, Optional, Callable, Tuple, Generic, TypeVar
+from typing import NamedTuple, Dict, List, Optional, Callable, Tuple, Generic, TypeVar, Union
 
 import cfn_flip
 import deepdiff
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 class StackConfiguration(NamedTuple):
     """A data container to represent the comparable parts of a Stack."""
     stack_name: str
-    parameters: Dict[str, str]
+    parameters: Dict[str, Union[str, List[str]]]
     stack_tags: Dict[str, str]
     notifications: List[str]
     role_arn: Optional[str]
@@ -170,7 +170,7 @@ class StackDiffer(Generic[DiffType]):
                 return None
             return StackConfiguration(
                 parameters={
-                    param['ParameterKey']: param['ParameterValue'].rstrip('\n')
+                    param['ParameterKey']: param['ParameterValue']
                     for param
                     in stack.get('Parameters', [])
                 },
@@ -193,6 +193,13 @@ class StackDiffer(Generic[DiffType]):
         generated_template_summary = stack_actions.fetch_local_template_summary()
 
         if deployed_config is not None:
+            # Trailing linebreaks sometimes get removed by CloudFormation in certain circumstances
+            # and can sometimes be added to files, but ultimately they shouldn't affect the diff.
+            self._remove_terminating_linebreaks_from_deployed_parameters(
+                deployed_template_summary,
+                deployed_config
+            )
+
             # If the parameter is not passed by Sceptre and the value on the deployed parameter is
             # the default value, we'll actually remove it from the deployed parameters list so it
             # doesn't show up as a false positive.
@@ -206,6 +213,27 @@ class StackDiffer(Generic[DiffType]):
             # marks as NoEcho parameters (unless show_no_echo is set to true). Therefore those
             # parameter values will be masked.
             self._mask_no_echo_parameters(generated_template_summary, generated_config)
+
+    def _remove_terminating_linebreaks_from_deployed_parameters(
+        self,
+        template_summary: Optional[dict],
+        deployed_config: StackConfiguration
+    ):
+        if template_summary is None:
+            return
+
+        parameter_types = {
+            parameter['ParameterKey']: parameter['ParameterType']
+            for parameter in template_summary['Parameters']
+        }
+
+        for key, value in deployed_config.parameters.items():
+            parameter_type = parameter_types[key]
+            if parameter_type == 'CommaDelimitedList':
+                # If it's a list of strings, remove trailing linebreaks for each item
+                value = ','.join([item.rstrip('\n') for item in value.split(',')])
+
+            deployed_config.parameters[key] = value.rstrip('\n')
 
     def _remove_deployed_default_parameters_that_arent_passed(
         self,

--- a/sceptre/diffing/stack_differ.py
+++ b/sceptre/diffing/stack_differ.py
@@ -154,7 +154,7 @@ class StackDiffer(Generic[DiffType]):
         for key, value in stack.parameters.items():
             if isinstance(value, list):
                 value = ','.join(value)
-            formatted_parameters[key] = value
+            formatted_parameters[key] = value.rstrip('\n')
 
         return formatted_parameters
 

--- a/sceptre/diffing/stack_differ.py
+++ b/sceptre/diffing/stack_differ.py
@@ -194,7 +194,8 @@ class StackDiffer(Generic[DiffType]):
 
         if deployed_config is not None:
             # Trailing linebreaks sometimes get removed by CloudFormation in certain circumstances
-            # and can sometimes be added to files, but ultimately they shouldn't affect the diff.
+            # and can sometimes come from using the !file_contents resolver, but ultimately they
+            # shouldn't affect the diff. We'll ignore all trailing linebreaks.
             self._remove_terminating_linebreaks_from_deployed_parameters(
                 deployed_template_summary,
                 deployed_config

--- a/sceptre/diffing/stack_differ.py
+++ b/sceptre/diffing/stack_differ.py
@@ -128,7 +128,7 @@ class StackDiffer(Generic[DiffType]):
         )
 
     def _create_generated_config(self, stack: Stack) -> StackConfiguration:
-        parameters = self._extract_parameters_dict(stack)
+        parameters = self._extract_parameters_from_generated_stack(stack)
         stack_configuration = StackConfiguration(
             stack_name=stack.external_name,
             parameters=parameters,
@@ -139,13 +139,9 @@ class StackDiffer(Generic[DiffType]):
 
         return stack_configuration
 
-    def _extract_parameters_dict(self, stack: Stack) -> dict:
-        """Extracts a USABLE dict of parameters from the stack.
-
-        Because stack parameters often contain resolvers referencing stacks that might not exist yet
-        (such as when producing a diff on a yet-to-be-deployed stack), we cannot always resolve the
-        stack parameters. Therefore, we need to resolve them (if possible) and fall back to a
-        different representation of that resolver, if necessary.
+    def _extract_parameters_from_generated_stack(self, stack: Stack) -> dict:
+        """Extracts a usable dict of parameters from the stack, performing some minor transformations
+        to match the what CloudFormation does on its end.
 
         :param stack: The stack to extract the parameters from
         :return: A dictionary of stack parameters to be compared.

--- a/sceptre/diffing/stack_differ.py
+++ b/sceptre/diffing/stack_differ.py
@@ -154,7 +154,7 @@ class StackDiffer(Generic[DiffType]):
         for key, value in stack.parameters.items():
             if isinstance(value, list):
                 value = ','.join(item.rstrip('\n') for item in value)
-            formatted_parameters[key] = value
+            formatted_parameters[key] = value.rstrip('\n')
 
         return formatted_parameters
 

--- a/sceptre/diffing/stack_differ.py
+++ b/sceptre/diffing/stack_differ.py
@@ -153,8 +153,8 @@ class StackDiffer(Generic[DiffType]):
         formatted_parameters = {}
         for key, value in stack.parameters.items():
             if isinstance(value, list):
-                value = ','.join(value)
-            formatted_parameters[key] = value.rstrip('\n')
+                value = ','.join(item.rstrip('\n') for item in value)
+            formatted_parameters[key] = value
 
         return formatted_parameters
 


### PR DESCRIPTION
This handles cases with trailing linebreaks being passed to parameters. While this normally doesn't happen when using yaml,  it's very likely when using the !file_contents resolver. This fixes the issue to avoid false-diffs.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
