### PR TITLE
[Resolve #1273]: Events start from response time

### DIFF
--- a/sceptre/helpers.py
+++ b/sceptre/helpers.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
-import dateutil.parser
-
 from contextlib import contextmanager
+from datetime import datetime
 from os import sep
+from typing import Optional
+
+import dateutil.parser
 
 from sceptre.exceptions import PathConversionError
 
@@ -121,11 +123,10 @@ def null_context():
     yield
 
 
-def extract_datetime_from_aws_response_headers(boto_response):
+def extract_datetime_from_aws_response_headers(boto_response: dict) -> Optional[datetime]:
     """Returns a datetime.datetime extracted from the response metadata in a
     boto response or None if it's unable to find or parse one.
     :param boto_response: A dictionary returned from a boto client call
-    :type boto_response: dict
     :returns a datetime.datetime or None
     """
     if boto_response is None:
@@ -133,7 +134,7 @@ def extract_datetime_from_aws_response_headers(boto_response):
     try:
         return dateutil.parser.parse(boto_response["ResponseMetadata"]["HTTPHeaders"]["date"])
     except (KeyError, dateutil.parser.ParserError):
-        # We expect a KeyError if the date isn't present in the response. We expect
-        # a ParserError if it's not well-formatted. Any other error we want to pass
-        # along.
+        # We expect a KeyError if the date isn't present in the response. We
+        # expect a ParserError if it's not well-formed. Any other error we want
+        # to pass along.
         return None

--- a/sceptre/helpers.py
+++ b/sceptre/helpers.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
+import email.utils as eut
+
 from contextlib import contextmanager
+from datetime import datetime
 from os import sep
 
 from sceptre.exceptions import PathConversionError
@@ -117,3 +120,10 @@ def null_context():
     available in py3.6, so providing it here instead.
     """
     yield
+
+
+def get_response_datetime(resp):
+    try:
+        return datetime(*eut.parsedate(resp["ResponseMetadata"]["HTTPHeaders"]["date"])[:6])
+    except (TypeError, KeyError):
+        return None

--- a/sceptre/helpers.py
+++ b/sceptre/helpers.py
@@ -122,8 +122,17 @@ def null_context():
     yield
 
 
-def get_response_datetime(resp):
+def extract_datetime_from_aws_response_headers(boto_response):
+    """Returns a datetime.datetime extracted from the response metadata in a
+    boto response or None if it's unable to find or parse one.
+    :param boto_response: A dictionary returned from a boto client call
+    :type boto_response: dict
+    :returns a datetime.datetime or None
+    """
     try:
-        return datetime(*eut.parsedate(resp["ResponseMetadata"]["HTTPHeaders"]["date"])[:6])
+        # email.utils.parsedate returns a 9-tuple that can be passed to
+        # time.mktime. Fields 6 (tm_wday), 7 (tm_yday), and 8 (tm_isdst) are
+        # unneeded so we slice them off when passing to datetime().
+        return datetime(*eut.parsedate(boto_response["ResponseMetadata"]["HTTPHeaders"]["date"])[:6])
     except (TypeError, KeyError):
         return None

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -14,21 +14,19 @@ import typing
 import urllib
 from datetime import datetime, timedelta
 from os import path
-from typing import Union, Optional, Tuple, Dict
+from typing import Dict, Optional, Tuple, Union
 
 import botocore
 from dateutil.tz import tzutc
 
 from sceptre.config.reader import ConfigReader
 from sceptre.connection_manager import ConnectionManager
-from sceptre.exceptions import (
-    CannotUpdateFailedStackError,
-    ProtectedStackError,
-    StackDoesNotExistError,
-    UnknownStackChangeSetStatusError,
-    UnknownStackStatusError
-)
-from sceptre.helpers import normalise_path, extract_datetime_from_aws_response_headers
+from sceptre.exceptions import (CannotUpdateFailedStackError,
+                                ProtectedStackError, StackDoesNotExistError,
+                                UnknownStackChangeSetStatusError,
+                                UnknownStackStatusError)
+from sceptre.helpers import (extract_datetime_from_aws_response_headers,
+                             normalise_path)
 from sceptre.hooks import add_stack_hooks
 from sceptre.stack import Stack
 from sceptre.stack_status import StackChangeSetStatus, StackStatus
@@ -766,7 +764,7 @@ class StackActions(object):
                 "currently enabled".format(self.stack.name)
             )
 
-    def _wait_for_completion(self, timeout=0, boto_response=None):
+    def _wait_for_completion(self, timeout=0, boto_response: Optional[dict] = None) -> StackStatus:
         """
         Waits for a Stack operation to finish. Prints CloudFormation events
         while it waits.
@@ -775,7 +773,6 @@ class StackActions(object):
         :param boto_response: Response from the boto call which initiated the stack change.
 
         :returns: The final Stack status.
-        :rtype: sceptre.stack_status.StackStatus
         """
         timeout = 60 * timeout
 
@@ -844,14 +841,12 @@ class StackActions(object):
                 "{0} is unknown".format(status)
             )
 
-    def _log_new_events(self, after_datetime):
+    def _log_new_events(self, after_datetime: datetime) -> datetime:
         """
         Log the latest Stack events while the Stack is being built.
 
         :param after_datetime: Only events after this datetime will be logged.
-        :type after_datetime: datetime.datetime
         :returns: The datetime of the last logged event or after_datetime if no events were logged.
-        :rtype: datetime.datetime
         """
         events = self.describe_events()["StackEvents"]
         events.reverse()

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -28,7 +28,7 @@ from sceptre.exceptions import (
     UnknownStackChangeSetStatusError,
     UnknownStackStatusError
 )
-from sceptre.helpers import normalise_path, get_response_datetime
+from sceptre.helpers import normalise_path, extract_datetime_from_aws_response_headers
 from sceptre.hooks import add_stack_hooks
 from sceptre.stack import Stack
 from sceptre.stack_status import StackChangeSetStatus, StackStatus
@@ -774,7 +774,7 @@ class StackActions(object):
             )
 
     def _note_response_time(self, resp):
-        self.most_recent_event_datetime = get_response_datetime(resp)
+        self.most_recent_event_datetime = extract_datetime_from_aws_response_headers(resp)
 
     def _wait_for_completion(self, timeout=0):
         """

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -997,7 +997,8 @@ class TestStackActions(object):
         mock_get_simplified_status.return_value = StackStatus.COMPLETE
 
         self.actions._wait_for_completion()
-        mock_log_new_events.assert_called_once_with()
+        mock_log_new_events.assert_called_once()
+        assert type(mock_log_new_events.mock_calls[0].args[0]) is datetime.datetime
 
     @pytest.mark.parametrize("test_input,expected", [
         ("ROLLBACK_COMPLETE", StackStatus.FAILED),
@@ -1020,7 +1021,7 @@ class TestStackActions(object):
         mock_describe_events.return_value = {
             "StackEvents": []
         }
-        self.actions._log_new_events()
+        self.actions._log_new_events(datetime.datetime.utcnow())
         self.actions.describe_events.assert_called_once_with()
 
     @patch("sceptre.plan.actions.StackActions.describe_events")
@@ -1047,10 +1048,7 @@ class TestStackActions(object):
                 }
             ]
         }
