### PR TITLE
Make unit tests run in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,6 @@ jobs:
             - project
 
   lint-and-unit-tests:
-    parallelism: 4
     docker:
       - image: cloudreach/sceptre-circleci:0.8.0
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,7 @@ jobs:
             - project
 
   lint-and-unit-tests:
+    parallelism: 4
     docker:
       - image: cloudreach/sceptre-circleci:0.8.0
     steps:

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ test:
 	pytest
 
 test-all:
-	tox
+	tox -p --all
 
 test-integration: install
 	behave integration-tests/

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ test:
 	pytest
 
 test-all:
-	tox -p --all
+	tox --parallel=auto
 
 test-integration: install
 	behave integration-tests/

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ test:
 	pytest
 
 test-all:
-	tox
+	tox --parallel
 
 test-integration: install
 	behave integration-tests/

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ test:
 	pytest
 
 test-all:
-	tox --parallel
+	tox
 
 test-integration: install
 	behave integration-tests/


### PR DESCRIPTION
Unit tests are taking a long time to run.  Change tox to run
them in parallel[1] to speed up the test execution.

[1] https://tox.wiki/en/latest/example/basic.html#parallel-mode
