### PR TITLE
[Resolves 1098] Deploy docker container to sceptreorg repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
 aliases:
   - &docs-job
     docker:
-      - image: sceptreorg/sceptre-circleci:1.0.0
+      - image: sceptreorg/sceptre-circleci:1.1.0
         environment:
           REPOSITORY_PATH: '/home/circleci/docs'
           DEPLOYMENT_GIT_SSH: 'git@github.com:Sceptre/sceptre.github.io.git'
@@ -35,7 +35,7 @@ aliases:
 jobs:
   build:
     docker:
-      - image: sceptreorg/sceptre-circleci:1.0.0
+      - image: sceptreorg/sceptre-circleci:1.1.0
     steps:
       - checkout
       - run:
@@ -72,7 +72,7 @@ jobs:
 
   lint-and-unit-tests:
     docker:
-      - image: sceptreorg/sceptre-circleci:1.0.0
+      - image: sceptreorg/sceptre-circleci:1.1.0
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -107,7 +107,7 @@ jobs:
   integration-tests:
     parallelism: 2
     docker:
-      - image: sceptreorg/sceptre-circleci:1.0.0
+      - image: sceptreorg/sceptre-circleci:1.1.0
         environment:
           AWS_DEFAULT_REGION: eu-west-1
     steps:
@@ -158,7 +158,7 @@ jobs:
 
   deploy-pypi:
     docker:
-      - image: sceptreorg/sceptre-circleci:1.0.0
+      - image: sceptreorg/sceptre-circleci:1.1.0
     steps:
       - attach_workspace:
           at: /home/circleci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,14 +6,14 @@ orbs:
 executors:
   docker-publisher:
     environment:
-      IMAGE_NAME: cloudreach/sceptre
+      IMAGE_NAME: sceptreorg/sceptre
     docker:
       - image: circleci/buildpack-deps:stretch
 
 aliases:
   - &docs-job
     docker:
-      - image: cloudreach/sceptre-circleci:1.0.0
+      - image: sceptreorg/sceptre-circleci:1.0.0
         environment:
           REPOSITORY_PATH: '/home/circleci/docs'
           DEPLOYMENT_GIT_SSH: 'git@github.com:Sceptre/sceptre.github.io.git'
@@ -35,7 +35,7 @@ aliases:
 jobs:
   build:
     docker:
-      - image: cloudreach/sceptre-circleci:1.0.0
+      - image: sceptreorg/sceptre-circleci:1.0.0
     steps:
       - checkout
       - run:
@@ -72,7 +72,7 @@ jobs:
 
   lint-and-unit-tests:
     docker:
-      - image: cloudreach/sceptre-circleci:1.0.0
+      - image: sceptreorg/sceptre-circleci:1.0.0
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -107,7 +107,7 @@ jobs:
   integration-tests:
     parallelism: 2
     docker:
-      - image: cloudreach/sceptre-circleci:1.0.0
+      - image: sceptreorg/sceptre-circleci:1.0.0
         environment:
           AWS_DEFAULT_REGION: eu-west-1
     steps:
@@ -158,7 +158,7 @@ jobs:
 
   deploy-pypi:
     docker:
-      - image: cloudreach/sceptre-circleci:1.0.0
+      - image: sceptreorg/sceptre-circleci:1.0.0
     steps:
       - attach_workspace:
           at: /home/circleci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,7 +285,7 @@ workflows:
             branches:
               ignore: /^pull\/.*/
       - deploy-latest-dockerhub:
-          context: sceptre-core
+          context: sceptreorg-dockerhub
           requires:
             - build-docker-image
           filters:
@@ -327,7 +327,7 @@ workflows:
             branches:
               ignore: /.*/
       - deploy-dockerhub-tagged:
-          context: sceptre-core
+          context: sceptreorg-dockerhub
           requires:
             - build-docker-image
           filters:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 3.9.0
     hooks:
       - id: flake8

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sceptre
 
 [![CircleCI](https://img.shields.io/circleci/build/github/Sceptre/sceptre?logo=circleci)](https://app.circleci.com/pipelines/github/Sceptre)
-[![Docker Image Version (latest semver)](https://img.shields.io/docker/v/cloudreach/sceptre?logo=docker&sort=semver)](https://hub.docker.com/r/cloudreach/sceptre)
+[![Docker Image Version (latest semver)](https://img.shields.io/docker/v/sceptreorg/sceptre?logo=docker&sort=semver)](https://hub.docker.com/r/sceptreorg/sceptre)
 [![PyPI](https://img.shields.io/pypi/v/sceptre?logo=pypi)](https://pypi.org/project/sceptre/)
 [![PyPI - Status](https://img.shields.io/pypi/status/sceptre?logo=pypi)](https://pypi.org/project/sceptre/)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/sceptre?logo=pypi)](https://pypi.org/project/sceptre/)
@@ -54,24 +54,24 @@ More information on installing sceptre can be found in our
 
 ### Using Docker Image
 
-View our [Docker repository](https://hub.docker.com/r/cloudreach/sceptre).
+View our [Docker repository](https://hub.docker.com/repositories/sceptreorg).
 Images available from version 2.0.0 onward.
 
 To use our Docker image follow these instructions:
 
-1. Pull the image `docker pull cloudreach/sceptre:[SCEPTRE_VERSION_NUMBER]` e.g.
-   `docker pull cloudreach/sceptre:2.5.0`. Leave out the version number if you
-   wish to run `latest` or run `docker pull cloudreach/sceptre:latest`.
+1. Pull the image `docker pull sceptreorg/sceptre:[SCEPTRE_VERSION_NUMBER]` e.g.
+   `docker pull sceptreorg/sceptre:2.5.0`. Leave out the version number if you
+   wish to run `latest` or run `docker pull sceptreorg/sceptre:latest`.
 
 2. Run the image. You will need to mount the working directory where your
    project resides to a directory called `project`. You will also need to mount
    a volume with your AWS config to your docker container. E.g.
 
-`docker run -v $(pwd):/project -v /Users/me/.aws/:/root/.aws/:ro cloudreach/sceptre:latest --help`
+`docker run -v $(pwd):/project -v /Users/me/.aws/:/root/.aws/:ro sceptreorg/sceptre:latest --help`
 
 If you want to use a custom ENTRYPOINT simply amend the Docker command:
 
-`docker run -ti --entrypoint='' cloudreach/sceptre:latest sh`
+`docker run -ti --entrypoint='' sceptreorg/sceptre:latest sh`
 
 The above command will enter you into the shell of the Docker container where
 you can execute sceptre commands - useful for development.


### PR DESCRIPTION
Deploy sceptre docker images to dockerhub sceptreorg repo instead of cloudreach repo

depends on https://github.com/Sceptre/sceptre-circleci/pull/16
