### PR TITLE
[Resolve #1234] Bugfix in helpers.py

### DIFF
--- a/sceptre/cli/helpers.py
+++ b/sceptre/cli/helpers.py
@@ -216,7 +216,7 @@ def setup_vars(var_file, var, merge_vars, debug, no_colour):
 
     if var_file:
         for fh in var_file:
-            parsed = yaml.safe_load(fh.read())
+            parsed = yaml.safe_load(fh.read()) or {}
 
             if merge_vars:
                 return_value = _deep_merge(parsed, return_value)


### PR DESCRIPTION
Before this, an empty var file would cause sceptre to fail with an
exception

```
TypeError: 'NoneType' object is not iterable
```

This was caused by yaml.safe_load returning `None` instead of an empty
dict. This adds a default value to avoid this bug.


## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [ ] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
