### PR TITLE
use circleci cache to speed up builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,7 @@ jobs:
           root: /home/circleci
           paths:
             - project
+            - .pyenv
 
   lint-and-unit-tests:
     docker:
@@ -80,11 +81,6 @@ jobs:
               checksum "requirements/prod.txt" }}-{{ checksum
               "requirements/dev.txt" }}-{{ checksum "tox.ini" }}
       - run:
-          name: 'Installing Dependencies'
-          command: |
-            pyenv global venv
-            make install-dev
-      - run:
           name: 'Linting'
           command: |
             pyenv global venv
@@ -92,6 +88,7 @@ jobs:
       - run:
           name: 'Unit Test'
           command: |
+            pyenv global venv
             make test-all
       - save_cache:
           key:
@@ -103,10 +100,6 @@ jobs:
       - store_test_results:
           path: coverage.xml
           destination: coverage-reports
-      - persist_to_workspace:
-          root: /home/circleci
-          paths:
-            - project
 
   integration-tests:
     parallelism: 2
@@ -122,11 +115,6 @@ jobs:
             sceptre-{{ .Environment.CACHE_VERSION }}-dependencies-{{ arch }}-{{
             checksum "requirements/prod.txt" }}-{{ checksum
             "requirements/dev.txt" }}
-      - run:
-          name: 'Installing Dependencies'
-          command: |
-            pyenv global venv
-            make install-dev
       - run:
           name: 'Integration Testing'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,11 @@ jobs:
           name: 'Creating Virtualenv'
           command: |
             pyenv virtualenv 3.9.4 venv
+      - restore_cache:
+          key:
+            sceptre-{{ .Environment.CACHE_VERSION }}-requirements-{{ arch }}-{{
+            checksum "requirements/prod.txt" }}-{{ checksum
+            "requirements/dev.txt" }}
       - run:
           name: 'Installing Dependencies'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
             checksum "requirements/prod.txt" }}-{{ checksum
             "requirements/dev.txt" }}
           paths:
-            - .pyenv/versions/3.9.4/envs/venv
+            - ../.pyenv/versions/3.9.4/envs/venv
       - run:
           name: 'Installing Sceptre'
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,11 +40,10 @@ jobs:
           command: |
             pyenv virtualenv 3.9.4 venv
       - run:
-          name: 'Installing Requirements'
+          name: 'Installing Dependencies'
           command: |
             pyenv global venv
