### PR TITLE
Update sceptre to use importlib

### DIFF
--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -176,7 +176,7 @@ class ConfigReader(object):
             return class_constructor
 
         for group in entry_point_groups:
-            if sys.version_info > (3,9):
+            if sys.version_info > (3, 9):
                 entry_points = iter_entry_points(group=group)
             else:
                 entry_points = iter_entry_points(group)

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -138,8 +138,8 @@ class ConfigReader(object):
 
     def iterate_entry_points(group):
         """
-        Helper to determine whether to use pkg_resources or
-        importlib.metadata.
+        Helper to determine whether to use pkg_resources or importlib.metadata.
+        https://docs.python.org/3/library/importlib.metadata.html
         """
         if sys.version_info < (3, 10):
             from pkg_resources import iter_entry_points

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -136,7 +136,7 @@ class ConfigReader(object):
 
         self.templating_vars = {"var": self.context.user_variables}
 
-    def iterate_entry_points(group):
+    def _iterate_entry_points(group):
         """
         Helper to determine whether to use pkg_resources or importlib.metadata.
         https://docs.python.org/3/library/importlib.metadata.html
@@ -183,7 +183,7 @@ class ConfigReader(object):
 
         for group in entry_point_groups:
 
-            for entry_point in iterate_entry_points(group):
+            for entry_point in self._iterate_entry_points(group):
                 # Retrieve name and class from entry point
                 node_tag = u'!' + entry_point.name
                 node_class = entry_point.load()

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -15,7 +15,11 @@ import logging
 from os import environ, path, walk
 from typing import Set
 
-from pkg_resources import iter_entry_points
+try:
+    from importlib.metadata import entry_points as iter_entry_points
+except:
+    from pkg_resources import iter_entry_points
+
 from pathlib import Path
 import yaml
 
@@ -171,7 +175,7 @@ class ConfigReader(object):
             return class_constructor
 
         for group in entry_point_groups:
-            for entry_point in iter_entry_points(group):
+            for entry_point in iter_entry_points(group=group):
                 # Retrieve name and class from entry point
                 node_tag = u'!' + entry_point.name
                 node_class = entry_point.load()

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -136,6 +136,7 @@ class ConfigReader(object):
 
         self.templating_vars = {"var": self.context.user_variables}
 
+    @staticmethod
     def _iterate_entry_points(group):
         """
         Helper to determine whether to use pkg_resources or importlib.metadata.

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -17,7 +17,7 @@ from typing import Set
 
 try:
     from importlib.metadata import entry_points as iter_entry_points
-except:
+except ImportError:
     from pkg_resources import iter_entry_points
 
 from pathlib import Path

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -177,9 +177,9 @@ class ConfigReader(object):
 
         for group in entry_point_groups:
             if sys.version_info < (3, 10):
-                entry_points = iter_entry_points("sceptre.template_handlers", type)
+                entry_points = iter_entry_points(group)
             else:
-                entry_points = iter_entry_points(group="sceptre.template_handlers", name=type)
+                entry_points = iter_entry_points(group=group)
 
             for entry_point in entry_points:
                 # Retrieve name and class from entry point

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -12,12 +12,13 @@ import copy
 import datetime
 import fnmatch
 import logging
+import sys
 from os import environ, path, walk
 from typing import Set
 
-try:
+if sys.version_info > (3, 9):
     from importlib.metadata import entry_points as iter_entry_points
-except ImportError:
+else:
     from pkg_resources import iter_entry_points
 
 from pathlib import Path
@@ -175,7 +176,12 @@ class ConfigReader(object):
             return class_constructor
 
         for group in entry_point_groups:
-            for entry_point in iter_entry_points(group=group):
+            if sys.version_info > (3,9):
+                entry_points = iter_entry_points(group=group)
+            else:
+                entry_points = iter_entry_points(group)
+
+            for entry_point in entry_points:
                 # Retrieve name and class from entry point
                 node_tag = u'!' + entry_point.name
                 node_class = entry_point.load()

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -16,10 +16,10 @@ import sys
 from os import environ, path, walk
 from typing import Set
 
-if sys.version_info > (3, 9):
-    from importlib.metadata import entry_points as iter_entry_points
-else:
+if sys.version_info < (3, 10):
     from pkg_resources import iter_entry_points
+else:
+    from importlib.metadata import entry_points as iter_entry_points
 
 from pathlib import Path
 import yaml
@@ -176,10 +176,10 @@ class ConfigReader(object):
             return class_constructor
 
         for group in entry_point_groups:
-            if sys.version_info > (3, 9):
-                entry_points = iter_entry_points(group=group)
+            if sys.version_info < (3, 10):
+                entry_points = iter_entry_points("sceptre.template_handlers", type)
             else:
-                entry_points = iter_entry_points(group)
+                entry_points = iter_entry_points(group="sceptre.template_handlers", name=type)
 
             for entry_point in entry_points:
                 # Retrieve name and class from entry point

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -10,11 +10,13 @@ and implements methods for uploading it to S3.
 import logging
 import threading
 import botocore
+import sys
 
 from sceptre.exceptions import TemplateHandlerNotFoundError
-try:
+
+if sys.version_info > (3, 9):
     from importlib.metadata import entry_points as iter_entry_points
-except ImportError:
+else:
     from pkg_resources import iter_entry_points
 
 
@@ -249,7 +251,12 @@ class Template(object):
         if not self._registry:
             self._registry = {}
 