-        self.actions.most_recent_event_datetime = (
-            datetime.datetime(2016, 3, 15, 14, 0, 0, 0, tzinfo=tzutc())
-        )
-        self.actions._log_new_events()
+        self.actions._log_new_events(datetime.datetime(2016, 3, 15, 14, 0, 0, 0, tzinfo=tzutc()))
 
     @patch("sceptre.plan.actions.StackActions._get_cs_status")
     def test_wait_for_cs_completion_calls_get_cs_status(

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import datetime
 import json
-from unittest.mock import patch, sentinel, Mock, call
+from unittest.mock import patch, sentinel, Mock, call, ANY
 
 import pytest
 from botocore.exceptions import ClientError
@@ -127,7 +127,7 @@ class TestStackActions(object):
                 "TimeoutInMinutes": sentinel.timeout
             }
         )
-        mock_wait_for_completion.assert_called_once_with()
+        mock_wait_for_completion.assert_called_once_with(boto_response=ANY)
 
     @patch("sceptre.plan.actions.StackActions._wait_for_completion")
     def test_create_sends_correct_request_no_notifications(
@@ -162,7 +162,7 @@ class TestStackActions(object):
                 "TimeoutInMinutes": sentinel.stack_timeout
             }
         )
-        mock_wait_for_completion.assert_called_once_with()
+        mock_wait_for_completion.assert_called_once_with(boto_response=ANY)
 
     @patch("sceptre.plan.actions.StackActions._wait_for_completion")
     def test_create_sends_correct_request_with_no_failure_no_timeout(
@@ -194,7 +194,8 @@ class TestStackActions(object):
                 ]
             }
         )
