### PR TITLE
update trophosphere version

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -11,4 +11,4 @@ PyYaml>=5.1,<6.0
 sceptre-cmd-resolver>=1.1.3,<2
 sceptre-file-resolver>=1.0.4,<2
 six>=1.11.0,<2.0.0
-troposphere>=2.7,<3
+troposphere>=4,<5

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ install_requirements = [
 ]
 
 extra_requirements = {
-    "troposphere": ["troposphere>=2.7,<3"],
+    "troposphere": ["troposphere>=4,<5"],
 }
 
 

--- a/tests/fixtures-vpc/templates/compiled_vpc.json
+++ b/tests/fixtures-vpc/templates/compiled_vpc.json
@@ -33,8 +33,8 @@
                 "CidrBlock": {
                     "Ref": "CidrBlock"
                 },
-                "EnableDnsHostnames": "true",
-                "EnableDnsSupport": "true",
+                "EnableDnsHostnames": true,
+                "EnableDnsSupport": true,
                 "InstanceTenancy": "default"
             },
             "Type": "AWS::EC2::VPC"

--- a/tests/fixtures-vpc/templates/compiled_vpc_sud.json
+++ b/tests/fixtures-vpc/templates/compiled_vpc_sud.json
@@ -25,8 +25,8 @@
         "VirtualPrivateCloud": {
             "Properties": {
                 "CidrBlock": "10.0.0.0/16",
-                "EnableDnsHostnames": "true",
-                "EnableDnsSupport": "true",
+                "EnableDnsHostnames": true,
+                "EnableDnsSupport": true,
                 "InstanceTenancy": "default"
             },
             "Type": "AWS::EC2::VPC"

--- a/tests/fixtures-vpc/templates/vpc.json
+++ b/tests/fixtures-vpc/templates/vpc.json
@@ -33,8 +33,8 @@
                 "CidrBlock": {
                     "Ref": "CidrBlock"
                 },
-                "EnableDnsHostnames": "true",
-                "EnableDnsSupport": "true",
+                "EnableDnsHostnames": true,
+                "EnableDnsSupport": true,
                 "InstanceTenancy": "default"
             },
             "Type": "AWS::EC2::VPC"

--- a/tests/fixtures-vpc/templates/vpc.template
+++ b/tests/fixtures-vpc/templates/vpc.template
@@ -33,8 +33,8 @@
                 "CidrBlock": {
                     "Ref": "CidrBlock"
                 },
-                "EnableDnsHostnames": "true",
-                "EnableDnsSupport": "true",
+                "EnableDnsHostnames": true,
+                "EnableDnsSupport": true,
                 "InstanceTenancy": "default"
             },
             "Type": "AWS::EC2::VPC"

--- a/tests/fixtures/templates/compiled_vpc.json
+++ b/tests/fixtures/templates/compiled_vpc.json
@@ -33,8 +33,8 @@
                 "CidrBlock": {
                     "Ref": "CidrBlock"
                 },
-                "EnableDnsHostnames": "true",
-                "EnableDnsSupport": "true",
+                "EnableDnsHostnames": true,
+                "EnableDnsSupport": true,
                 "InstanceTenancy": "default"
             },
             "Type": "AWS::EC2::VPC"

--- a/tests/fixtures/templates/compiled_vpc_sud.json
+++ b/tests/fixtures/templates/compiled_vpc_sud.json
@@ -25,8 +25,8 @@
         "VirtualPrivateCloud": {
             "Properties": {
                 "CidrBlock": "10.0.0.0/16",
-                "EnableDnsHostnames": "true",
-                "EnableDnsSupport": "true",
+                "EnableDnsHostnames": true,
+                "EnableDnsSupport": true,
                 "InstanceTenancy": "default"
             },
             "Type": "AWS::EC2::VPC"

--- a/tests/fixtures/templates/vpc.template
+++ b/tests/fixtures/templates/vpc.template
@@ -33,8 +33,8 @@
                 "CidrBlock": {
                     "Ref": "CidrBlock"
                 },
-                "EnableDnsHostnames": "true",
-                "EnableDnsSupport": "true",
+                "EnableDnsHostnames": true,
+                "EnableDnsSupport": true,
                 "InstanceTenancy": "default"
             },
             "Type": "AWS::EC2::VPC"

--- a/tests/fixtures/templates/vpc.without_start_marker.yaml
+++ b/tests/fixtures/templates/vpc.without_start_marker.yaml
@@ -21,7 +21,7 @@ Resources:
     Properties:
       CidrBlock:
         Ref: CidrBlock
-      EnableDnsHostnames: 'true'
-      EnableDnsSupport: 'true'
+      EnableDnsHostnames: true
+      EnableDnsSupport: true
       InstanceTenancy: default
     Type: AWS::EC2::VPC

--- a/tests/fixtures/templates/vpc.yaml
+++ b/tests/fixtures/templates/vpc.yaml
@@ -22,7 +22,7 @@ Resources:
     Properties:
       CidrBlock:
         Ref: CidrBlock
-      EnableDnsHostnames: 'true'
-      EnableDnsSupport: 'true'
+      EnableDnsHostnames: true
+      EnableDnsSupport: true
       InstanceTenancy: default
     Type: AWS::EC2::VPC


### PR DESCRIPTION
On python 3.10 pip fails when installing troposphere.
The troposphere library needs to be updated to support
python 3.10.  It's also pretty old and should be updated
anyways.  This is partial resolution for issue #1225

```
Collecting troposphere<3,>=2.7
  Using cached troposphere-2.7.1.tar.gz (205 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [12 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 14, in <module>
        File "/Users/zaro0508/.pyenv/versions/3.10.1/envs/py310-sceptretest1/lib/python3.10/site-packages/setuptools/__init__.py", line 20, in <module>
          from setuptools.dist import Distribution, Feature
        File "/Users/zaro0508/.pyenv/versions/3.10.1/envs/py310-sceptretest1/lib/python3.10/site-packages/setuptools/dist.py", line 35, in <module>
          from setuptools.depends import Require
        File "/Users/zaro0508/.pyenv/versions/3.10.1/envs/py310-sceptretest1/lib/python3.10/site-packages/setuptools/depends.py", line 7, in <module>
          from .py33compat import Bytecode
        File "/Users/zaro0508/.pyenv/versions/3.10.1/envs/py310-sceptretest1/lib/python3.10/site-packages/setuptools/py33compat.py", line 55, in <module>
          unescape = getattr(html, 'unescape', html_parser.HTMLParser().unescape)
      AttributeError: 'HTMLParser' object has no attribute 'unescape'
      [end of output]
```
