### PR TITLE
[Resolve #1223] Fix crash when resolvers return None

### DIFF
--- a/sceptre/resolvers/__init__.py
+++ b/sceptre/resolvers/__init__.py
@@ -238,8 +238,19 @@ class ResolvableContainerProperty(ResolvableProperty):
             resolve, container, Resolver
         )
         # Remove keys and indexes from their containers that had resolvers resolve to None.
+        list_items_to_delete = []
         for attr, key in keys_to_delete:
-            del attr[key]
+            if isinstance(attr, list):
+                # If it's a list, we want to gather up the items to remove from the list.
+                # We don't want to modify the list length yet.
+                # Since removals will change all the other list indexes,
+                # we don't wan't to modify lists yet.
+                list_items_to_delete.append((attr, attr[key]))
+            else:
+                del attr[key]
+
+        for containing_list, item in list_items_to_delete:
+            containing_list.remove(item)
 
         return container
 

--- a/tests/test_resolvers/test_resolver.py
+++ b/tests/test_resolvers/test_resolver.py
@@ -341,6 +341,42 @@ class TestResolvableContainerPropertyDescriptor:
             'resolver': 'stack1'
         }
 
+    def test_get__resolver_resolves_to_none__value_is_dict__deletes_those_items_from_dict(self):
+        class MyResolver(Resolver):
+            def resolve(self):
+                return None
+
+        resolver = MyResolver()
+        self.mock_object.resolvable_container_property = {
+            'a': 4,
+            'b': resolver,
+            'c': 3,
+            'd': resolver,
+            'e': resolver,
+            'f': 5,
+        }
+        expected = {'a': 4, 'c': 3, 'f': 5}
+        assert self.mock_object.resolvable_container_property == expected
+
+    def test_get__resolver_resolves_to_none__value_is_dict__deletes_those_items_from_complex_structure(self):
+        class MyResolver(Resolver):
+            def resolve(self):
+                return None
+
+        resolver = MyResolver()
+        self.mock_object.resolvable_container_property = {
+            'a': 4,
+            'b': [
+                resolver,
+            ],
+            'c': [{
+                'v': resolver
+            }],
+            'd': 3
+        }
+        expected = {'a': 4, 'b': [], 'c': [{}], 'd': 3}
+        assert self.mock_object.resolvable_container_property == expected
+
     def test_get__resolver_resolves_to_none__value_is_list__deletes_that_item_from_list(self):
         class MyResolver(Resolver):
             def resolve(self):
@@ -366,6 +402,39 @@ class TestResolvableContainerPropertyDescriptor:
             'resolver': resolver
         }
         expected = {'some key': 'some value'}
+        assert self.mock_object.resolvable_container_property == expected
+
+    def test_get__resolvers_resolves_to_none__value_is_list__deletes_those_items_from_list(self):
+        class MyResolver(Resolver):
+            def resolve(self):
+                return None
+
+        resolver = MyResolver()
+
+        self.mock_object.resolvable_container_property = [
+            1,
+            resolver,
+            3,
+            resolver,
+            resolver,
+            6
+        ]
+        expected = [1, 3, 6]
+        assert self.mock_object.resolvable_container_property == expected
+
+    def test_get__resolvers_resolves_to_none__value_is_list__deletes_all_items_from_list(self):
+        class MyResolver(Resolver):
+            def resolve(self):
+                return None
+
+        resolver = MyResolver()
+
+        self.mock_object.resolvable_container_property = [
+            resolver,
+            resolver,
+            resolver
+        ]
+        expected = []
         assert self.mock_object.resolvable_container_property == expected
 
     def test_get__value_in_list_is_none__returns_list_with_none(self):


### PR DESCRIPTION
When multiple resolvers in a stack config return None sceptre fails, this change 
fixes that by suporting lists, dicts as well as complex structures

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
