### PR TITLE
[Resolve #1212] Conditional Stacks via "ignore" and "obsolete"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.52.0
+    rev: v0.61.5
     hooks:
       - id: cfn-python-lint
         args:

--- a/docs/_source/conf.py
+++ b/docs/_source/conf.py
@@ -68,7 +68,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set 'language' from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -185,10 +185,10 @@ epub_exclude_files = ['search.html']
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/', None),
+    'python': ('https://docs.python.org/3/', None),
     'boto3': (
-        'https://boto3.readthedocs.io/en/latest/',
-        'https://boto3.readthedocs.io/en/latest/objects.inv',
+        'https://boto3.amazonaws.com/v1/documentation/api/latest/',
+        'https://boto3.amazonaws.com/v1/documentation/api/latest/objects.inv',
     ),
     'deepdiff': (
         'https://zepworks.com/deepdiff/current/',

--- a/docs/_source/docs/faq.rst
+++ b/docs/_source/docs/faq.rst
@@ -106,14 +106,15 @@ in its Stack and StackGroup Configs; If you delete a Stack Config, Sceptre won't
 
 Therefore, the way to accomplish this "clean up" operation is to perform the change in 3 steps:
 
-1. First, add ``launch_action: "delete"`` to the Stack Config(s) you want to clean up.
-   For more information on ``launch_action``, see the :ref:`Stack Config entry on it<launch_action>`.
-2. Run ``sceptre launch`` to apply the change to AWS. This will cause that stack to be deleted.
-3. Delete the local Stack Config files you added the launch_action to in step 1, since the stacks
-   they create have all been deleted.
+1. First, add ``obsolete: True`` to the Stack Config(s) you want to clean up.
+   For more information on ``obsolete``, see the :ref:`Stack Config entry on it<obsolete>`.
+2. Update your CI/CD process to run ``sceptre launch --prune`` instead of ``sceptre launch``. This
+   will cause all stacks marked as obsolete to be deleted going forward.
+3. Once your CI/CD process has cleaned up all the obsolete stacks, delete the local Stack Config files
+   you marked as obsolete in step 1, since the stacks they create have all been deleted.
 
 .. note::
 
-   Using ``launch_action: "delete"`` will not work if any other stacks depend on that stack that are
-   not themselves marked with ``launch_action: "delete"``. Attempting to launch any stacks that
-   depend on a stack marked "delete" will result in Sceptre immediately failing the launch.
+   Using ``obsolete: True`` will not work if any other stacks depend on that stack that are
+   not themselves obsolete. Attempting to prune any stacks that depend on a obsolete stack will
+   result in Sceptre immediately failing the launch.

--- a/docs/_source/docs/faq.rst
+++ b/docs/_source/docs/faq.rst
@@ -116,5 +116,5 @@ Therefore, the way to accomplish this "clean up" operation is to perform the cha
 .. note::
 
    Using ``obsolete: True`` will not work if any other stacks depend on that stack that are
-   not themselves obsolete. Attempting to prune any stacks that depend on a obsolete stack will
-   result in Sceptre immediately failing the launch.
+   not themselves obsolete. Attempting to prune any obsolete stacks that are depended on by
+   non-obsolete stacks will result in Sceptre immediately failing the launch.

--- a/docs/_source/docs/faq.rst
+++ b/docs/_source/docs/faq.rst
@@ -101,8 +101,8 @@ creating stacks that don't exist and updating stacks that do exist. This makes i
 command to configure your CI/CD system to invoke. However, sometimes you need to delete a stack that
 isn't needed anymore and you want this automatically applied by the same process.
 
-This "clean up" is complicated by the fact that Sceptre doesn't know about anything that isn't
-in its Stack and StackGroup Configs; If you delete a Stack Config, Sceptre won't know to clean it up.
+This "clean up" is complicated by the fact that Sceptre doesn't know anything that isn't in its
+Stack and StackGroup Configs; If you delete a Stack Config, Sceptre won't know to clean it up.
 
 Therefore, the way to accomplish this "clean up" operation is to perform the change in 3 steps:
 

--- a/docs/_source/docs/faq.rst
+++ b/docs/_source/docs/faq.rst
@@ -93,13 +93,13 @@ Sceptre project, see the `sceptre-sam-handler`_ page on PyPI.
 
 .. _sceptre-sam-handler: https://pypi.org/project/sceptre-sam-handler/
 
-My CI/CD process uses ``sceptre launch``. How do I delete stacks that aren't needed any more?
+My CI/CD process uses ``sceptre launch``. How do I delete stacks that aren't needed anymore?
 ---------------------------------------------------------------------------------------------
 
 Running the ``launch`` command is a very useful "1-stop-shop" to apply changes from Stack Configs,
 creating stacks that don't exist and updating stacks that do exist. This makes it a very useful
 command to configure your CI/CD system to invoke. However, sometimes you need to delete a stack that
-isn't needed any more and you want this automatically applied by the same process.
+isn't needed anymore and you want this automatically applied by the same process.
 
 This "clean up" is complicated by the fact that Sceptre doesn't know about anything that isn't
 in its Stack and StackGroup Configs; If you delete a Stack Config, Sceptre won't know to clean it up.

--- a/docs/_source/docs/faq.rst
+++ b/docs/_source/docs/faq.rst
@@ -104,13 +104,13 @@ isn't needed anymore and you want this automatically applied by the same process
 This "clean up" is complicated by the fact that Sceptre doesn't know about anything that isn't
 in its Stack and StackGroup Configs; If you delete a Stack Config, Sceptre won't know to clean it up.
 
-Therefore, the way to accomplish this "clean up" operation is to perform the change in 2 steps:
+Therefore, the way to accomplish this "clean up" operation is to perform the change in 3 steps:
 
-1. First, add ``launch_action: "delete"`` to the Stack Config(s) you want to clean up. This will
-   cause that stack to be deleted (if it has been deployed to AWS) when you run ``sceptre launch``.
+1. First, add ``launch_action: "delete"`` to the Stack Config(s) you want to clean up.
    For more information on ``launch_action``, see the :ref:`Stack Config entry on it<launch_action>`.
-2. Once you've launched the Stack(s) to have them deleted this way, only **then** should you
-   delete the Stack Configs.
+2. Run ``sceptre launch`` to apply the change to AWS. This will cause that stack to be deleted.
+3. Delete the local Stack Config files you added the launch_action to in step 1, since the stacks
+   they create have all been deleted.
 
 .. note::
 

--- a/docs/_source/docs/faq.rst
+++ b/docs/_source/docs/faq.rst
@@ -107,8 +107,8 @@ in its Stack and StackGroup Configs; If you delete a Stack Config, Sceptre won't
 Therefore, the way to accomplish this "clean up" operation is to perform the change in 2 steps:
 
 1. First, add ``launch_action: "delete"`` to the Stack Config(s) you want to clean up. This will
-   cause that stack to be deleted (if it exists) when you run ``sceptre launch``. For more information
-   on ``launch_action``, see the :ref:`Stack Config entry on it<launch_action>`.
+   cause that stack to be deleted (if it has been deployed to AWS) when you run ``sceptre launch``.
+   For more information on ``launch_action``, see the :ref:`Stack Config entry on it<launch_action>`.
 2. Once you've launched the Stack(s) to have them deleted this way, only **then** should you
    delete the Stack Configs.
 

--- a/docs/_source/docs/faq.rst
+++ b/docs/_source/docs/faq.rst
@@ -111,3 +111,9 @@ Therefore, the way to accomplish this "clean up" operation is to perform the cha
    on ``launch_action``, see the :ref:`Stack Config entry on it<launch_action>`.
 2. Once you've launched the Stack(s) to have them deleted this way, only **then** should you
    delete the Stack Configs.
+
+.. note::
+
+   Using ``launch_action: "delete"`` will not work if any other stacks depend on that stack that are
+   not themselves marked with ``launch_action: "delete"``. Attempting to launch any stacks that
+   depend on a stack marked "delete" will result in Sceptre immediately failing the launch.

--- a/docs/_source/docs/faq.rst
+++ b/docs/_source/docs/faq.rst
@@ -104,7 +104,7 @@ isn't needed anymore and you want this automatically applied by the same process
 This "clean up" is complicated by the fact that Sceptre doesn't know about anything that isn't
 in its Stack and StackGroup Configs; If you delete a Stack Config, Sceptre won't know to clean it up.
 
-Therefore, the way to accomplish this "clean up" operation is to perform the change in 2 stages:
+Therefore, the way to accomplish this "clean up" operation is to perform the change in 2 steps:
 
 1. First, add ``launch_action: "delete"`` to the Stack Config(s) you want to clean up. This will
    cause that stack to be deleted (if it exists) when you run ``sceptre launch``. For more information

--- a/docs/_source/docs/stack_config.rst
+++ b/docs/_source/docs/stack_config.rst
@@ -111,14 +111,14 @@ launch_action
 * Inheritance strategy: Overrides parent if set
 
 This setting determines how the stack should be handled when running ``sceptre launch``. This must
-be one of three values:
+be one of the following values:
 
-* "deploy" - The stack will be created/updated as "normal". **This is the default value on all stacks**
-* "delete" - If the stack does NOT exist, it won't be created; It will be excluded from the launch.
+* **"deploy"** - The stack will be created/updated as "normal". **This is the default value on all stacks**
+* **"delete"** - If the stack does NOT exist, it won't be created; It will be excluded from the launch.
    If the stack *DOES* exist, it will be deleted. You **cannot** mark as stack with "delete" that
    other stacks marked "deploy" depend upon. If a stack is marked "delete", you do not need any
    other Stack Config keys present on it in order for it to be deleted.
-* "skip" - The stack will be completely ignored by the launch command. If the stack does NOT exist,
+* **"skip"** - The stack will be completely ignored by the launch command. If the stack does NOT exist,
    it won't be created. If it *DOES* exist, it will neither be updated nor deleted. You *can* mark
    a stack with "skip" that other stacks depend upon, but the launch will fail if dependent stacks
    require resources or outputs that don't exist because the stack has been skipped.

--- a/docs/_source/docs/stack_config.rst
+++ b/docs/_source/docs/stack_config.rst
@@ -111,12 +111,14 @@ ignore
 This configuration should be set with a boolean value of ``True`` or ``False``. By default, this is
 set to ``False`` on all stacks.
 
-This setting determines how the stack should be handled when running ``sceptre launch``. A stack
+``ignore`` determines how the stack should be handled when running ``sceptre launch``. A stack
 marked with ``ignore: True`` will be completely ignored by the launch command. If the stack does NOT
-exist, it won't be created. If it *DOES* exist, it will neither be updated nor deleted. You *can*
-mark a stack with ``ignore: True`` that other non-ignored stacks depend on, but the lauch will fail
-if dependent stacks require resources or outputs that don't exist because the stack has not been
-launched. **Therefore, only ignore dependencies of other stacks if you are aware of the risks of launch failure.**
+exist on AWS, it won't be created. If it *DOES* exist, it will neither be updated nor deleted.
+
+You *can* mark a stack with ``ignore: True`` that other non-ignored stacks depend on, but the launch
+will fail if dependent stacks require resources or outputs that don't exist because the stack has not been
+launched. **Therefore, only ignore dependencies of other stacks if you are aware of the risks of
+launch failure.**
 
 This setting can be especially useful when combined with Jinja logic to exclude certain stacks from
 launch based upon conditional Jinja-based template logic.

--- a/docs/_source/docs/stack_config.rst
+++ b/docs/_source/docs/stack_config.rst
@@ -116,7 +116,8 @@ be one of three values:
 * "deploy" - The stack will be created/updated as "normal". **This is the default value on all stacks**
 * "delete" - If the stack does NOT exist, it won't be created; It will be excluded from the launch.
    If the stack *DOES* exist, it will be deleted. You **cannot** mark as stack with "delete" that
-   other stacks marked "deploy" depend upon.
+   other stacks marked "deploy" depend upon. If a stack is marked "delete", you do not need any
+   other Stack Config keys present on it in order for it to be deleted.
 * "skip" - The stack will be completely ignored by the launch command. If the stack does NOT exist,
    it won't be created. If it *DOES* exist, it will neither be updated nor deleted. You *can* mark
    a stack with "skip" that other stacks depend upon, but the launch will fail if dependent stacks

--- a/docs/_source/docs/stack_config.rst
+++ b/docs/_source/docs/stack_config.rst
@@ -139,51 +139,7 @@ For Example:
 .. note::
    The ``ignore`` configuration **only** applies to the **launch** command. You can still run
    ``create``, ``update``, or ``delete`` commands on a stack marked with ``ignore: "true"``;
-   these commands will ignore the ``ignore`` setting and act upon the stack regardless.
-
-.. _launch_action:
-
-launch_action
-~~~~~~~~~~~~~
-* Resolvable: No
-* Can be inherited from StackGroup: Yes
-* Inheritance strategy: Overrides parent if set
-
-This setting determines how the stack should be handled when running ``sceptre launch``. This must
-be one of the following values:
-
-* **"delete"** - If the stack does NOT exist, it won't be created; It will be excluded from the launch.
-   If the stack *DOES* exist, it will be deleted. You **cannot** mark as stack with "delete" that
-   other stacks marked "deploy" depend upon. If a stack is marked "delete", you do not need any
-   other Stack Config keys present on it in order for it to be deleted.
-
-
-This setting is especially useful in two situations:
-
-1. You can use it to make conditional stacks that may or may not be included in a deployment based
-   upon some Jinja2 logic.
-2. If your CI/CD deployment process runs ``sceptre launch``, you can use this to have stacks deleted
-   when it runs. Once the stack(s) have been deleted, you can then delete the StackConfig file.
-
-For Example:
-
-.. code-block:: yaml
-
-   template:
-       path: "my/test/resources.yaml"
-
-   # Configured this way, if the var "use_test_resources" is not true, the stack will be deleted and
-   # excluded from the launch. But if "use_test_resources" is true, the stack will be deployed along
-   # with the rest of the resources being deployed.
-   {% if not var.use_test_resources %}
-   launch_action: "delete"
-   {% endif %}
-
-.. note::
-
-   The ``launch_action`` configuration only applies to the **launch** command. You can still run
-   ``create``, ``update``, or ``delete`` commands on a stack marked with ``launch_action: "delete"``;
-   these commands will ignore the launch_action setting.
+   these commands will ignore the ``ignore`` setting and act upon the stack the same as any other.
 
 notifications
 ~~~~~~~~~~~~~
@@ -196,6 +152,39 @@ can be specified per Stack. This configuration will be used by the ``create``,
 ``update``, and ``delete`` commands. More information about Stack notifications
 can found under the relevant section in the `AWS CloudFormation API
 documentation`_.
+
+.. _`obsolete`:
+
+obsolete
+~~~~~~~~
+* Resolvable: No
+* Can be inherited from StackGroup: Yes
+* Inheritance strategy: Overrides parent if set
+
+This configuration should be set with a boolean value of ``True`` or ``False``. By default, this is
+set to ``False`` on all stacks.
+
+The ``obsolete`` configuration should be used to mark stacks to be deleted via ``prune`` actions,
+if they currently exist on AWS. (If they don't exist on AWS, pruning does nothing).
+
+There are two ways to prune obsolete stacks:
+
+1. ``sceptre prune`` will delete *all* obsolete stacks in the **project**
+2. ``sceptre launch --prune [command path]`` will delete all obsolete stacks in the command path
+   before continuing with the launch.
+
+In practice, the ``obsolete`` configuration operates identically to ``ignore`` with the extra prune
+effects. When the ``launch`` command is invoked without the ``--prune`` flag, obsolete stacks will
+be ignored and not launched, just as if ``ignore: True`` was on the Stack Config.
+
+**Important**: You cannot have non-obsolete stacks dependent upon obsolete stacks. Both the
+``prune`` and ``launch --prune`` will reject such configurations and will not continue if this sort
+of dependency structure is detected. Only obsolete stacks can depend on obsolete stacks.
+
+.. note::
+   The ``obsolete`` configuration **only** applies to the **launch** and **prune** commands. You can
+   still run ``create``, ``update``, or ``delete`` commands on a stack marked with ``obsolete: "true"``;
+   these commands will ignore the ``obsolete`` setting and act upon the stack the same as any other.
 
 on_failure
 ~~~~~~~~~~

--- a/docs/_source/docs/stack_config.rst
+++ b/docs/_source/docs/stack_config.rst
@@ -185,7 +185,7 @@ of dependency structure is detected. Only obsolete stacks can depend on obsolete
 
 .. note::
    The ``obsolete`` configuration **only** applies to the **launch** and **prune** commands. You can
-   still run ``create``, ``update``, or ``delete`` commands on a stack marked with ``obsolete: "true"``;
+   still run ``create``, ``update``, or ``delete`` commands on a stack marked with ``obsolete: True``;
    these commands will ignore the ``obsolete`` setting and act upon the stack the same as any other.
 
 on_failure

--- a/docs/_source/docs/stack_config.rst
+++ b/docs/_source/docs/stack_config.rst
@@ -16,8 +16,9 @@ particular Stack. The available keys are listed below.
 -  `template_path`_ or `template`_ *(required)*
 -  `dependencies`_ *(optional)*
 -  `hooks`_ *(optional)*
--  `launch_action`_ *(optional)*
+-  `ignore`_ *(optional)*
 -  `notifications`_ *(optional)*
+-  `obsolete`_ *(optional)*
 -  `on_failure`_ *(optional)*
 -  `parameters`_ *(optional)*
 -  `protected`_ *(optional)*
@@ -101,6 +102,44 @@ hooks
 A list of arbitrary shell or Python commands or scripts to run. Find out more
 in the :doc:`hooks` section.
 
+ignore
+~~~~~~
+* Resolvable: No
+* Can be inherited from StackGroup: Yes
+* Inheritance strategy: Overrides parent if set
+
+This configuration should be set with a boolean value of ``True`` or ``False``. By default, this is
+set to ``False`` on all stacks.
+
+This setting determines how the stack should be handled when running ``sceptre launch``. A stack
+marked with ``ignore: True`` will be completely ignored by the launch command. If the stack does NOT
+exist, it won't be created. If it *DOES* exist, it will neither be updated nor deleted. You *can*
+mark a stack with ``ignore: True`` that other non-ignored stacks depend on, but the lauch will fail
+if dependent stacks require resources or outputs that don't exist because the stack has not been
+launched. **Therefore, only ignore dependencies of other stacks if you are aware of the risks of launch failure.**
+
+This setting can be especially useful when combined with Jinja logic to exclude certain stacks from
+launch based upon conditional Jinja-based template logic.
+
+For Example:
+
+.. code-block:: yaml
+
+   template:
+       path: "my/test/resources.yaml"
+
+   # Configured this way, if the var "use_test_resources" is not true, the stack will not be launched
+   # and instead excluded from the launch. But if "use_test_resources" is true, the stack will be
+   # deployed along with the rest of the resources being deployed.
+   {% if not var.use_test_resources %}
+   ignore: True
+   {% endif %}
+
+
+.. note::
+   The ``ignore`` configuration **only** applies to the **launch** command. You can still run
+   ``create``, ``update``, or ``delete`` commands on a stack marked with ``ignore: "true"``;
+   these commands will ignore the ``ignore`` setting and act upon the stack regardless.
 
 .. _launch_action:
 
@@ -113,16 +152,11 @@ launch_action
 This setting determines how the stack should be handled when running ``sceptre launch``. This must
 be one of the following values:
 
-* **"deploy"** - The stack will be created/updated as "normal". **This is the default value on all stacks**
 * **"delete"** - If the stack does NOT exist, it won't be created; It will be excluded from the launch.
    If the stack *DOES* exist, it will be deleted. You **cannot** mark as stack with "delete" that
    other stacks marked "deploy" depend upon. If a stack is marked "delete", you do not need any
    other Stack Config keys present on it in order for it to be deleted.
-* **"skip"** - The stack will be completely ignored by the launch command. If the stack does NOT exist,
-   it won't be created. If it *DOES* exist, it will neither be updated nor deleted. You *can* mark
-   a stack with "skip" that other stacks depend upon, but the launch will fail if dependent stacks
-   require resources or outputs that don't exist because the stack has been skipped.
-   **Use this option at your own risk.**
+
 
 This setting is especially useful in two situations:
 

--- a/docs/_source/docs/stack_config.rst
+++ b/docs/_source/docs/stack_config.rst
@@ -140,7 +140,7 @@ For Example:
 
 .. note::
    The ``ignore`` configuration **only** applies to the **launch** command. You can still run
-   ``create``, ``update``, or ``delete`` commands on a stack marked with ``ignore: "true"``;
+   ``create``, ``update``, or ``delete`` commands on a stack marked with ``ignore: True``;
    these commands will ignore the ``ignore`` setting and act upon the stack the same as any other.
 
 notifications
@@ -171,7 +171,7 @@ if they currently exist on AWS. (If they don't exist on AWS, pruning does nothin
 
 There are two ways to prune obsolete stacks:
 
-1. ``sceptre prune`` will delete *all* obsolete stacks in the **project**
+1. ``sceptre prune`` will delete *all* obsolete stacks in the **project**.
 2. ``sceptre launch --prune [command path]`` will delete all obsolete stacks in the command path
    before continuing with the launch.
 

--- a/integration-tests/features/launch-stack-group.feature
+++ b/integration-tests/features/launch-stack-group.feature
@@ -48,23 +48,30 @@ Feature: Launch stack_group
     When the user launches stack_group "2" with ignore dependencies
     Then all the stacks in stack_group "2" are in "CREATE_COMPLETE"
 
-  Scenario: launch a StackGroup with stacks with launch_type = delete and skip that has not been launched
+  Scenario: launch a StackGroup with ignored and obsolete stacks that have not been launched
     Given stack_group "launch-actions" does not exist
     When the user launches stack_group "launch-actions"
-    Then stack "launch-actions/delete" does not exist
-    And stack "launch-actions/skip" does not exist
+    Then stack "launch-actions/obsolete" does not exist
+    And stack "launch-actions/ignore" does not exist
     And stack "launch-actions/deploy" exists in "CREATE_COMPLETE" state
 
-  Scenario: launch a StackGroup with stacks with launch_type = delete that currently exist
-    Given  stack "launch-actions/delete" exists using "valid_template.json"
+  Scenario: launch a StackGroup without --prune with obsolete stacks that currently exist
+    Given  stack "launch-actions/obsolete" exists using "valid_template.json"
     And stack "launch-actions/deploy" exists using "valid_template.json"
     When the user launches stack_group "launch-actions"
-    Then stack "launch-actions/delete" does not exist
+    Then stack "launch-actions/obsolete" exists in "CREATE_COMPLETE" state
     And stack "launch-actions/deploy" exists in "CREATE_COMPLETE" state
 
-  Scenario: launch a StackGroup with stacks with launch_type = skip that currently exist
-    Given  stack "launch-actions/skip" exists using "valid_template.json"
+  Scenario: launch a StackGroup with --prune with obsolete stacks that currently exist
+    Given  stack "launch-actions/obsolete" exists using "valid_template.json"
+    And stack "launch-actions/deploy" exists using "valid_template.json"
+    When the user launches stack_group "launch-actions" with --prune
+    Then stack "launch-actions/obsolete" does not exist
+    And stack "launch-actions/deploy" exists in "CREATE_COMPLETE" state
+
+  Scenario: launch a StackGroup with ignored stacks that currently exist
+    Given  stack "launch-actions/ignore" exists using "valid_template.json"
     And stack "launch-actions/deploy" exists using "valid_template.json"
     When the user launches stack_group "launch-actions"
-    Then stack "launch-actions/skip" exists in "CREATE_COMPLETE" state
+    Then stack "launch-actions/ignore" exists in "CREATE_COMPLETE" state
     And stack "launch-actions/deploy" exists in "CREATE_COMPLETE" state

--- a/integration-tests/features/launch-stack-group.feature
+++ b/integration-tests/features/launch-stack-group.feature
@@ -48,15 +48,23 @@ Feature: Launch stack_group
     When the user launches stack_group "2" with ignore dependencies
     Then all the stacks in stack_group "2" are in "CREATE_COMPLETE"
 
-  Scenario: launch a StackGroup with stacks with launch_type = excluded that has not been launched
+  Scenario: launch a StackGroup with stacks with launch_type = delete and skip that has not been launched
     Given stack_group "launch-actions" does not exist
     When the user launches stack_group "launch-actions"
-    Then stack "launch-actions/excluded" does not exist
-    And stack "launch-actions/included" exists in "CREATE_COMPLETE" state
+    Then stack "launch-actions/delete" does not exist
+    And stack "launch-actions/skip" does not exist
+    And stack "launch-actions/deploy" exists in "CREATE_COMPLETE" state
 
-  Scenario: launch a StackGroup with stacks with launch_type = excluded that currently exist
-    Given  stack "launch-actions/excluded" exists using "valid_template.json"
-    And stack "launch-actions/included" exists using "valid_template.json"
+  Scenario: launch a StackGroup with stacks with launch_type = delete that currently exist
+    Given  stack "launch-actions/delete" exists using "valid_template.json"
+    And stack "launch-actions/deploy" exists using "valid_template.json"
     When the user launches stack_group "launch-actions"
-    Then stack "launch-actions/excluded" does not exist
-    And stack "launch-actions/included" exists in "CREATE_COMPLETE" state
+    Then stack "launch-actions/delete" does not exist
+    And stack "launch-actions/deploy" exists in "CREATE_COMPLETE" state
+
+  Scenario: launch a StackGroup with stacks with launch_type = skip that currently exist
+    Given  stack "launch-actions/skip" exists using "valid_template.json"
+    And stack "launch-actions/deploy" exists using "valid_template.json"
+    When the user launches stack_group "launch-actions"
+    Then stack "launch-actions/skip" exists in "CREATE_COMPLETE" state
+    And stack "launch-actions/deploy" exists in "CREATE_COMPLETE" state

--- a/integration-tests/features/launch-stack.feature
+++ b/integration-tests/features/launch-stack.feature
@@ -24,7 +24,7 @@ Feature: Launch stack
     When the user launches stack "1/A" with ignore dependencies
     Then stack "1/A" exists in "CREATE_COMPLETE" state
 
-  Scenario: launch an obsolete that doesn't exist
+  Scenario: launch an obsolete stack that doesn't exist
     Given stack "launch-actions/obsolete" does not exist
     When the user launches stack "launch-actions/obsolete"
     Then stack "launch-actions/obsolete" does not exist

--- a/integration-tests/features/launch-stack.feature
+++ b/integration-tests/features/launch-stack.feature
@@ -24,22 +24,27 @@ Feature: Launch stack
     When the user launches stack "1/A" with ignore dependencies
     Then stack "1/A" exists in "CREATE_COMPLETE" state
 
-  Scenario: launch a stack with launch_type = delete that doesn't exist
-    Given stack "launch-actions/delete" does not exist
-    When the user launches stack "launch-actions/delete"
-    Then stack "launch-actions/delete" does not exist
+  Scenario: launch an obsolete that doesn't exist
+    Given stack "launch-actions/obsolete" does not exist
+    When the user launches stack "launch-actions/obsolete"
+    Then stack "launch-actions/obsolete" does not exist
 
-  Scenario: launch a stack with launch_type = delete that does exist
-    Given stack "launch-actions/delete" exists using "valid_template.json"
-    When the user launches stack "launch-actions/delete"
-    Then stack "launch-actions/delete" does not exist
+  Scenario: launch an obsolete stack that does exist without --prune
+    Given stack "launch-actions/obsolete" exists using "valid_template.json"
+    When the user launches stack "launch-actions/obsolete"
+    Then stack "launch-actions/obsolete" exists in "CREATE_COMPLETE" state
 
-  Scenario: launch a stack with launch_type = skip that doesn't exist
-    Given stack "launch-actions/skip" does not exist
-    When the user launches stack "launch-actions/skip"
-    Then stack "launch-actions/skip" does not exist
+  Scenario: launch an obsolete stack that does exist with --prune
+    Given stack "launch-actions/obsolete" exists using "valid_template.json"
+    When the user launches stack "launch-actions/obsolete" with --prune
+    Then stack "launch-actions/obsolete" does not exist
 
-  Scenario: launch a stack with launch_type = skip that does exist
-    Given stack "launch-actions/skip" exists using "valid_template.json"
-    When the user launches stack "launch-actions/skip"
-    Then stack "launch-actions/skip" exists in "CREATE_COMPLETE" state
+  Scenario: launch an ignored stack that doesn't exist
+    Given stack "launch-actions/ignore" does not exist
+    When the user launches stack "launch-actions/ignore"
+    Then stack "launch-actions/ignore" does not exist
+
+  Scenario: launch an ignored stack that does exist
+    Given stack "launch-actions/ignore" exists using "valid_template.json"
+    When the user launches stack "launch-actions/ignore"
+    Then stack "launch-actions/ignore" exists in "CREATE_COMPLETE" state

--- a/integration-tests/features/launch-stack.feature
+++ b/integration-tests/features/launch-stack.feature
@@ -24,12 +24,22 @@ Feature: Launch stack
     When the user launches stack "1/A" with ignore dependencies
     Then stack "1/A" exists in "CREATE_COMPLETE" state
 
-  Scenario: launch a stack with launch_type = exclude that doesn't exist
-    Given stack "launch-actions/excluded" does not exist
-    When the user launches stack "launch-actions/excluded"
-    Then stack "launch-actions/excluded" does not exist
+  Scenario: launch a stack with launch_type = delete that doesn't exist
+    Given stack "launch-actions/delete" does not exist
+    When the user launches stack "launch-actions/delete"
+    Then stack "launch-actions/delete" does not exist
 
-  Scenario: launch a stack with launch_type = exclude that does exist
-    Given stack "launch-actions/excluded" exists using "valid_template.json"
-    When the user launches stack "launch-actions/excluded"
-    Then stack "launch-actions/excluded" does not exist
+  Scenario: launch a stack with launch_type = delete that does exist
+    Given stack "launch-actions/delete" exists using "valid_template.json"
+    When the user launches stack "launch-actions/delete"
+    Then stack "launch-actions/delete" does not exist
+
+  Scenario: launch a stack with launch_type = skip that doesn't exist
+    Given stack "launch-actions/skip" does not exist
+    When the user launches stack "launch-actions/skip"
+    Then stack "launch-actions/skip" does not exist
+
+  Scenario: launch a stack with launch_type = skip that does exist
+    Given stack "launch-actions/skip" exists using "valid_template.json"
+    When the user launches stack "launch-actions/skip"
+    Then stack "launch-actions/skip" exists in "CREATE_COMPLETE" state

--- a/integration-tests/features/prune.feature
+++ b/integration-tests/features/prune.feature
@@ -1,0 +1,22 @@
+Feature: Prune
+
+  Scenario: Prune with no stacks marked obsolete does nothing
+    Given stack "pruning/not-obsolete" exists using "valid_template.json"
+    When command path "pruning/not-obsolete" is pruned
+    Then stack "pruning/not-obsolete" exists in "CREATE_COMPLETE" state
+
+  Scenario: Prune whole project deletes all obsolete stacks that exist
+    Given all the stacks in stack_group "pruning" are in "CREATE_COMPLETE"
+    And stack "launch-actions/obsolete" exists using "valid_template.json"
+    When the whole project is pruned
+    Then stack "pruning/obsolete-1" does not exist
+    And stack "pruning/obsolete-2" does not exist
+    And stack "launch-actions/obsolete" does not exist
+    And stack "pruning/not-obsolete" exists in "CREATE_COMPLETE" state
+
+  Scenario: Prune command path only deletes stacks on command path
+    Given stack "pruning/obsolete-1" exists using "valid_template.json"
+    And stack "pruning/obsolete-2" exists using "valid_template.json"
+    When command path "pruning/obsolete-1.yaml" is pruned
+    Then stack "pruning/obsolete-1" does not exist
+    And stack "pruning/obsolete-2" exists in "CREATE_COMPLETE" state

--- a/integration-tests/sceptre-project/config/launch-actions/delete.yaml
+++ b/integration-tests/sceptre-project/config/launch-actions/delete.yaml
@@ -1,4 +1,0 @@
-# This stack shouldn't ever be launched
-launch_action: delete
-
-# Since the launch type is exclude, we don't need any other attributes

--- a/integration-tests/sceptre-project/config/launch-actions/deploy.yaml
+++ b/integration-tests/sceptre-project/config/launch-actions/deploy.yaml
@@ -1,5 +1,2 @@
-# This is the default so it isn't required, but for testing let's explicitly set it.
-launch_action: deploy
-
 template:
   path: valid_template.yaml

--- a/integration-tests/sceptre-project/config/launch-actions/ignore.yaml
+++ b/integration-tests/sceptre-project/config/launch-actions/ignore.yaml
@@ -1,4 +1,4 @@
-launch_action: skip
+ignore: True
 
 template:
   path: valid_template.yaml

--- a/integration-tests/sceptre-project/config/launch-actions/obsolete.yaml
+++ b/integration-tests/sceptre-project/config/launch-actions/obsolete.yaml
@@ -1,0 +1,5 @@
+# This stack shouldn't ever be launched
+obsolete: True
+
+template:
+  path: valid_template.yaml

--- a/integration-tests/sceptre-project/config/launch-actions/obsolete.yaml
+++ b/integration-tests/sceptre-project/config/launch-actions/obsolete.yaml
@@ -1,4 +1,3 @@
-# This stack shouldn't ever be launched
 obsolete: True
 
 template:

--- a/integration-tests/sceptre-project/config/pruning/not-obsolete.yaml
+++ b/integration-tests/sceptre-project/config/pruning/not-obsolete.yaml
@@ -1,0 +1,3 @@
+template:
+  path: /Users/jfalkenstein/sceptre/integration-tests/sceptre-project/templates/valid_template.json
+  type: file

--- a/integration-tests/sceptre-project/config/pruning/obsolete-1.yaml
+++ b/integration-tests/sceptre-project/config/pruning/obsolete-1.yaml
@@ -1,0 +1,4 @@
+obsolete: true
+template:
+  path: /Users/jfalkenstein/sceptre/integration-tests/sceptre-project/templates/valid_template.json
+  type: file

--- a/integration-tests/sceptre-project/config/pruning/obsolete-2.yaml
+++ b/integration-tests/sceptre-project/config/pruning/obsolete-2.yaml
@@ -1,0 +1,4 @@
+obsolete: true
+template:
+  path: /Users/jfalkenstein/sceptre/integration-tests/sceptre-project/templates/valid_template.json
+  type: file

--- a/integration-tests/sceptre-project/templates/sam_template.yaml
+++ b/integration-tests/sceptre-project/templates/sam_template.yaml
@@ -5,5 +5,5 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: index.handler
-      Runtime: python3.6
+      Runtime: python3.9
       InlineCode: "print('Hello World!')"

--- a/integration-tests/sceptre-project/templates/sam_updated_template.yaml
+++ b/integration-tests/sceptre-project/templates/sam_updated_template.yaml
@@ -5,5 +5,5 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: index.handler
-      Runtime: python3.6
+      Runtime: python3.9
       InlineCode: "print('Hello Again World!')"

--- a/integration-tests/steps/project_dependencies.py
+++ b/integration-tests/steps/project_dependencies.py
@@ -51,7 +51,7 @@ def step_impl(context: Context, stack_name):
     buckets = get_template_buckets(plan)
     assert len(buckets) > 0
     filtered_objects = list(chain.from_iterable(
-        bucket.objects.filter_by(
+        bucket.objects.filter(
             Prefix=stack_name
         )
         for bucket in buckets

--- a/integration-tests/steps/stack_groups.py
+++ b/integration-tests/steps/stack_groups.py
@@ -48,24 +48,28 @@ def step_impl(context, stack_group_name, status):
 
 @when('the user launches stack_group "{stack_group_name}"')
 def step_impl(context, stack_group_name):
-    sceptre_context = SceptreContext(
-        command_path=stack_group_name,
-        project_path=context.sceptre_dir
-    )
-    launcher = Launcher(sceptre_context)
-    launcher.launch(True)
+    launch_stack_group(context, stack_group_name)
+
+
+@when('the user launches stack_group "{stack_group_name}" with --prune')
+def step_impl(context, stack_group_name):
+    launch_stack_group(context, stack_group_name, True)
 
 
 @when('the user launches stack_group "{stack_group_name}" with ignore dependencies')
 def step_impl(context, stack_group_name):
+    launch_stack_group(context, stack_group_name, False, True)
+
+
+def launch_stack_group(context, stack_group_name, prune=False, ignore_dependencies=False):
     sceptre_context = SceptreContext(
         command_path=stack_group_name,
         project_path=context.sceptre_dir,
-        ignore_dependencies=True
+        ignore_dependencies=ignore_dependencies
     )
 
     launcher = Launcher(sceptre_context)
-    launcher.launch(True)
+    launcher.launch(True, prune)
 
 
 @when('the user deletes stack_group "{stack_group_name}"')

--- a/integration-tests/steps/stack_groups.py
+++ b/integration-tests/steps/stack_groups.py
@@ -6,6 +6,7 @@ from botocore.exceptions import ClientError
 
 from helpers import read_template_file, get_cloudformation_stack_name, retry_boto_call
 from sceptre.cli.launch import Launcher
+from sceptre.cli.prune import PATH_FOR_WHOLE_PROJECT, Pruner
 from sceptre.context import SceptreContext
 from sceptre.diffing.diff_writer import DeepDiffWriter
 from sceptre.diffing.stack_differ import DeepDiffStackDiffer, DifflibStackDiffer
@@ -293,6 +294,17 @@ def step_impl(context, group_name, diff_type):
     differ = differ_classes[diff_type]()
     context.writer_class = writer_class[diff_type]
     context.output = list(sceptre_plan.diff(differ).values())
+
+
+@when("the whole project is pruned")
+def step_impl(context):
+    sceptre_context = SceptreContext(
+        command_path=PATH_FOR_WHOLE_PROJECT,
+        project_path=context.sceptre_dir,
+    )
+
+    pruner = Pruner(sceptre_context)
+    pruner.prune()
 
 
 def get_stack_creation_times(context, stacks):

--- a/integration-tests/steps/stack_groups.py
+++ b/integration-tests/steps/stack_groups.py
@@ -5,6 +5,7 @@ from behave import *
 from botocore.exceptions import ClientError
 
 from helpers import read_template_file, get_cloudformation_stack_name, retry_boto_call
+from sceptre.cli.launch import Launcher
 from sceptre.context import SceptreContext
 from sceptre.diffing.diff_writer import DeepDiffWriter
 from sceptre.diffing.stack_differ import DeepDiffStackDiffer, DifflibStackDiffer
@@ -51,9 +52,8 @@ def step_impl(context, stack_group_name):
         command_path=stack_group_name,
         project_path=context.sceptre_dir
     )
-
-    sceptre_plan = SceptrePlan(sceptre_context)
-    sceptre_plan.launch()
+    launcher = Launcher(sceptre_context)
+    launcher.launch(True)
 
 
 @when('the user launches stack_group "{stack_group_name}" with ignore dependencies')
@@ -64,8 +64,8 @@ def step_impl(context, stack_group_name):
         ignore_dependencies=True
     )
 
-    sceptre_plan = SceptrePlan(sceptre_context)
-    sceptre_plan.launch()
+    launcher = Launcher(sceptre_context)
+    launcher.launch(True)
 
 
 @when('the user deletes stack_group "{stack_group_name}"')

--- a/integration-tests/steps/stack_groups.py
+++ b/integration-tests/steps/stack_groups.py
@@ -69,7 +69,7 @@ def launch_stack_group(context, stack_group_name, prune=False, ignore_dependenci
     )
 
     launcher = Launcher(sceptre_context)
-    launcher.launch(True, prune)
+    launcher.launch(prune)
 
 
 @when('the user deletes stack_group "{stack_group_name}"')

--- a/integration-tests/steps/stacks.py
+++ b/integration-tests/steps/stacks.py
@@ -13,6 +13,7 @@ from contextlib import contextmanager
 from botocore.exceptions import ClientError
 from helpers import read_template_file, get_cloudformation_stack_name
 from helpers import retry_boto_call
+from sceptre.cli.launch import Launcher
 from sceptre.diffing.diff_writer import DeepDiffWriter, DiffWriter
 from sceptre.diffing.stack_differ import DeepDiffStackDiffer, DifflibStackDiffer, StackDiff
 
@@ -271,10 +272,10 @@ def step_impl(context, stack_name):
         project_path=context.sceptre_dir
     )
 
-    sceptre_plan = SceptrePlan(sceptre_context)
+    launcher = Launcher(sceptre_context)
 
     try:
-        sceptre_plan.launch()
+        launcher.launch(True)
     except Exception as e:
         context.error = e
 
@@ -287,10 +288,10 @@ def step_impl(context, stack_name):
         ignore_dependencies=True
     )
 
-    sceptre_plan = SceptrePlan(sceptre_context)
+    launcher = Launcher(sceptre_context)
 
     try:
-        sceptre_plan.launch()
+        launcher.launch(True)
     except Exception as e:
         context.error = e
 

--- a/integration-tests/steps/stacks.py
+++ b/integration-tests/steps/stacks.py
@@ -14,6 +14,7 @@ from botocore.exceptions import ClientError
 from helpers import read_template_file, get_cloudformation_stack_name
 from helpers import retry_boto_call
 from sceptre.cli.launch import Launcher
+from sceptre.cli.prune import Pruner
 from sceptre.diffing.diff_writer import DeepDiffWriter, DiffWriter
 from sceptre.diffing.stack_differ import DeepDiffStackDiffer, DifflibStackDiffer, StackDiff
 
@@ -273,6 +274,17 @@ def step_impl(context, stack_name):
 @when('the user launches stack "{stack_name}" with --prune')
 def step_impl(context, stack_name):
     launch_stack(context, stack_name, True)
+
+
+@when('command path "{path}" is pruned')
+def step_impl(context, path):
+    sceptre_context = SceptreContext(
+        command_path=path,
+        project_path=context.sceptre_dir,
+    )
+
+    pruner = Pruner(sceptre_context)
+    pruner.prune()
 
 
 def launch_stack(context, stack_name, prune=False, ignore_dependencies=False):

--- a/integration-tests/steps/stacks.py
+++ b/integration-tests/steps/stacks.py
@@ -285,7 +285,7 @@ def launch_stack(context, stack_name, prune=False, ignore_dependencies=False):
     launcher = Launcher(sceptre_context)
 
     try:
-        launcher.launch(True, prune)
+        launcher.launch(prune)
     except Exception as e:
         context.error = e
 

--- a/integration-tests/steps/stacks.py
+++ b/integration-tests/steps/stacks.py
@@ -267,33 +267,32 @@ def step_impl(context, stack_name):
 
 @when('the user launches stack "{stack_name}"')
 def step_impl(context, stack_name):
+    launch_stack(context, stack_name)
+
+
+@when('the user launches stack "{stack_name}" with --prune')
+def step_impl(context, stack_name):
+    launch_stack(context, stack_name, True)
+
+
+def launch_stack(context, stack_name, prune=False, ignore_dependencies=False):
     sceptre_context = SceptreContext(
         command_path=stack_name + '.yaml',
-        project_path=context.sceptre_dir
+        project_path=context.sceptre_dir,
+        ignore_dependencies=ignore_dependencies
     )
 
     launcher = Launcher(sceptre_context)
 
     try:
-        launcher.launch(True)
+        launcher.launch(True, prune)
     except Exception as e:
         context.error = e
 
 
 @when('the user launches stack "{stack_name}" with ignore dependencies')
 def step_impl(context, stack_name):
-    sceptre_context = SceptreContext(
-        command_path=stack_name + '.yaml',
-        project_path=context.sceptre_dir,
-        ignore_dependencies=True
-    )
-
-    launcher = Launcher(sceptre_context)
-
-    try:
-        launcher.launch(True)
-    except Exception as e:
-        context.error = e
+    launch_stack(context, stack_name, False, True)
 
 
 @when('the user describes the resources of stack "{stack_name}"')

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,10 +12,10 @@ pytest-sugar>=0.9.4,<1.0.0
 readme-renderer>=24.0,<25.0
 requests-mock>=1.9.3,<2.0
 setuptools==63.2.0
-Sphinx>=1.6.5,<4.3
+Sphinx>=1.6.5,<=5.1.1
 sphinx-click>=2.0.1,<4.0.0
 sphinx-rtd-theme==0.5.2
-sphinx-autodoc-typehints==1.12.0
+sphinx-autodoc-typehints==1.19.2
 docutils<0.17 # temporary fix for sphinx-rtd-theme==0.5.2, it depends on docutils<0.17
 tox>=3.23.0,<4.0.0
 twine>=1.12.1,<2.0.0

--- a/sceptre/cli/__init__.py
+++ b/sceptre/cli/__init__.py
@@ -16,6 +16,7 @@ import colorama
 from sceptre import __version__
 from sceptre.cli.new import new_group
 from sceptre.cli.create import create_command
+from sceptre.cli.prune import prune_command
 from sceptre.cli.update import update_command
 from sceptre.cli.delete import delete_command
 from sceptre.cli.launch import launch_command
@@ -92,3 +93,4 @@ cli.add_command(describe_group)
 cli.add_command(fetch_remote_template_command)
 cli.add_command(diff_command)
 cli.add_command(drift_group)
+cli.add_command(prune_command)

--- a/sceptre/cli/diff.py
+++ b/sceptre/cli/diff.py
@@ -49,9 +49,8 @@ logger = getLogger(__name__)
     'all_',
     is_flag=True,
     help=(
-         "If set, will perform diffing on ALL stacks, not just ones that have a \"deploy\" "
-         "launch_action; Otherwise, it will diff only stacks that would be created or updated when "
-         "running the launch command."
+         "If set, will perform diffing on ALL stacks, including ignored and obsolete ones; Otherwise, "
+         "it will diff only stacks that would be created or updated when running the launch command."
     )
 )
 @click.argument('path')
@@ -181,6 +180,5 @@ def output_buffer_with_normalized_bar_lengths(buffer: io.StringIO, output_stream
 
 
 def filter_plan_for_launchable(plan: SceptrePlan):
-    """Filters out the stacks without launch_action:deploy from the SceptrePlan."""
     plan.resolve(plan.diff.__name__)
     plan.filter(lambda stack: not stack.ignore and not stack.obsolete)

--- a/sceptre/cli/diff.py
+++ b/sceptre/cli/diff.py
@@ -44,11 +44,13 @@ logger = getLogger(__name__)
     help="If set, no placeholder values will be supplied for resolvers that cannot be resolved."
 )
 @click.option(
-    '-a',
-    '--all',
-    'all_stacks',
+    '-l',
+    '--launchable',
     is_flag=True,
-    help="If set, it will perform diffing on ALL stacks, not just the ones with launch_action:deploy"
+    help=(
+         "If set, will only perform diffing on stacks that have a \"deploy\" launch_action; "
+         "Otherwise, it will diff all stacks, no matter the launch_action"
+    )
 )
 @click.argument('path')
 @click.pass_context
@@ -58,7 +60,7 @@ def diff_command(
     differ: str,
     show_no_echo: bool,
     no_placeholders: bool,
-    all_stacks: bool,
+    launchable: bool,
     path: str
 ):
     """Indicates the difference between the currently DEPLOYED stacks in the command path and
@@ -102,7 +104,7 @@ def diff_command(
     )
     output_format = context.output_format
     plan = SceptrePlan(context)
-    if not all_stacks:
+    if launchable:
         filter_plan_for_launchable(plan)
 
     if differ == "deepdiff":
@@ -176,6 +178,7 @@ def output_buffer_with_normalized_bar_lengths(buffer: io.StringIO, output_stream
 
 
 def filter_plan_for_launchable(plan: SceptrePlan):
+    """Filters out the stacks without launch_action:deploy from the SceptrePlan."""
     plan.resolve(plan.diff.__name__)
     for stack in plan:
         if stack.launch_action != LaunchAction.deploy:

--- a/sceptre/cli/diff.py
+++ b/sceptre/cli/diff.py
@@ -65,8 +65,9 @@ def diff_command(
 ):
     """Indicates the difference between the currently DEPLOYED stacks in the command path and
     the stacks configured in Sceptre right now. This command will compare both the templates as well
-    as the subset of stack configurations that can be compared. By default, only stacks that can be
-    launched will be diffed, but this can be overridden with the "--all" flag.
+    as the subset of stack configurations that can be compared. By default, all stacks relevant to
+    the path will be will be diffed, but the --launchable flag will narrow the scope down to only
+    stacks with launch_action: deploy.
 
     Some settings (such as sceptre_user_data) are not available in a CloudFormation stack
     description, so the diff will not be indicated. Currently compared stack configurations are:

--- a/sceptre/cli/diff.py
+++ b/sceptre/cli/diff.py
@@ -183,6 +183,4 @@ def output_buffer_with_normalized_bar_lengths(buffer: io.StringIO, output_stream
 def filter_plan_for_launchable(plan: SceptrePlan):
     """Filters out the stacks without launch_action:deploy from the SceptrePlan."""
     plan.resolve(plan.diff.__name__)
-    for stack in plan:
-        if stack.obsolete or stack.ignore:
-            plan.remove_stack_from_plan(stack)
+    plan.filter(lambda stack: not stack.ignore and not stack.obsolete)

--- a/sceptre/cli/diff.py
+++ b/sceptre/cli/diff.py
@@ -44,12 +44,14 @@ logger = getLogger(__name__)
     help="If set, no placeholder values will be supplied for resolvers that cannot be resolved."
 )
 @click.option(
-    '-l',
-    '--launchable',
+    '-a',
+    '--all',
+    'all_',
     is_flag=True,
     help=(
-         "If set, will only perform diffing on stacks that have a \"deploy\" launch_action; "
-         "Otherwise, it will diff all stacks, no matter the launch_action"
+         "If set, will perform diffing on ALL stacks, not just ones that have a \"deploy\" "
+         "launch_action; Otherwise, it will diff only stacks that would be created or updated when "
+         "running the launch command."
     )
 )
 @click.argument('path')
@@ -60,14 +62,14 @@ def diff_command(
     differ: str,
     show_no_echo: bool,
     no_placeholders: bool,
-    launchable: bool,
+    all_: bool,
     path: str
 ):
     """Indicates the difference between the currently DEPLOYED stacks in the command path and
     the stacks configured in Sceptre right now. This command will compare both the templates as well
-    as the subset of stack configurations that can be compared. By default, all stacks relevant to
-    the path will be will be diffed, but the --launchable flag will narrow the scope down to only
-    stacks with launch_action: deploy.
+    as the subset of stack configurations that can be compared. By default, only stacks that would
+    be launched via the launch command will be diffed, but you can diff ALL stacks relevant to the
+    passed command path if you pass the --all flag.
 
     Some settings (such as sceptre_user_data) are not available in a CloudFormation stack
     description, so the diff will not be indicated. Currently compared stack configurations are:
@@ -78,7 +80,7 @@ def diff_command(
       * role_arn
       * stack_tags
 
-    Important: There are resolvers (notably !stack_output, among others) that rely on other stacks
+    Important: There are resolvers (notably !stack_output) that rely on other stacks
     to be already deployed when they are resolved. When producing a diff on Stack Configs that have
     such resolvers that point to non-deployed stacks, this presents a challenge, since this means
     those resolvers cannot be resolved. This particularly applies to stack parameters and when a
@@ -105,7 +107,7 @@ def diff_command(
     )
     output_format = context.output_format
     plan = SceptrePlan(context)
-    if launchable:
+    if not all_:
         filter_plan_for_launchable(plan)
 
     if differ == "deepdiff":

--- a/sceptre/cli/diff.py
+++ b/sceptre/cli/diff.py
@@ -13,7 +13,7 @@ from sceptre.diffing.stack_differ import DeepDiffStackDiffer, DifflibStackDiffer
 from sceptre.helpers import null_context
 from sceptre.plan.plan import SceptrePlan
 from sceptre.resolvers.placeholders import use_resolver_placeholders_on_error
-from sceptre.stack import Stack, LaunchAction
+from sceptre.stack import Stack
 
 logger = getLogger(__name__)
 
@@ -184,5 +184,5 @@ def filter_plan_for_launchable(plan: SceptrePlan):
     """Filters out the stacks without launch_action:deploy from the SceptrePlan."""
     plan.resolve(plan.diff.__name__)
     for stack in plan:
-        if stack.launch_action != LaunchAction.deploy:
+        if stack.obsolete or stack.ignore:
             plan.remove_stack_from_plan(stack)

--- a/sceptre/cli/launch.py
+++ b/sceptre/cli/launch.py
@@ -145,7 +145,7 @@ class Launcher:
     def _delete(self, stacks_to_delete: List[Stack]) -> int:
         if len(stacks_to_delete) == 0:
             return 0
-        
+
         delete_plan = self._create_deletion_plan(stacks_to_delete)
         result = delete_plan.delete()
         exit_code = stack_status_exit_code(result.values())

--- a/sceptre/cli/launch.py
+++ b/sceptre/cli/launch.py
@@ -66,6 +66,8 @@ class Launcher:
         self._make_plan = plan_factory
         self._make_pruner = pruner_factory
 
+        self._plan = None
+
     def confirm(self, prune: bool):
         self._confirm_launch(prune)
 
@@ -93,10 +95,12 @@ class Launcher:
         return code
 
     def _create_deploy_plan(self) -> SceptrePlan:
-        plan = self._make_plan(self._context)
-        # The plan must be resolved so we can modify launch order and items before executing it
-        plan.resolve(plan.launch.__name__)
-        return plan
+        if not self._plan:
+            plan = self._make_plan(self._context)
+            # The plan must be resolved so we can modify launch order and items before executing it
+            plan.resolve(plan.launch.__name__)
+            self._plan = plan
+        return self._plan
 
     def _get_stacks_to_skip(self, deploy_plan: SceptrePlan, prune: bool) -> List[Stack]:
         return [stack for stack in deploy_plan if stack.ignore or (stack.obsolete and not prune)]

--- a/sceptre/cli/launch.py
+++ b/sceptre/cli/launch.py
@@ -143,6 +143,9 @@ class Launcher:
         confirmation("launch", yes, command_path=self._context.command_path)
 
     def _delete(self, stacks_to_delete: List[Stack]) -> int:
+        if len(stacks_to_delete) == 0:
+            return 0
+        
         delete_plan = self._create_deletion_plan(stacks_to_delete)
         result = delete_plan.delete()
         exit_code = stack_status_exit_code(result.values())

--- a/sceptre/cli/launch.py
+++ b/sceptre/cli/launch.py
@@ -166,7 +166,7 @@ class Launcher:
         delete_context.ignore_dependencies = True  # we ONLY care about deleting the command stacks
         deletion_plan = self._make_plan(delete_context)
         # We're overriding the command_stacks so we target only those stacks that have been marked
-        # with launch_action:delete
+        # with obsolete: True
         deletion_plan.command_stacks = set(stacks_to_prune)
         return deletion_plan
 

--- a/sceptre/cli/launch.py
+++ b/sceptre/cli/launch.py
@@ -129,7 +129,8 @@ class Launcher:
             for dependency in stack.dependencies:
                 if dependency.ignore or dependency.obsolete:
                     skipped_dependencies.add(dependency)
-                validate_stack_dependencies(dependency)
+                if not self._context.ignore_dependencies:
+                    validate_stack_dependencies(dependency)
             validated_stacks.add(stack)
 
         for stack in deploy_plan:

--- a/sceptre/cli/launch.py
+++ b/sceptre/cli/launch.py
@@ -17,9 +17,7 @@ logger = logging.getLogger(__name__)
 
 @click.command(name="launch", short_help="Launch a Stack or StackGroup.")
 @click.argument("path")
-@click.option(
-    "-y", "--yes", is_flag=True, help="Assume yes to all questions."
-)
+@click.option("-y", "--yes", is_flag=True, help="Assume yes to all questions.")
 @click.option(
     "-p",
     "--prune",
@@ -38,13 +36,8 @@ def launch_command(ctx: Context, path: str, yes: bool, prune: bool):
     * Any stacks that already exist will be updated (if there are any changes)
     * If any stacks are marked with "ignore: True", those stacks will neither be created nor updated
     * If any stacks are marked with "obsolete: True", those stacks will neither be created nor updated.
-        Furthermore, if the "-p"/"--prune" flag is used, these stacks will be deleted prior to any
-        other launch commands
-
-    \f
-    :param path: The path to launch. Can be a Stack or StackGroup.
-    :param yes: A flag to answer 'yes' to all CLI questions.
-    :params prune: If True, will delete obsolete stacks
+      Furthermore, if the "-p"/"--prune" flag is used, these stacks will be deleted prior to any
+      other launch commands
     """
     context = SceptreContext(
         command_path=path,
@@ -59,12 +52,12 @@ def launch_command(ctx: Context, path: str, yes: bool, prune: bool):
 
 
 class Launcher:
-    def __init__(self, context: SceptreContext, plan_factory=SceptrePlan):
-        """Launcher is a utility to coordinate the flow of launching.
+    """Launcher is a utility to coordinate the flow of launching.
 
-        :param context: The Sceptre context to use for launching
-        :param plan_factory: A callable with the signature of (SceptreContext) -> SceptrePlan
-        """
+    :param context: The Sceptre context to use for launching
+    :param plan_factory: A callable with the signature of (SceptreContext) -> SceptrePlan
+    """
+    def __init__(self, context: SceptreContext, plan_factory=SceptrePlan):
         self._context = context
         self._make_plan = plan_factory
 

--- a/sceptre/cli/launch.py
+++ b/sceptre/cli/launch.py
@@ -124,7 +124,7 @@ class Launcher:
         self._print_stacks_with_message(list(skipped_dependencies), message)
 
     def _print_skips(self, stacks_to_skip: List[Stack]):
-        skip_message = "During launch, the following stacks will be skipped, neither created nor deleted:"
+        skip_message = "During launch, the following stacks will be skipped, neither created nor updated:"
         self._print_stacks_with_message(stacks_to_skip, skip_message)
 
     def _print_stacks_with_message(self, stacks: List[Stack], message: str):

--- a/sceptre/cli/prune.py
+++ b/sceptre/cli/prune.py
@@ -56,7 +56,8 @@ class Pruner:
             return 0
 
         self._resolve_plan(plan)
-        self._validate_plan_for_dependencies_on_obsolete_stacks(plan)
+        if not self._context.ignore_dependencies:
+            self._validate_plan_for_dependencies_on_obsolete_stacks(plan)
         self._print_stacks_to_be_deleted(plan)
         self._confirm_prune(yes)
 

--- a/sceptre/cli/prune.py
+++ b/sceptre/cli/prune.py
@@ -1,0 +1,132 @@
+import click
+from colorama import Fore, Style
+
+from sceptre.cli.helpers import catch_exceptions, stack_status_exit_code
+from sceptre.context import SceptreContext
+from sceptre.exceptions import CannotPruneStackError
+from sceptre.plan.plan import SceptrePlan
+from sceptre.stack import Stack
+
+
+@click.command(name="prune", short_help="Deletes all obsolete stacks in the project")
+@click.option(
+    "-y", "--yes", is_flag=True, help="Assume yes to all questions."
+)
+@click.pass_context
+@catch_exceptions
+def prune_command(ctx, yes: bool):
+    """
+    This command deletes all obsolete stacks in the project. Only obsolete stacks can be deleted
+    via prune, however; If any non-obsolete stacks depend on obsolete stacks, an error will be
+    raised and this command will fail
+
+    \f
+
+    :param yes: Flag to answer yes to all CLI questions.
+    """
+    context = SceptreContext(
+        # We're going to override the command stacks, so the path doesn't really matter
+        command_path=".",
+        project_path=ctx.obj.get("project_path"),
+        user_variables=ctx.obj.get("user_variables"),
+        options=ctx.obj.get("options"),
+        ignore_dependencies=ctx.obj.get("ignore_dependencies"),
+        full_scan=True,
+    )
+    pruner = Pruner(context)
+    code = pruner.prune(yes)
+    exit(code)
+
+    
+class Pruner:
+    def __init__(self, context:  SceptreContext, plan_factory=SceptrePlan):
+        self._context = context
+        self._make_plan = plan_factory
+
+    def prune(self, yes: bool) -> int:
+        plan = self._create_plan()
+
+        if not self._plan_has_obsolete_stacks(plan):
+            self._print_no_obsolete_stacks()
+            return 0
+
+        self._resolve_plan(plan)
+        self._validate_plan_for_dependencies_on_obsolete_stacks(plan)
+        self._print_stacks_to_be_deleted(plan)
+        self._confirm_prune(yes)
+
+        code = self._prune(plan)
+        return code
+
+    def _create_plan(self):
+        context = self._context.clone()
+        # We require full_scan because we're pruning ALL stacks in the project, regardless of any
+        # command path
+        context.full_scan = True
+        # The command_path doesn't matter, since we're going to override the command stacks
+        context.command_path = "."
+        plan = self._make_plan(self._context)
+        plan.command_stacks = {
+            stack for stack in plan.graph if stack.obsolete
+        }
+        return plan
+
+    def _plan_has_obsolete_stacks(self, plan: SceptrePlan):
+        return len(plan.command_stacks) > 0
+
+    def _print_no_obsolete_stacks(self):
+        click.echo("There are no stacks marked obsolete, so there is nothing to prune.")
+
+    def _resolve_plan(self, plan: SceptrePlan):
+        # Prune is actually a particular kind of filtered deletion, so we use delete as the actual
+        # resolved command.
+        plan.resolve(plan.delete.__name__, reverse=True)
+
+    def _validate_plan_for_dependencies_on_obsolete_stacks(self, plan: SceptrePlan):
+        def check_for_non_obsolete_dependencies(stack: Stack):
+            # If we've already established it as an obsolete stack to delete, we're good.
+            if stack in plan.command_stacks:
+                return
+
+            # This check shouldn't be necessary, but we're just double-checking that it is indeed
+            # not obsolete.
+            if stack.obsolete:
+                return
+
+            # Theoretically, we've already gathered up ALL obsolete stacks as command stacks. If
+            # we've hit this line, there's a problem. Now we just need to know what caused it. This
+            # block climbs down the dependency graph to see which obsolete stack caused this stack
+            # to be included in the plan.
+            for dependency in stack.dependencies:
+                if dependency.obsolete:
+                    raise CannotPruneStackError(
+                        f"Cannot prune obsolete stack {dependency.name} because stack {stack.name} "
+                        f"depends on it but is not obsolete."
+                    )
+
+            # If we get to this point, it means this stack isn't obsolete and none of its dependencies
+            # are either. That only happens it depends on another non-obsolete stack that depends on
+            # an obsolete stack. As a result, we're not going to blow up here and instead will
+            # continue iterating on the plan and will raise the error on a stack that directly
+            # depends on the obsolete stack.
+            return
+
+        for stack in plan:
+            check_for_non_obsolete_dependencies(stack)
+
+    def _print_stacks_to_be_deleted(self, plan: SceptrePlan):
+        delete_msg = "The following obsolete stacks will be deleted:\n"
+
+        stacks_list = ''
+        for stack in plan:
+            stacks_list += "{}{}{}\n".format(Fore.YELLOW, stack.name, Style.RESET_ALL)
+
+        click.echo(delete_msg + stacks_list)
+
+    def _confirm_prune(self, yes: bool):
+        if not yes:
+            click.confirm("Do you want to delete these stacks?", abort=True)
+
+    def _prune(self, plan: SceptrePlan):
+        responses = plan.delete()
+        return stack_status_exit_code(responses.values())

--- a/sceptre/cli/prune.py
+++ b/sceptre/cli/prune.py
@@ -62,6 +62,7 @@ class Pruner:
 
         if not self._plan_has_obsolete_stacks(plan):
             self._print_no_obsolete_stacks()
+            return
 
         self._resolve_plan(plan)
         self._print_stacks_to_be_deleted(plan)

--- a/sceptre/cli/prune.py
+++ b/sceptre/cli/prune.py
@@ -37,9 +37,18 @@ def prune_command(ctx, yes: bool):
     code = pruner.prune(yes)
     exit(code)
 
-    
+
 class Pruner:
     def __init__(self, context:  SceptreContext, plan_factory=SceptrePlan):
+        """Pruner is a utility to coordinate the flow of deleting all stacks in the project that
+        are marked "obsolete".
+
+        Note: The command_path on the passed context will be ignored; This command operates on the
+        entire project rather than on any particular command path.
+
+        :param context: The Sceptre context to use for pruning
+        :param plan_factory: A callable with the signature of (SceptreContext) -> SceptrePlan
+        """
         self._context = context
         self._make_plan = plan_factory
 

--- a/sceptre/cli/prune.py
+++ b/sceptre/cli/prune.py
@@ -17,12 +17,8 @@ from sceptre.stack import Stack
 def prune_command(ctx, yes: bool):
     """
     This command deletes all obsolete stacks in the project. Only obsolete stacks can be deleted
-    via prune, however; If any non-obsolete stacks depend on obsolete stacks, an error will be
-    raised and this command will fail
-
-    \f
-
-    :param yes: Flag to answer yes to all CLI questions.
+    via prune; If any non-obsolete stacks depend on obsolete stacks, an error will be
+    raised and this command will fail.
     """
     context = SceptreContext(
         # We're going to override the command stacks, so the path doesn't really matter
@@ -39,16 +35,16 @@ def prune_command(ctx, yes: bool):
 
 
 class Pruner:
+    """Pruner is a utility to coordinate the flow of deleting all stacks in the project that
+    are marked "obsolete".
+
+    Note: The command_path on the passed context will be ignored; This command operates on the
+    entire project rather than on any particular command path.
+
+    :param context: The Sceptre context to use for pruning
+    :param plan_factory: A callable with the signature of (SceptreContext) -> SceptrePlan
+    """
     def __init__(self, context:  SceptreContext, plan_factory=SceptrePlan):
-        """Pruner is a utility to coordinate the flow of deleting all stacks in the project that
-        are marked "obsolete".
-
-        Note: The command_path on the passed context will be ignored; This command operates on the
-        entire project rather than on any particular command path.
-
-        :param context: The Sceptre context to use for pruning
-        :param plan_factory: A callable with the signature of (SceptreContext) -> SceptrePlan
-        """
         self._context = context
         self._make_plan = plan_factory
 

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -32,7 +32,7 @@ from sceptre.exceptions import InvalidSceptreDirectoryError
 from sceptre.exceptions import VersionIncompatibleError
 from sceptre.exceptions import ConfigFileNotFoundError
 from sceptre.helpers import sceptreise_path
-from sceptre.stack import Stack, LaunchAction, DEFAULT_LAUNCH_ACTION
+from sceptre.stack import Stack
 from sceptre.config import strategies
 
 ConfigAttributes = collections.namedtuple("Attributes", "required optional")
@@ -59,7 +59,8 @@ CONFIG_MERGE_STRATEGIES = {
     "template_key_value": strategies.child_wins,
     "template_path": strategies.child_wins,
     "template": strategies.child_wins,
-    "launch_action": strategies.child_wins
+    "ignore": strategies.child_wins,
+    "obsolete": strategies.child_wins
 }
 
 STACK_GROUP_CONFIG_ATTRIBUTES = ConfigAttributes(
@@ -543,14 +544,6 @@ class ConfigReader(object):
         s3_details = self._collect_s3_details(
             stack_name, config
         )
-        launch_action_name = config.get('launch_action', DEFAULT_LAUNCH_ACTION.name)
-        try:
-            launch_action = LaunchAction[launch_action_name]
-        except KeyError as e:
-            raise InvalidConfigFileError(
-                f'{launch_action_name} is not a valid launch_action enumeration. Valid values are: '
-                f'{", ".join(option.name for option in LaunchAction)}'
-            ) from e
 
         stack = Stack(
             name=stack_name,
@@ -576,7 +569,8 @@ class ConfigReader(object):
             notifications=config.get("notifications"),
             on_failure=config.get("on_failure"),
             stack_timeout=config.get("stack_timeout", 0),
-            launch_action=launch_action,
+            ignore=config.get("ignore", False),
+            obsolete=config.get("obsolete", False),
             stack_group_config=parsed_stack_group_config
         )
 

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -303,6 +303,8 @@ class ConfigReader(object):
                             "have their full path from `config` defined."
                             .format(stackname=stack.name, dep=dep,
                                     stackkeys=", ".join(stack_map.keys())))
+                # We deduplicate the dependencies using a set here, since it's possible that a given
+                # dependency ends up in the list multiple times.
                 stack.dependencies = list(set(stack.dependencies))
             else:
                 stack.dependencies = []

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -543,6 +543,15 @@ class ConfigReader(object):
         s3_details = self._collect_s3_details(
             stack_name, config
         )
+        launch_action_name = config.get('launch_action', DEFAULT_LAUNCH_ACTION.name)
+        try:
+            launch_action = LaunchAction[launch_action_name]
+        except KeyError as e:
+            raise InvalidConfigFileError(
+                f'{launch_action_name} is not a valid launch_action enumeration. Valid values are: '
+                f'{", ".join(option.name for option in LaunchAction)}'
+            ) from e
+
         stack = Stack(
             name=stack_name,
             project_code=config["project_code"],
@@ -567,7 +576,7 @@ class ConfigReader(object):
             notifications=config.get("notifications"),
             on_failure=config.get("on_failure"),
             stack_timeout=config.get("stack_timeout", 0),
-            launch_action=LaunchAction[config.get('launch_action', DEFAULT_LAUNCH_ACTION.name)],
+            launch_action=launch_action,
             stack_group_config=parsed_stack_group_config
         )
 

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -266,8 +266,11 @@ class ConfigReader(object):
             stack_map[sceptreise_path(rel_path)] = stack
 
             full_command_path = self.context.full_command_path()
-            if abs_path == full_command_path\
-                    or abs_path.startswith(full_command_path.rstrip(path.sep) + path.sep):
+            if (
+                abs_path == full_command_path
+                or abs_path.startswith(full_command_path.rstrip(path.sep) + path.sep)
+                or self.context.command_path == "."
+            ):
                 command_stacks.add(stack)
 
         stacks = self.resolve_stacks(stack_map)

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -266,11 +266,8 @@ class ConfigReader(object):
             stack_map[sceptreise_path(rel_path)] = stack
 
             full_command_path = self.context.full_command_path()
-            if (
-                abs_path == full_command_path
-                or abs_path.startswith(full_command_path.rstrip(path.sep) + path.sep)
-                or self.context.command_path == "."
-            ):
+            if abs_path == full_command_path\
+                    or abs_path.startswith(full_command_path.rstrip(path.sep) + path.sep):
                 command_stacks.add(stack)
 
         stacks = self.resolve_stacks(stack_map)
@@ -306,7 +303,7 @@ class ConfigReader(object):
                             "have their full path from `config` defined."
                             .format(stackname=stack.name, dep=dep,
                                     stackkeys=", ".join(stack_map.keys())))
-
+                stack.dependencies = list(set(stack.dependencies))
             else:
                 stack.dependencies = []
             stacks.add(stack)

--- a/sceptre/context.py
+++ b/sceptre/context.py
@@ -125,6 +125,7 @@ class SceptreContext(object):
         )
 
     def clone(self) -> "SceptreContext":
+        """Creates a new, deep clone of the context with all the same values."""
         new = type(self).__new__(type(self))
         new.__dict__.update(deepcopy(self.__dict__))
         return new

--- a/sceptre/exceptions.py
+++ b/sceptre/exceptions.py
@@ -187,3 +187,10 @@ class TemplateNotFoundError(SceptreException):
     Error raised when a Template file is not found
     """
     pass
+
+
+class CannotPruneStackError(SceptreException):
+    """
+    Error raised when an obsolete stack cannot be pruned because another stack depends on it that is
+    not itself obsolete.
+    """

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -29,7 +29,7 @@ from sceptre.exceptions import (
 )
 from sceptre.helpers import normalise_path
 from sceptre.hooks import add_stack_hooks
-from sceptre.stack import LaunchAction, Stack
+from sceptre.stack import Stack
 from sceptre.stack_status import StackChangeSetStatus, StackStatus
 
 

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -10,6 +10,7 @@ available to a Stack.
 import json
 import logging
 import time
+import typing
 import urllib
 from datetime import datetime, timedelta
 from os import path
@@ -31,6 +32,9 @@ from sceptre.helpers import normalise_path
 from sceptre.hooks import add_stack_hooks
 from sceptre.stack import Stack
 from sceptre.stack_status import StackChangeSetStatus, StackStatus
+
+if typing.TYPE_CHECKING:
+    from sceptre.diffing.stack_differ import StackDiff, StackDiffer
 
 
 class StackActions(object):
@@ -992,18 +996,13 @@ class StackActions(object):
             raise
 
     @add_stack_hooks
-    def diff(self, stack_differ):
+    def diff(self, stack_differ: "StackDiffer") -> "StackDiff":
         """
-        Returns a diff of Template and Remote Template
-        using a specific diff library.
+        Returns a diff of local and deployed template and stack configuration using a specific diff
+        library.
 
-        :param stack_differ: The diff lib to use, default difflib.
-        :type: sceptre.diffing.stack_differ.StackDiffer
-
-        :param all_stacks: If True, will perform the diff on ALL stacks
-
-        :returns: A StackDiff object.
-        :rtype: sceptre.diffing.stack_differ.StackDiff
+        :param stack_differ: The differ to use
+        :returns: A StackDiff object with the full, computed diff
         """
         return stack_differ.diff(self)
 

--- a/sceptre/plan/executor.py
+++ b/sceptre/plan/executor.py
@@ -8,33 +8,30 @@ executing the command specified in a SceptrePlan.
 """
 import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import List, Set
 
 from sceptre.plan.actions import StackActions
-from sceptre.stack_status import StackStatus
+from sceptre.stack import Stack
 
 
 class SceptrePlanExecutor(object):
 
-    def __init__(self, command, launch_order):
+    def __init__(self, command: str, launch_order: List[Set[Stack]]):
         """
-        Initalises a SceptrePlanExecutor, generates the launch order, threads
+        Initialises a SceptrePlanExecutor, generates the launch order, threads
         and intial Stack Statuses.
 
         :param command: The command to execute on the Stack.
-        :type command: str
 
-        :param launch_order: A list containing sets of Stacks that can be\
-                executed concurrently.
-        :type launch_order: list
+        :param launch_order: A list containing sets of Stacks that can be executed concurrently.
         """
 
         self.logger = logging.getLogger(__name__)
         self.command = command
         self.launch_order = launch_order
-
-        self.num_threads = len(max(launch_order, key=len))
-        self.stack_statuses = {stack: StackStatus.PENDING
-                               for batch in launch_order for stack in batch}
+        # Select the number of threads based upon the max batch size,
+        # or use 1 if all batches are empty
+        self.num_threads = len(max(launch_order, key=len)) or 1
 
     def execute(self, *args):
         """

--- a/sceptre/plan/executor.py
+++ b/sceptre/plan/executor.py
@@ -35,7 +35,7 @@ class SceptrePlanExecutor(object):
 
     def execute(self, *args):
         """
-        Execute is responsible executing the sets of Stacks in ``launch_order``
+        Execute is responsible executing the sets of Stacks in launch_order
         concurrently, in the correct order.
 
         :param args: Any arguments that should be passed through to the

--- a/sceptre/plan/executor.py
+++ b/sceptre/plan/executor.py
@@ -7,12 +7,9 @@ This module implements a SceptrePlanExecutor, which is responsible for
 executing the command specified in a SceptrePlan.
 """
 import logging
-
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Callable
 
 from sceptre.plan.actions import StackActions
-from sceptre.stack import Stack
 from sceptre.stack_status import StackStatus
 
 

--- a/sceptre/plan/plan.py
+++ b/sceptre/plan/plan.py
@@ -82,6 +82,7 @@ class SceptrePlan(object):
 
     @require_resolved
     def __iter__(self) -> Iterable[Stack]:
+        """Iterates the stacks in the launch_order"""
         # We cast it to list so it's "frozen" in time, in case the launch order is modified
         # while iterating.
         yield from list(itertools.chain.from_iterable(self.launch_order))
@@ -95,8 +96,12 @@ class SceptrePlan(object):
 
     @require_resolved
     def filter(self, predicate: Callable[[Stack], bool]):
-        # Cast self to list so we're not modifying what we're iterating over
-        for stack in list(self):
+        """Filters the plan's resolved launch_order to remove specific stacks.
+
+        :param predicate: This callable should take a single Stack and return True if it should stay
+            in the launch_order or False if it should be filtered out.
+        """
+        for stack in self:
             if not predicate(stack):
                 self.remove_stack_from_plan(stack)
 

--- a/sceptre/plan/plan.py
+++ b/sceptre/plan/plan.py
@@ -9,15 +9,15 @@ nessessary information for a command to execute.
 import functools
 import itertools
 from os import path, walk
-from typing import Dict, List, Set, Callable, Iterable, Optional, Any
+from typing import Dict, List, Set, Callable, Iterable, Optional
 
+from sceptre.config.graph import StackGraph
+from sceptre.config.reader import ConfigReader
 from sceptre.context import SceptreContext
 from sceptre.diffing.stack_differ import StackDiff
 from sceptre.exceptions import ConfigFileNotFoundError
-from sceptre.config.graph import StackGraph
-from sceptre.config.reader import ConfigReader
-from sceptre.plan.executor import SceptrePlanExecutor
 from sceptre.helpers import sceptreise_path
+from sceptre.plan.executor import SceptrePlanExecutor
 from sceptre.stack import Stack
 
 

--- a/sceptre/plan/plan.py
+++ b/sceptre/plan/plan.py
@@ -93,6 +93,13 @@ class SceptrePlan(object):
                 batch.remove(stack)
                 return
 
+    @require_resolved
+    def filter(self, predicate: Callable[[Stack], bool]):
+        # Cast self to list so we're not modifying what we're iterating over
+        for stack in list(self):
+            if not predicate(stack):
+                self.remove_stack_from_plan(stack)
+
     def resolve(self, command, reverse=False):
         if command == self.command and reverse == self.reverse:
             return

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -8,7 +8,7 @@ This module implements a Stack class, which stores a Stack's data.
 """
 
 import logging
-from typing import List, Union
+from typing import List
 
 from sceptre.connection_manager import ConnectionManager
 from sceptre.exceptions import InvalidConfigFileError

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -194,7 +194,9 @@ class Stack(object):
 
     def _ensure_boolean(self, config_name: str, value: Any) -> bool:
         if not isinstance(value, bool):
-            raise InvalidConfigFileError(f"Value for {config_name} must be a boolean, not a {type(value).__name__}")
+            raise InvalidConfigFileError(
+                f"{self.name}: Value for {config_name} must be a boolean, not a {type(value).__name__}"
+            )
         return value
 
     def __repr__(self):

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -228,7 +228,7 @@ class Stack(object):
         return self.name
 
     def __eq__(self, stack):
-        # We should no use any resolvable properties in __eq__, since it is used when adding the
+        # We should not use any resolvable properties in __eq__, since it is used when adding the
         # Stack to a set, which is done very early in plan resolution. Trying to reference resolvers
         # before the plan is fully resolved can potentially blow up.
         return (

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -228,33 +228,25 @@ class Stack(object):
         return self.name
 
     def __eq__(self, stack):
+        # We should no use any resolvable properties in __eq__, since it is used when adding the
+        # Stack to a set, which is done very early in plan resolution. Trying to reference resolvers
+        # before the plan is fully resolved can potentially blow up.
         return (
             self.name == stack.name and
+            self.external_name == stack.external_name and
             self.project_code == stack.project_code and
             self.template_path == stack.template_path and
-            self.template_handler_config == stack.template_handler_config and
             self.region == stack.region and
-            self.template_bucket_name == stack.template_bucket_name and
             self.template_key_prefix == stack.template_key_prefix and
             self.required_version == stack.required_version and
-            self.iam_role == stack.iam_role and
             self.iam_role_session_duration == stack.iam_role_session_duration and
             self.profile == stack.profile and
-            self.sceptre_user_data == stack.sceptre_user_data and
-            self.parameters == stack.parameters and
-            self.hooks == stack.hooks and
-            self.s3_details == stack.s3_details and
             self.dependencies == stack.dependencies and
-            self.role_arn == stack.role_arn and
             self.protected == stack.protected and
-            self.tags == stack.tags and
-            self.external_name == stack.external_name and
-            self.notifications == stack.notifications and
             self.on_failure == stack.on_failure and
             self.stack_timeout == stack.stack_timeout and
             self.ignore == stack.ignore and
-            self.obsolete == stack.obsolete and
-            self.stack_group_config == stack.stack_group_config
+            self.obsolete == stack.obsolete
         )
 
     def __hash__(self):

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -8,7 +8,6 @@ This module implements a Stack class, which stores a Stack's data.
 """
 
 import logging
-from enum import Enum
 from typing import List
 
 from sceptre.connection_manager import ConnectionManager
@@ -196,58 +195,33 @@ class Stack(object):
     def __repr__(self):
         return (
             "sceptre.stack.Stack("
-            "name='{name}', "
-            "project_code={project_code}, "
-            "template_path={template_path}, "
-            "template_handler_config={template_handler_config}, "
-            "region={region}, "
-            "template_bucket_name={template_bucket_name}, "
-            "template_key_prefix={template_key_prefix}, "
-            "required_version={required_version}, "
-            "iam_role={iam_role}, "
-            "iam_role_session_duration={iam_role_session_duration}, "
-            "profile={profile}, "
-            "sceptre_user_data={sceptre_user_data}, "
-            "parameters={parameters}, "
-            "hooks={hooks}, "
-            "s3_details={s3_details}, "
-            "dependencies={dependencies}, "
-            "role_arn={role_arn}, "
-            "protected={protected}, "
-            "tags={tags}, "
-            "external_name={external_name}, "
-            "notifications={notifications}, "
-            "on_failure={on_failure}, "
-            "stack_timeout={stack_timeout}, "
-            "stack_group_config={stack_group_config}, "
-            "launch_action={launch_action}"
-            ")".format(
-                name=self.name,
-                project_code=self.project_code,
-                template_path=self.template_path,
-                template_handler_config=self.template_handler_config,
-                region=self.region,
-                template_bucket_name=self.template_bucket_name,
-                template_key_prefix=self.template_key_prefix,
-                required_version=self.required_version,
-                iam_role=self.iam_role,
-                iam_role_session_duration=self.iam_role_session_duration,
-                profile=self.profile,
-                sceptre_user_data=self.sceptre_user_data,
-                parameters=self.parameters,
-                hooks=self.hooks,
-                s3_details=self.s3_details,
-                dependencies=self.dependencies,
-                role_arn=self.role_arn,
-                protected=self.protected,
-                tags=self.tags,
-                external_name=self.external_name,
-                notifications=self.notifications,
-                on_failure=self.on_failure,
-                stack_timeout=self.stack_timeout,
-                launch_action=self.launch_action.name,
-                stack_group_config=self.stack_group_config
-            )
+            f"name='{self.name}', "
+            f"project_code={self.project_code}, "
+            f"template_path={self.template_path}, "
+            f"template_handler_config={self.template_handler_config}, "
+            f"region={self.region}, "
+            f"template_bucket_name={self.template_bucket_name}, "
+            f"template_key_prefix={self.template_key_prefix}, "
+            f"required_version={self.required_version}, "
+            f"iam_role={self.iam_role}, "
+            f"iam_role_session_duration={self.iam_role_session_duration}, "
+            f"profile={self.profile}, "
+            f"sceptre_user_data={self.sceptre_user_data}, "
+            f"parameters={self.parameters}, "
+            f"hooks={self.hooks}, "
+            f"s3_details={self.s3_details}, "
+            f"dependencies={self.dependencies}, "
+            f"role_arn={self.role_arn}, "
+            f"protected={self.protected}, "
+            f"tags={self.tags}, "
+            f"external_name={self.external_name}, "
+            f"notifications={self.notifications}, "
+            f"on_failure={self.on_failure}, "
+            f"stack_timeout={self.stack_timeout}, "
+            f"stack_group_config={self.stack_group_config}, "
+            f"ignore={self.ignore}, "
+            f"obsolete={self.obsolete}"
+            ")"
         )
 
     def __str__(self):
@@ -278,7 +252,8 @@ class Stack(object):
             self.notifications == stack.notifications and
             self.on_failure == stack.on_failure and
             self.stack_timeout == stack.stack_timeout and
-            self.launch_action == stack.launch_action and
+            self.ignore == stack.ignore and
+            self.obsolete == stack.obsolete and
             self.stack_group_config == stack.stack_group_config
         )
 

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -8,7 +8,7 @@ This module implements a Stack class, which stores a Stack's data.
 """
 
 import logging
-from typing import List
+from typing import List, Any
 
 from sceptre.connection_manager import ConnectionManager
 from sceptre.exceptions import InvalidConfigFileError
@@ -171,8 +171,8 @@ class Stack(object):
         self.profile = profile
         self.template_key_prefix = template_key_prefix
         self.iam_role_session_duration = iam_role_session_duration
-        self.ignore = ignore
-        self.obsolete = obsolete
+        self.ignore = self._ensure_boolean("ignore", ignore)
+        self.obsolete = self._ensure_boolean("obsolete", obsolete)
 
         self._template = None
         self._connection_manager = None
@@ -191,6 +191,11 @@ class Stack(object):
         self.notifications = notifications or []
 
         self.hooks = hooks or {}
+
+    def _ensure_boolean(self, config_name: str, value: Any) -> bool:
+        if not isinstance(value, bool):
+            raise InvalidConfigFileError(f"Value for {config_name} must be a boolean, not a {type(value).__name__}")
+        return value
 
     def __repr__(self):
         return (

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -8,7 +8,7 @@ This module implements a Stack class, which stores a Stack's data.
 """
 
 import logging
-from typing import List
+from typing import List, Union
 
 from sceptre.connection_manager import ConnectionManager
 from sceptre.exceptions import InvalidConfigFileError
@@ -144,10 +144,10 @@ class Stack(object):
         self, name: str, project_code: str, region: str, template_path: str = None,
         template_handler_config: dict = None, template_bucket_name: str = None, template_key_prefix: str = None,
         required_version: str = None, parameters: dict = None, sceptre_user_data: dict = None, hooks: Hook = None,
-        s3_details: dict = None, iam_role: str = None, dependencies=None, role_arn: str = None, protected: bool = False,
-        tags: dict = None, external_name: str = None, notifications: List[str] = None, on_failure: str = None,
-        profile: str = None, stack_timeout: int = 0, iam_role_session_duration: int = 0, ignore=False, obsolete=False,
-        stack_group_config: dict = {}
+        s3_details: dict = None, iam_role: str = None, dependencies: List["Stack"] = None, role_arn: str = None,
+        protected: bool = False, tags: dict = None, external_name: str = None, notifications: List[str] = None,
+        on_failure: str = None, profile: str = None, stack_timeout: int = 0, iam_role_session_duration: int = 0,
+        ignore=False, obsolete=False, stack_group_config: dict = {}
     ):
         self.logger = logging.getLogger(__name__)
 

--- a/tests/fixtures/config/invalid-launch-action.yaml
+++ b/tests/fixtures/config/invalid-launch-action.yaml
@@ -1,0 +1,1 @@
+launch_action: "bad"

--- a/tests/fixtures/config/invalid-launch-action.yaml
+++ b/tests/fixtures/config/invalid-launch-action.yaml
@@ -1,1 +1,0 @@
-launch_action: "bad"

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,21 +1,22 @@
 # -*- coding: utf-8 -*-
 import datetime
 import json
+from unittest.mock import patch, sentinel, Mock, call
 
 import pytest
 from botocore.exceptions import ClientError
 from dateutil.tz import tzutc
-from unittest.mock import patch, sentinel, Mock, call, DEFAULT
 
-from sceptre.exceptions import CannotUpdateFailedStackError
-from sceptre.exceptions import ProtectedStackError
-from sceptre.exceptions import StackDoesNotExistError
-from sceptre.exceptions import UnknownStackChangeSetStatusError
-from sceptre.exceptions import UnknownStackStatusError
+from sceptre.exceptions import (
+    CannotUpdateFailedStackError,
+    ProtectedStackError,
+    StackDoesNotExistError,
+    UnknownStackChangeSetStatusError,
+    UnknownStackStatusError
+)
 from sceptre.plan.actions import StackActions
-from sceptre.stack import Stack, LaunchAction
-from sceptre.stack_status import StackChangeSetStatus
-from sceptre.stack_status import StackStatus
+from sceptre.stack import Stack
+from sceptre.stack_status import StackChangeSetStatus, StackStatus
 from sceptre.template import Template
 
 

--- a/tests/test_cli/test_cli_commands.py
+++ b/tests/test_cli/test_cli_commands.py
@@ -26,7 +26,7 @@ from sceptre.diffing.stack_differ import \
 
 from sceptre.exceptions import SceptreException
 from sceptre.plan.actions import StackActions
-from sceptre.stack import Stack, LaunchAction
+from sceptre.stack import Stack
 from sceptre.stack_status import StackStatus
 
 
@@ -42,13 +42,17 @@ class TestCli:
         self.mock_config_reader = MagicMock(spec=ConfigReader)
         self.mock_stack_actions = MagicMock(spec=StackActions)
 
-        self.mock_stack = MagicMock(spec=Stack)
+        self.mock_stack = MagicMock(
+            spec=Stack,
+            region=None,
+            profile=None,
+            external_name='mock-stack-external',
+            dependencies=[],
+            ignore=False,
+            obsolete=False,
+        )
 
         self.mock_stack.name = 'mock-stack'
-        self.mock_stack.region = None
-        self.mock_stack.profile = None
-        self.mock_stack.external_name = 'mock-stack-external'
-        self.mock_stack.dependencies = []
 
         self.mock_config_reader.construct_stacks.return_value = \
             set([self.mock_stack]), set([self.mock_stack])

--- a/tests/test_cli/test_cli_commands.py
+++ b/tests/test_cli/test_cli_commands.py
@@ -49,7 +49,6 @@ class TestCli:
         self.mock_stack.profile = None
         self.mock_stack.external_name = 'mock-stack-external'
         self.mock_stack.dependencies = []
-        self.mock_stack.launch_action = LaunchAction.deploy
 
         self.mock_config_reader.construct_stacks.return_value = \
             set([self.mock_stack]), set([self.mock_stack])

--- a/tests/test_cli/test_launch.py
+++ b/tests/test_cli/test_launch.py
@@ -116,7 +116,6 @@ class TestLauncher:
         expected_stacks = set(self.all_stacks)
         assert expected_stacks == launched_stacks
         assert self.plans[0].executions[0][0] == "launch"
-        assert len(self.plans) == 1
         assert len(self.plans[0].executions) == 1
 
     def test_launch__no_deletions__returns_0(self):

--- a/tests/test_cli/test_launch.py
+++ b/tests/test_cli/test_launch.py
@@ -90,8 +90,6 @@ class TestLauncher:
         self.plan_factory = create_autospec(SceptrePlan)
         self.plan_factory.side_effect = self.fake_plan_factory
 
-
-
         self.launcher = Launcher(self.context, self.plan_factory)
 
     def fake_plan_factory(self, sceptre_context):
@@ -124,10 +122,12 @@ class TestLauncher:
 
         assert result == 0
 
-    @pytest.mark.parametrize("launch_action", [
-        LaunchAction.skip,
-        LaunchAction.delete
-    ])
+    @pytest.mark.parametrize(
+        "launch_action", [
+            LaunchAction.skip,
+            LaunchAction.delete
+        ]
+    )
     def test_launch__does_not_launch_stacks_that_should_be_excluded(self, launch_action):
         self.all_stacks[4].launch_action = launch_action
         self.all_stacks[5].launch_action = launch_action

--- a/tests/test_cli/test_prune.py
+++ b/tests/test_cli/test_prune.py
@@ -122,18 +122,18 @@ class TestPruner:
         return list(itertools.chain.from_iterable(launch_order))
 
     def test_prune__no_obsolete_stacks__returns_zero(self):
-        code = self.pruner.prune(True)
+        code = self.pruner.prune()
         assert code == 0
 
     def test_prune__no_obsolete_stacks__does_not_call_command_on_plan(self):
-        self.pruner.prune(True)
+        self.pruner.prune()
         assert len(self.plans[0].executions) == 0
 
     def test_prune__whole_project__obsolete_stacks__deletes_all_obsolete_stacks(self):
         self.all_stacks[4].obsolete = True
         self.all_stacks[5].obsolete = True
 
-        self.pruner.prune(True)
+        self.pruner.prune()
 
         assert self.plans[0].executions[0][0] == 'delete'
         assert set(self.executed_stacks) == {self.all_stacks[4], self.all_stacks[5]}
@@ -142,7 +142,7 @@ class TestPruner:
         self.all_stacks[4].obsolete = True  # On command path
         self.all_stacks[5].obsolete = True  # not on command path
         self.context.command_path = "my/command/path"
-        self.pruner.prune(True)
+        self.pruner.prune()
 
         assert self.plans[0].executions[0][0] == 'delete'
         assert set(self.executed_stacks) == {self.all_stacks[4]}
@@ -151,7 +151,7 @@ class TestPruner:
         self.all_stacks[4].obsolete = True
         self.all_stacks[5].obsolete = True
 
-        code = self.pruner.prune(True)
+        code = self.pruner.prune()
         assert code == 0
 
     def test_prune__obsolete_stacks_depend_on_other_obsolete_stacks__deletes_only_obsolete_stacks(self):
@@ -163,7 +163,7 @@ class TestPruner:
         self.all_stacks[4].dependencies.append(self.all_stacks[3])
         self.all_stacks[5].dependencies.append(self.all_stacks[3])
 
-        self.pruner.prune(True)
+        self.pruner.prune()
 
         assert self.plans[0].executions[0][0] == 'delete'
         assert set(self.executed_stacks) == {
@@ -183,7 +183,7 @@ class TestPruner:
         self.all_stacks[5].dependencies.append(self.all_stacks[3])
 
         with pytest.raises(CannotPruneStackError):
-            self.pruner.prune(True)
+            self.pruner.prune()
 
     def test_prune__non_obsolete_stacks_depend_on_obsolete_stacks__ignore_dependencies__deletes_obsolete_stacks(self):
         self.all_stacks[1].obsolete = True
@@ -194,7 +194,7 @@ class TestPruner:
         self.all_stacks[4].dependencies.append(self.all_stacks[3])
         self.all_stacks[5].dependencies.append(self.all_stacks[3])
         self.context.ignore_dependencies = True
-        self.pruner.prune(True)
+        self.pruner.prune()
 
         assert self.plans[0].executions[0][0] == 'delete'
         assert set(self.executed_stacks) == {
@@ -205,5 +205,5 @@ class TestPruner:
         self.all_stacks[1].obsolete = True
         self.statuses_to_return[self.all_stacks[1]] = StackStatus.FAILED
 
-        code = self.pruner.prune(True)
+        code = self.pruner.prune()
         assert code != 0

--- a/tests/test_cli/test_prune.py
+++ b/tests/test_cli/test_prune.py
@@ -176,6 +176,22 @@ class TestPruner:
         with pytest.raises(CannotPruneStackError):
             self.pruner.prune(True)
 
+    def test_prune__non_obsolete_stacks_depend_on_obsolete_stacks__ignore_dependencies__deletes_obsolete_stacks(self):
+        self.all_stacks[1].obsolete = True
+        self.all_stacks[3].obsolete = False
+        self.all_stacks[4].obsolete = False
+        self.all_stacks[5].obsolete = False
+        self.all_stacks[3].dependencies.append(self.all_stacks[1])
+        self.all_stacks[4].dependencies.append(self.all_stacks[3])
+        self.all_stacks[5].dependencies.append(self.all_stacks[3])
+        self.context.ignore_dependencies = True
+        self.pruner.prune(True)
+
+        assert self.plans[0].executions[0][0] == 'delete'
+        assert set(self.executed_stacks) == {
+            self.all_stacks[1],
+        }
+
     def test_prune__delete_action_fails__returns_nonzero(self):
         self.all_stacks[1].obsolete = True
         self.statuses_to_return[self.all_stacks[1]] = StackStatus.FAILED

--- a/tests/test_cli/test_prune.py
+++ b/tests/test_cli/test_prune.py
@@ -1,0 +1,184 @@
+import functools
+import itertools
+from collections import defaultdict
+from typing import Set, Optional, List
+from unittest.mock import Mock, create_autospec
+
+import pytest
+
+from sceptre.cli.prune import Pruner
+from sceptre.context import SceptreContext
+from sceptre.exceptions import CannotPruneStackError
+from sceptre.plan.plan import SceptrePlan
+from sceptre.stack import Stack
+from sceptre.stack_status import StackStatus
+
+
+class FakePlan(SceptrePlan):
+    def __init__(
+        self,
+        context: SceptreContext,
+        command_stacks: Set[Stack],
+        all_stacks: Set[Stack],
+        statuses_to_return: dict,
+    ):
+        self.context = context
+        self.command = None
+        self.reverse = None
+        self.launch_order: Optional[List[Set[Stack]]] = None
+
+        self.all_stacks = self.graph = all_stacks
+        self.command_stacks = command_stacks
+        self.statuses_to_return = statuses_to_return
+
+        self.executions = []
+
+    def _execute(self, *args):
+        self.executions.append(
+            (self.command, self.launch_order.copy(), args)
+        )
+        return {
+            stack: self.statuses_to_return[stack]
+            for stack in self
+        }
+
+    def _generate_launch_order(self, reverse=False) -> List[Set[Stack]]:
+        launch_order = [self.command_stacks]
+        if self.context.ignore_dependencies:
+            return launch_order
+
+        all_stacks = list(self.all_stacks)
+
+        for start_index in range(0, len(all_stacks), 2):
+            chunk = {
+                stack for stack in all_stacks[start_index: start_index + 2]
+                if stack not in self.command_stacks
+                and self._has_dependency_on_a_command_stack(stack)
+            }
+            if len(chunk):
+                launch_order.append(chunk)
+
+        return launch_order
+
+    @functools.lru_cache()
+    def _has_dependency_on_a_command_stack(self, stack):
+        if len(self.command_stacks.intersection(stack.dependencies)):
+            return True
+
+        for dependency in stack.dependencies:
+            if self._has_dependency_on_a_command_stack(dependency):
+                return True
+
+        return False
+
+
+class TestPruner:
+
+    def setup_method(self, test_method):
+        self.plans: List[FakePlan] = []
+
+        self.context = SceptreContext(
+            project_path="project",
+            command_path="my-test-group",
+        )
+
+        self.all_stacks = [
+            Mock(spec=Stack, ignore=False, obsolete=False, dependencies=[]),
+            Mock(spec=Stack, ignore=False, obsolete=False, dependencies=[]),
+            Mock(spec=Stack, ignore=False, obsolete=False, dependencies=[]),
+            Mock(spec=Stack, ignore=False, obsolete=False, dependencies=[]),
+            Mock(spec=Stack, ignore=False, obsolete=False, dependencies=[]),
+            Mock(spec=Stack, ignore=False, obsolete=False, dependencies=[])
+        ]
+        for index, stack in enumerate(self.all_stacks):
+            stack.name = f'stacks/stack-{index}.yaml'
+
+        self.command_stacks = [
+            self.all_stacks[2],
+            self.all_stacks[4]
+        ]
+
+        self.statuses_to_return = defaultdict(lambda: StackStatus.COMPLETE)
+
+        self.plan_factory = create_autospec(SceptrePlan)
+        self.plan_factory.side_effect = self.fake_plan_factory
+
+        self.pruner = Pruner(self.context, self.plan_factory)
+
+    def fake_plan_factory(self, sceptre_context):
+        fake_plan = FakePlan(
+            sceptre_context,
+            set(self.command_stacks),
+            set(self.all_stacks),
+            self.statuses_to_return
+        )
+        self.plans.append(fake_plan)
+        return fake_plan
+
+    @property
+    def executed_stacks(self):
+        assert len(self.plans) == 1
+        launch_order = self.plans[0].executions[0][1]
+        return list(itertools.chain.from_iterable(launch_order))
+
+    def test_prune__no_obsolete_stacks__returns_zero(self):
+        code = self.pruner.prune(True)
+        assert code == 0
+
+    def test_prune__no_obsolete_stacks__does_not_call_command_on_plan(self):
+        self.pruner.prune(True)
+        assert len(self.plans[0].executions) == 0
+
+    def test_prune__obsolete_stacks__deletes_only_obsolete_stacks(self):
+        self.all_stacks[4].obsolete = True
+        self.all_stacks[5].obsolete = True
+
+        self.pruner.prune(True)
+
+        assert self.plans[0].executions[0][0] == 'delete'
+        assert set(self.executed_stacks) == {self.all_stacks[4], self.all_stacks[5]}
+
+    def test_prune__obsolete_stacks__returns_zero(self):
+        self.all_stacks[4].obsolete = True
+        self.all_stacks[5].obsolete = True
+
+        code = self.pruner.prune(True)
+        assert code == 0
+
+    def test_prune__obsolete_stacks_depend_on_other_obsolete_stacks__deletes_only_obsolete_stacks(self):
+        self.all_stacks[1].obsolete = True
+        self.all_stacks[3].obsolete = True
+        self.all_stacks[4].obsolete = True
+        self.all_stacks[5].obsolete = True
+        self.all_stacks[3].dependencies.append(self.all_stacks[1])
+        self.all_stacks[4].dependencies.append(self.all_stacks[3])
+        self.all_stacks[5].dependencies.append(self.all_stacks[3])
+
+        self.pruner.prune(True)
+
+        assert self.plans[0].executions[0][0] == 'delete'
+        assert set(self.executed_stacks) == {
+            self.all_stacks[1],
+            self.all_stacks[3],
+            self.all_stacks[4],
+            self.all_stacks[5],
+        }
+
+    def test_prune__non_obsolete_stacks_depend_on_obsolete_stacks__raises_cannot_prune_stack_error(self):
+        self.all_stacks[1].obsolete = True
+        self.all_stacks[3].obsolete = False
+        self.all_stacks[4].obsolete = False
+        self.all_stacks[5].obsolete = False
+        self.all_stacks[3].dependencies.append(self.all_stacks[1])
+        self.all_stacks[4].dependencies.append(self.all_stacks[3])
+        self.all_stacks[5].dependencies.append(self.all_stacks[3])
+
+        with pytest.raises(CannotPruneStackError):
+            self.pruner.prune(True)
+
+    def test_prune__delete_action_fails__returns_nonzero(self):
+        self.all_stacks[1].obsolete = True
+        self.statuses_to_return[self.all_stacks[1]] = StackStatus.FAILED
+
+        code = self.pruner.prune(True)
+        assert code != 0

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -18,7 +18,6 @@ from sceptre.exceptions import (
     InvalidSceptreDirectoryError,
     InvalidConfigFileError
 )
-from sceptre.stack import LaunchAction
 
 
 class TestConfigReader(object):
@@ -327,6 +326,8 @@ class TestConfigReader(object):
             required_version='>1.0',
             template_bucket_name='stack_group_template_bucket_name',
             template_key_prefix=None,
+            ignore=False,
+            obsolete=False,
             stack_group_config={
                 "project_path": self.context.project_path,
                 "custom_key": "custom_value"
@@ -334,20 +335,6 @@ class TestConfigReader(object):
         )
 
         assert stacks == ({sentinel.stack}, {sentinel.stack})
-
-    @patch("sceptre.config.reader.ConfigReader._collect_s3_details")
-    @patch("sceptre.config.reader.Stack")
-    def test_construct_stacks__invalid_launch_action__raises_invalid_config_file_error(
-        self, mock_Stack, mock_collect_s3_details
-    ):
-        mock_Stack.return_value = sentinel.stack
-        sentinel.stack.dependencies = []
-
-        mock_collect_s3_details.return_value = sentinel.s3_details
-        self.context.project_path = os.path.abspath("tests/fixtures")
-        self.context.command_path = "invalid-launch-action.yaml"
-        with pytest.raises(InvalidConfigFileError):
-            ConfigReader(self.context).construct_stacks()
 
     @pytest.mark.parametrize("command_path,filepaths,expected_stacks,expected_command_stacks,full_scan", [
         (

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -327,7 +327,6 @@ class TestConfigReader(object):
             required_version='>1.0',
             template_bucket_name='stack_group_template_bucket_name',
             template_key_prefix=None,
-            launch_action=LaunchAction.deploy,
             stack_group_config={
                 "project_path": self.context.project_path,
                 "custom_key": "custom_value"

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -1,23 +1,23 @@
 # -*- coding: utf-8 -*-
 
+import errno
 import os
 from unittest.mock import patch, sentinel, MagicMock
+
 import pytest
 import yaml
-import errno
-
-from pyfakefs.fake_filesystem_unittest import Patcher
-
-from sceptre.context import SceptreContext
-from sceptre.exceptions import DependencyDoesNotExistError
-from sceptre.exceptions import VersionIncompatibleError
-from sceptre.exceptions import ConfigFileNotFoundError
-from sceptre.exceptions import InvalidSceptreDirectoryError
-from sceptre.exceptions import InvalidConfigFileError
-
-from freezegun import freeze_time
 from click.testing import CliRunner
+from freezegun import freeze_time
+
 from sceptre.config.reader import ConfigReader
+from sceptre.context import SceptreContext
+from sceptre.exceptions import (
+    DependencyDoesNotExistError,
+    VersionIncompatibleError,
+    ConfigFileNotFoundError,
+    InvalidSceptreDirectoryError,
+    InvalidConfigFileError
+)
 from sceptre.stack import LaunchAction
 
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -66,3 +66,25 @@ class TestSceptreContext(object):
         )
         full_templates_path = path.join("project_path", self.templates_path)
         assert context.full_templates_path() == full_templates_path
+
+    def test_clone__returns_full_clone_of_context(self):
+        context = SceptreContext(
+            project_path="project_path",
+            command_path="command",
+            user_variables={"user": "variables"},
+            options={"hello": "there"},
+            output_format=sentinel.output_format,
+            no_colour=sentinel.no_colour,
+            ignore_dependencies=sentinel.ignore_dependencies
+        )
+        clone = context.clone()
+        assert clone is not context
+        assert clone.project_path == context.project_path
+        assert clone.command_path == context.command_path
+        assert clone.user_variables == context.user_variables
+        assert clone.user_variables is not context.user_variables
+        assert clone.options == context.options
+        assert clone.options is not context.options
+        assert clone.output_format == context.output_format
+        assert clone.no_colour == context.no_colour
+        assert clone.ignore_dependencies == context.ignore_dependencies

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -6,7 +6,7 @@ import pytest
 
 from sceptre.exceptions import InvalidConfigFileError
 from sceptre.resolvers import Resolver
-from sceptre.stack import Stack, LaunchAction
+from sceptre.stack import Stack
 from sceptre.template import Template
 
 
@@ -158,7 +158,8 @@ class TestStack(object):
             "on_failure=sentinel.on_failure, " \
             "stack_timeout=sentinel.stack_timeout, " \
             "stack_group_config={}, " \
-            f"launch_action={self.stack.launch_action.name}" \
+            "ignore=False, " \
+            "obsolete=False" \
             ")"
 
     def test_configuration_manager__iam_role_raises_recursive_resolve__returns_connection_manager_with_no_role(self):

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -131,15 +131,6 @@ class TestStack(object):
                 region="region"
             )
 
-    def test_initialize__stack_has_excluded_launch_type__no_template_parameters__does_not_raise_error(self):
-        # If not for LaunchAction.exclude, this would blow up with an InvalidConfigFileError
-        Stack(
-            name='dev/stack/app', project_code='testing',
-            template_handler_config=None, template_path=None,
-            launch_action=LaunchAction.delete,
-            region=sentinel.region
-        )
-
     def test_stack_repr(self):
         assert self.stack.__repr__() == \
             "sceptre.stack.Stack(" \

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -61,7 +61,7 @@ class TestStack(object):
         )
         self.stack._template = MagicMock(spec=Template)
 
-    def test_initiate_stack_with_template_path(self):
+    def test_initialize_stack_with_template_path(self):
         stack = Stack(
             name='dev/stack/app', project_code=sentinel.project_code,
             template_path=sentinel.template_path,
@@ -92,7 +92,7 @@ class TestStack(object):
         assert stack.on_failure is None
         assert stack.stack_group_config == {}
 
-    def test_initiate_stack_with_template_handler(self):
+    def test_initialize_stack_with_template_handler(self):
         stack = Stack(
             name='dev/stack/app', project_code=sentinel.project_code,
             template_handler_config=sentinel.template_handler_config,
@@ -129,6 +129,30 @@ class TestStack(object):
                 name="stack_name", project_code="project_code",
                 template_path="template_path", template_handler_config={"type": "file"},
                 region="region"
+            )
+
+    def test_init__non_boolean_ignore_value__raises_invalid_config_file_error(self):
+        with pytest.raises(InvalidConfigFileError):
+            Stack(
+                name='dev/stack/app', project_code=sentinel.project_code,
+                template_handler_config=sentinel.template_handler_config,
+                template_bucket_name=sentinel.template_bucket_name,
+                template_key_prefix=sentinel.template_key_prefix,
+                required_version=sentinel.required_version,
+                region=sentinel.region, external_name=sentinel.external_name,
+                ignore="true"
+            )
+
+    def test_init__non_boolean_obsolete_value__raises_invalid_config_file_error(self):
+        with pytest.raises(InvalidConfigFileError):
+            Stack(
+                name='dev/stack/app', project_code=sentinel.project_code,
+                template_handler_config=sentinel.template_handler_config,
+                template_bucket_name=sentinel.template_bucket_name,
+                template_key_prefix=sentinel.template_key_prefix,
+                required_version=sentinel.required_version,
+                region=sentinel.region, external_name=sentinel.external_name,
+                obsolete="true"
             )
 
     def test_stack_repr(self):


### PR DESCRIPTION
This feature adds two new Stack configurations, a new option on `launch` and a new command (`prune`):
* `ignore` will cause the `launch` command to completely ignore the Stack; It will be neither created, nor updated, nor deleted. If the Stack currently exists on AWS, it will stay as it is. If the stack does not exist on AWS, it will not be created.
* `obsolete` stacks function like `ignore`d. ones, but will be deleted when _pruned_ (see below)
* The `launch` command now has a `--prune` option. When `launch --prune` is invoked, all obsolete stacks on the command path will deleted first before the rest of the deployment proceeds.
* The new `prune` command will delete _all_ obsolete stacks in the entire project (irrespective of any command path). This is a simple way to clean up potentially multiple stacks that need to be deleted.

This PR adds the feature described in #1212 and addresses the spirit of #1193 . 

The basic idea here is you could do something like:

```yaml
template:
    path: my/test/resources.yaml

{% if not var.use_test_resources %}
# If we set obsolete: True, it won't be created and will be deleted if it exists when launched with --prune
obsolete: True
{% endif %}
```

This feature addresses two needs:
1. The ability to selectively exclude Stack Configs when you run `sceptre launch` when it isn't ready or certain Jinja Logic determines that it should not be launched.
2. The ability to delete stacks as a part of a CI/CD process when they aren't needed/wanted any more.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
