### PR TITLE
[Resolve #1253]: Failed downloads in http handler now raise exceptions

### DIFF
--- a/sceptre/template_handlers/http.py
+++ b/sceptre/template_handlers/http.py
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 import pathlib
-import requests
 import tempfile
-import sceptre.template_handlers.helper as helper
+from urllib.parse import urlparse
 
+import requests
 from requests.adapters import HTTPAdapter
-from requests.exceptions import InvalidURL, ConnectTimeout
 from requests.packages.urllib3.util.retry import Retry
+
+import sceptre.template_handlers.helper as helper
 from sceptre.exceptions import UnsupportedTemplateFileTypeError
 from sceptre.template_handlers import TemplateHandler
-from urllib.parse import urlparse
 
 HANDLER_OPTION_KEY = "http_template_handler"
 HANDLER_RETRIES_OPTION_PARAM = "retries"
@@ -77,23 +77,22 @@ class Http(TemplateHandler):
 
         return template
 
-    def _get_template(self, url, retries, timeout):
+    def _get_template(self, url: str, retries: int, timeout: int) -> str:
         """
         Get template from the web
         :param url: The url to the template
-        :type: str
         :param retries: The number of retry attempts.
-        :rtype: int
         :param timeout: The timeout for the session in seconds.
-        :rtype: int
+        :raises: :class:`requests.exceptions.HTTPError`: When a download error occurs
         """
         self.logger.debug("Downloading file from: %s", url)
         session = self._get_retry_session(retries=retries)
-        try:
-            response = session.get(url, timeout=timeout)
-            return response.content
-        except (InvalidURL, ConnectTimeout) as e:
-            raise e
+        response = session.get(url, timeout=timeout)
+
+        # If the response was unsuccessful, raise an error.
+        response.raise_for_status()
+
+        return response.content
 
     def _get_retry_session(self,
                            retries,

--- a/tests/test_template_handlers/test_http.py
+++ b/tests/test_template_handlers/test_http.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 import json
+from unittest.mock import patch
 
 import pytest
+from requests.exceptions import HTTPError
 
 from sceptre.exceptions import UnsupportedTemplateFileTypeError
 from sceptre.template_handlers.http import Http
-from unittest.mock import patch
 
 
 class TestHttp(object):
@@ -19,6 +20,16 @@ class TestHttp(object):
         )
         result = template_handler.handle()
         assert result == b"Stuff is working"
+
+    def test_get_template__request_error__raises_error(self, requests_mock):
+        url = "https://raw.githubusercontent.com/acme/bucket.yaml"
+        requests_mock.get(url, content=b"Error message", status_code=404)
+        template_handler = Http(
+            name="vpc",
+            arguments={"url": url},
+        )
+        with pytest.raises(HTTPError):
+            template_handler.handle()
 
     def test_handler_unsupported_type(self):
         handler = Http("http_handler", {'url': 'https://raw.githubusercontent.com/acme/bucket.unsupported'})


### PR DESCRIPTION
This PR addresses #1253 by throwing an informative error when the template fails to download instead of passing the error message to CloudFormation.

## PR Checklist

- [ ] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