-        mock_wait_for_completion.assert_called_once_with()
+
+        mock_wait_for_completion.assert_called_once_with(boto_response=ANY)
 
     @patch("sceptre.plan.actions.StackActions._wait_for_completion")
     def test_create_stack_already_exists(
@@ -245,7 +246,8 @@ class TestStackActions(object):
             }
         )
         mock_wait_for_completion.assert_called_once_with(
-            sentinel.stack_timeout
+            sentinel.stack_timeout,
+            boto_response=ANY
         )
 
     @patch("sceptre.plan.actions.StackActions._wait_for_completion")
@@ -284,7 +286,7 @@ class TestStackActions(object):
         ]
         self.actions.connection_manager.call.assert_has_calls(calls)
         mock_wait_for_completion.assert_has_calls(
-            [call(sentinel.stack_timeout), call()]
+            [call(sentinel.stack_timeout, boto_response=ANY), call(boto_response=ANY)]
         )
 
     @patch("sceptre.plan.actions.StackActions._wait_for_completion")
@@ -319,7 +321,8 @@ class TestStackActions(object):
             }
         )
         mock_wait_for_completion.assert_called_once_with(
-            sentinel.stack_timeout
+            sentinel.stack_timeout,
+            boto_response=ANY
         )
 
     @patch("sceptre.plan.actions.StackActions._wait_for_completion")
@@ -352,7 +355,7 @@ class TestStackActions(object):
             command="cancel_update_stack",
             kwargs={"StackName": sentinel.external_name}
         )
-        mock_wait_for_completion.assert_called_once_with()
+        mock_wait_for_completion.assert_called_once_with(boto_response=ANY)
 
     @patch("sceptre.plan.actions.StackActions.create")
     @patch("sceptre.plan.actions.StackActions._get_status")
@@ -707,7 +710,7 @@ class TestStackActions(object):
                 "StackName": sentinel.external_name
             }
         )
-        mock_wait_for_completion.assert_called_once_with()
+        mock_wait_for_completion.assert_called_once_with(boto_response=ANY)
 
     def test_execute_change_set__change_set_is_failed_for_no_changes__returns_0(self):
         def fake_describe(service, command, kwargs):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,7 +3,7 @@
 import pytest
 
 from os.path import join, sep
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 
 from sceptre.exceptions import PathConversionError
 from sceptre.helpers import get_external_stack_name
@@ -70,13 +70,22 @@ class TestHelpers(object):
                 'this\\path\\is\\invalid\\'
             )
 
-    def test_get_response_datetime__response_is_none__returns_datetime(self):
+    def test_get_response_datetime__response_is_valid__returns_datetime(self):
         resp = {
             "ResponseMetadata": {
                 "HTTPHeaders": {"date": "Wed, 16 Oct 2019 07:28:00 GMT"}
             }
         }
