### PR TITLE
CI does not need awscli

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,6 @@ jobs:
             . ./venv/bin/activate
             pip install -r requirements/prod.txt
             pip install -r requirements/dev.txt
-            pip install awscli
       - save_cache:
           key:
             sceptre-{{ .Environment.CACHE_VERSION }}-requirements-{{ arch }}-{{


### PR DESCRIPTION
The CI workflow does not need the AWS CLI.