-            pip install -r requirements/prod.txt
-            pip install -r requirements/dev.txt
+            make install-dev
       - save_cache:
           key:
             sceptre-{{ .Environment.CACHE_VERSION }}-requirements-{{ arch }}-{{
@@ -70,36 +69,32 @@ jobs:
           at: /home/circleci
       - restore_cache:
           key:
-            sceptre-{{ .Environment.CACHE_VERSION }}-requirements-{{ arch }}-{{
-            checksum "requirements/prod.txt" }}-{{ checksum
-            "requirements/dev.txt" }}
+            sceptre-{{ .Environment.CACHE_VERSION }}-requirements-{{ arch
+            }}-{{ checksum "requirements/prod.txt" }}-{{ checksum
+            "requirements/dev.txt" }}-{{ checksum "tox.ini" }}
       - run:
           name: 'Linting'
           command: |
             pyenv global venv
             make lint
-
       - run:
           name: 'Unit Test'
           command: |
             make test-all
-
-      - store_test_results:
-          path: coverage.xml
-          destination: coverage-reports
-
-      - persist_to_workspace:
-          root: /home/circleci
-          paths:
-            - .
-
       - save_cache:
           key:
-            sceptre-{{ .Environment.CACHE_VERSION }}-tox-requirements-{{ arch
+            sceptre-{{ .Environment.CACHE_VERSION }}-requirements-{{ arch
             }}-{{ checksum "requirements/prod.txt" }}-{{ checksum
             "requirements/dev.txt" }}-{{ checksum "tox.ini" }}
           paths:
             - .tox
+      - store_test_results:
+          path: coverage.xml
+          destination: coverage-reports
+      - persist_to_workspace:
+          root: /home/circleci
+          paths:
+            - .
 
   integration-tests:
     parallelism: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
             pyenv virtualenv 3.9.4 venv
       - restore_cache:
           key:
-            sceptre-{{ .Environment.CACHE_VERSION }}-requirements-{{ arch }}-{{
+            sceptre-{{ .Environment.CACHE_VERSION }}-dependencies-{{ arch }}-{{
             checksum "requirements/prod.txt" }}-{{ checksum
             "requirements/dev.txt" }}
       - run:
@@ -51,7 +51,7 @@ jobs:
             make install-dev
       - save_cache:
           key:
-            sceptre-{{ .Environment.CACHE_VERSION }}-requirements-{{ arch }}-{{
+            sceptre-{{ .Environment.CACHE_VERSION }}-dependencies-{{ arch }}-{{
             checksum "requirements/prod.txt" }}-{{ checksum
             "requirements/dev.txt" }}
           paths:
@@ -73,10 +73,12 @@ jobs:
       - attach_workspace:
           at: /home/circleci
       - restore_cache:
-          key:
-            sceptre-{{ .Environment.CACHE_VERSION }}-requirements-{{ arch
-            }}-{{ checksum "requirements/prod.txt" }}-{{ checksum
-            "requirements/dev.txt" }}-{{ checksum "tox.ini" }}
+          keys:
+            - sceptre-{{ .Environment.CACHE_VERSION }}-dependencies-{{ arch }}-{{
+              checksum "requirements/prod.txt" }}-{{ checksum "requirements/dev.txt" }}
+            - sceptre-{{ .Environment.CACHE_VERSION }}-dependencies-{{ arch }}-{{
+              checksum "requirements/prod.txt" }}-{{ checksum
+              "requirements/dev.txt" }}-{{ checksum "tox.ini" }}
       - run:
           name: 'Linting'
           command: |
@@ -88,7 +90,7 @@ jobs:
             make test-all
       - save_cache:
           key:
-            sceptre-{{ .Environment.CACHE_VERSION }}-requirements-{{ arch
+            sceptre-{{ .Environment.CACHE_VERSION }}-{{ arch
             }}-{{ checksum "requirements/prod.txt" }}-{{ checksum
             "requirements/dev.txt" }}-{{ checksum "tox.ini" }}
           paths:
@@ -112,7 +114,7 @@ jobs:
           at: /home/circleci
       - restore_cache:
           key:
-            sceptre-{{ .Environment.CACHE_VERSION }}-requirements-{{ arch }}-{{
+            sceptre-{{ .Environment.CACHE_VERSION }}-dependencies-{{ arch }}-{{
             checksum "requirements/prod.txt" }}-{{ checksum
             "requirements/dev.txt" }}
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
       - persist_to_workspace:
           root: /home/circleci
           paths:
-            - .
+            - project
 
   lint-and-unit-tests:
     docker:
@@ -101,7 +101,7 @@ jobs:
       - persist_to_workspace:
           root: /home/circleci
           paths:
-            - .
+            - project
 
   integration-tests:
     parallelism: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,11 @@ jobs:
               checksum "requirements/prod.txt" }}-{{ checksum
               "requirements/dev.txt" }}-{{ checksum "tox.ini" }}
       - run:
+          name: 'Installing Dependencies'
+          command: |
+            pyenv global venv
+            make install-dev
+      - run:
           name: 'Linting'
           command: |
             pyenv global venv
@@ -117,6 +122,11 @@ jobs:
             sceptre-{{ .Environment.CACHE_VERSION }}-dependencies-{{ arch }}-{{
             checksum "requirements/prod.txt" }}-{{ checksum
             "requirements/dev.txt" }}
+      - run:
+          name: 'Installing Dependencies'
+          command: |
+            pyenv global venv
+            make install-dev
       - run:
           name: 'Integration Testing'
           command: |
@@ -161,6 +171,16 @@ jobs:
     steps:
       - attach_workspace:
           at: /home/circleci
+      - restore_cache:
+          key:
+            sceptre-{{ .Environment.CACHE_VERSION }}-dependencies-{{ arch }}-{{
+            checksum "requirements/prod.txt" }}-{{ checksum
+            "requirements/dev.txt" }}
+      - run:
+          name: 'Installing Dependencies'
+          command: |
+            pyenv global venv
+            make install-dev
       - run:
           name: 'Create Distributions'
           command: |


### PR DESCRIPTION
Setup the circleci cache and workspace settings to speed
up sceptre build and tests pipelines.

* reduce the build pipeline time from ~5 min to 1 min
* reduce the lint-and-unit-tests pipeline from ~6 min to ~3 mins