-        assert extract_datetime_from_aws_response_headers(resp) == datetime(2019, 10, 16, 7, 28)
+        assert extract_datetime_from_aws_response_headers(resp) == datetime(2019, 10, 16, 7, 28, tzinfo=timezone.utc)
+
+    def test_get_response_datetime__response_has_offset__returns_datetime(self):
+        resp = {
+            "ResponseMetadata": {
+                "HTTPHeaders": {"date": "Wed, 16 Oct 2019 07:28:00 +0400"}
+            }
+        }
+        offset = timezone(timedelta(hours=4))
+        assert extract_datetime_from_aws_response_headers(resp) == datetime(2019, 10, 16, 7, 28, tzinfo=offset)
 
     def test_get_response_datetime__date_string_is_invalid__returns_none(self):
         resp = {

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -9,7 +9,7 @@ from sceptre.exceptions import PathConversionError
 from sceptre.helpers import get_external_stack_name
 from sceptre.helpers import normalise_path
 from sceptre.helpers import sceptreise_path
-from sceptre.helpers import get_response_datetime
+from sceptre.helpers import extract_datetime_from_aws_response_headers
 
 
 class TestHelpers(object):
@@ -70,24 +70,24 @@ class TestHelpers(object):
                 'this\\path\\is\\invalid\\'
             )
 
-    def test_get_response_datetime_valid(self):
+    def test_get_response_datetime__response_is_none__returns_datetime(self):
         resp = {
             "ResponseMetadata": {
                 "HTTPHeaders": {"date": "Wed, 16 Oct 2019 07:28:00 GMT"}
             }
         }
-        assert get_response_datetime(resp) == datetime(2019, 10, 16, 7, 28)
+        assert extract_datetime_from_aws_response_headers(resp) == datetime(2019, 10, 16, 7, 28)
 
-    def test_get_response_datetime_invalid(self):
+    def test_get_response_datetime__date_string_is_invalid__returns_none(self):
         resp = {
             "ResponseMetadata": {
                 "HTTPHeaders": {"date": "garbage"}
             }
         }
-        assert get_response_datetime(resp) is None
+        assert extract_datetime_from_aws_response_headers(resp) is None
 
-    def test_get_response_datetime_missing(self):
-        assert get_response_datetime({}) is None
+    def test_get_response_datetime__response_is_empty__returns_none(self):
+        assert extract_datetime_from_aws_response_headers({}) is None
 
-    def test_get_response_datetime_null(self):
-        assert get_response_datetime(None) is None
+    def test_get_response_datetime__response_is_none__returns_none(self):
+        assert extract_datetime_from_aws_response_headers(None) is None

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,11 +3,13 @@
 import pytest
 
 from os.path import join, sep
+from datetime import datetime
 
 from sceptre.exceptions import PathConversionError
 from sceptre.helpers import get_external_stack_name
 from sceptre.helpers import normalise_path
 from sceptre.helpers import sceptreise_path
+from sceptre.helpers import get_response_datetime
 
 
 class TestHelpers(object):
@@ -67,3 +69,25 @@ class TestHelpers(object):
             sceptreise_path(
                 'this\\path\\is\\invalid\\'
             )
+
+    def test_get_response_datetime_valid(self):
+        resp = {
+            "ResponseMetadata": {
+                "HTTPHeaders": {"date": "Wed, 16 Oct 2019 07:28:00 GMT"}
+            }
+        }
+        assert get_response_datetime(resp) == datetime(2019, 10, 16, 7, 28)
+
+    def test_get_response_datetime_invalid(self):
+        resp = {
+            "ResponseMetadata": {
+                "HTTPHeaders": {"date": "garbage"}
+            }
+        }
+        assert get_response_datetime(resp) is None
+
+    def test_get_response_datetime_missing(self):
+        assert get_response_datetime({}) is None
+
+    def test_get_response_datetime_null(self):
+        assert get_response_datetime(None) is None


### PR DESCRIPTION
Resolves #1273 by starting event filtering from the timestamp returned in the AWS response headers rather than relying on the workstation clock.

## PR Checklist

- [ ] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