-            for entry_point in iter_entry_points(group="sceptre.template_handlers", name=type):
+            if sys.version_info > (3,9):
+                entry_points = iter_entry_points(group="sceptre.template_handlers", name=type)
+            else:
+                entry_points = iter_entry_points("sceptre.template_handlers", type)
+
+            for entry_point in entry_points:
                 self._registry[entry_point.name] = entry_point.load()
 
         if type not in self._registry:

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -12,7 +12,10 @@ import threading
 import botocore
 
 from sceptre.exceptions import TemplateHandlerNotFoundError
-from pkg_resources import iter_entry_points
+try:
+    from importlib.metadata import entry_points as iter_entry_points
+except:
+    from pkg_resources import iter_entry_points
 
 
 class Template(object):
@@ -246,7 +249,7 @@ class Template(object):
         if not self._registry:
             self._registry = {}
 
-            for entry_point in iter_entry_points("sceptre.template_handlers", type):
+            for entry_point in iter_entry_points(group="sceptre.template_handlers", name=type):
                 self._registry[entry_point.name] = entry_point.load()
 
         if type not in self._registry:

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -14,7 +14,7 @@ import botocore
 from sceptre.exceptions import TemplateHandlerNotFoundError
 try:
     from importlib.metadata import entry_points as iter_entry_points
-except:
+except ImportError:
     from pkg_resources import iter_entry_points
 
 

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -14,10 +14,10 @@ import sys
 
 from sceptre.exceptions import TemplateHandlerNotFoundError
 
-if sys.version_info > (3, 9):
-    from importlib.metadata import entry_points as iter_entry_points
-else:
+if sys.version_info < (3, 10):
     from pkg_resources import iter_entry_points
+else:
+    from importlib.metadata import entry_points as iter_entry_points
 
 
 class Template(object):
@@ -251,10 +251,10 @@ class Template(object):
         if not self._registry:
             self._registry = {}
 
-            if sys.version_info > (3, 9):
-                entry_points = iter_entry_points(group="sceptre.template_handlers", name=type)
-            else:
+            if sys.version_info < (3, 10):
                 entry_points = iter_entry_points("sceptre.template_handlers", type)
+            else:
+                entry_points = iter_entry_points(group="sceptre.template_handlers", name=type)
 
             for entry_point in entry_points:
                 self._registry[entry_point.name] = entry_point.load()

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -251,7 +251,7 @@ class Template(object):
         if not self._registry:
             self._registry = {}
 
-            if sys.version_info > (3,9):
+            if sys.version_info > (3, 9):
                 entry_points = iter_entry_points(group="sceptre.template_handlers", name=type)
             else:
                 entry_points = iter_entry_points("sceptre.template_handlers", type)

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -14,11 +14,6 @@ import sys
 
 from sceptre.exceptions import TemplateHandlerNotFoundError
 
-if sys.version_info < (3, 10):
-    from pkg_resources import iter_entry_points
-else:
-    from importlib.metadata import entry_points as iter_entry_points
-
 
 class Template(object):
     """
@@ -241,8 +236,8 @@ class Template(object):
 
     def iterate_entry_points(group, name):
         """
-        Helper to determine whether to use pkg_resources or
-        importlib.metadata.
+        Helper to determine whether to use pkg_resources or importlib.metadata.
+        https://docs.python.org/3/library/importlib.metadata.html
         """
         if sys.version_info < (3, 10):
             from pkg_resources import iter_entry_points

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -234,6 +234,7 @@ class Template(object):
     def _domain_from_region(region):
         return "com.cn" if region.startswith("cn-") else "com"
 
+    @staticmethod
     def _iterate_entry_points(group, name):
         """
         Helper to determine whether to use pkg_resources or importlib.metadata.

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -234,7 +234,7 @@ class Template(object):
     def _domain_from_region(region):
         return "com.cn" if region.startswith("cn-") else "com"
 
-    def iterate_entry_points(group, name):
+    def _iterate_entry_points(group, name):
         """
         Helper to determine whether to use pkg_resources or importlib.metadata.
         https://docs.python.org/3/library/importlib.metadata.html
@@ -258,7 +258,7 @@ class Template(object):
         if not self._registry:
             self._registry = {}
 
-            for entry_point in iterate_entry_points("sceptre.template_handlers", type):
+            for entry_point in self._iterate_entry_points("sceptre.template_handlers", type):
                 self._registry[entry_point.name] = entry_point.load()
 
         if type not in self._registry:

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -239,6 +239,18 @@ class Template(object):
     def _domain_from_region(region):
         return "com.cn" if region.startswith("cn-") else "com"
 
+    def iterate_entry_points(group, name):
+        """
+        Helper to determine whether to use pkg_resources or
+        importlib.metadata.
+        """
+        if sys.version_info < (3, 10):
+            from pkg_resources import iter_entry_points
+            return iter_entry_points(group, name)
+        else:
+            from importlib.metadata import entry_points
+            return entry_points(group=group, name=name)
+
     def _get_handler_of_type(self, type):
         """
         Gets a TemplateHandler type from the registry that can be used to get a string
@@ -251,12 +263,7 @@ class Template(object):
         if not self._registry:
             self._registry = {}
 
-            if sys.version_info < (3, 10):
-                entry_points = iter_entry_points("sceptre.template_handlers", type)
-            else:
-                entry_points = iter_entry_points(group="sceptre.template_handlers", name=type)
-
-            for entry_point in entry_points:
+            for entry_point in iterate_entry_points("sceptre.template_handlers", type):
                 self._registry[entry_point.name] = entry_point.load()
 
         if type not in self._registry:


### PR DESCRIPTION
The purpose of this change is to get us to a point where we can add
support for python 3.10.  It partially resolves issue #1225 

* pkg_resources does not work with python 3.10 so need to switch
to importlib.

* importlib entry_points requires keyword arguments in python 3.10
