### PR TITLE
[Resolves #1179] cloudformation disable-rollback option

### DIFF
--- a/docs/_source/docs/stack_config.rst
+++ b/docs/_source/docs/stack_config.rst
@@ -214,12 +214,13 @@ disable_rollback
 
 This parameter describes the action taken by CloudFormation when a Stack fails
 to create or update, default is False. This option can be set from the stack
-config or from the Sceptre CLI commands to deploy stacks. Enabling disable-rollback
-using the CLI option disables rollback globally for all stacks. This option
-overrides on_failure since Cloudformation does not allow setting both on deployment.
-For more information and valid values see the `AWS Documentation`_.
+config or from the Sceptre CLI commands to deploy stacks. The disable_rollback
+CLI option (i.e. sceptre launch --disable-rollback) disables cloudformation
+rollback globally for all stacks. This option overrides on_failure since
+Cloudformation does not allow setting both on deployment. For more information
+and valid values see the `AWS Documentation`_.
 
-Examples include:
+Examples:
 
 ``disable_rollback: "True"``
 

--- a/docs/_source/docs/stack_config.rst
+++ b/docs/_source/docs/stack_config.rst
@@ -20,6 +20,7 @@ particular Stack. The available keys are listed below.
 -  `notifications`_ *(optional)*
 -  `obsolete`_ *(optional)*
 -  `on_failure`_ *(optional)*
+-  `disable_rollback`_ *(optional)*
 -  `parameters`_ *(optional)*
 -  `protected`_ *(optional)*
 -  `role_arn`_ *(optional)*
@@ -205,6 +206,22 @@ Examples include:
 
 ``on_failure: "DELETE"``
 
+disable_rollback
+~~~~~~~~~~~~~~~~
+* Resolvable: No
+* Can be inherited from StackGroup: Yes
+* Inheritance strategy: Overrides parent if set
+
+This parameter describes the action taken by CloudFormation when a Stack fails
+to create or update, default is False. This option can be set from the stack
+config or from the Sceptre CLI commands to deploy stacks. Enabling disable-rollback
+using the CLI option disables rollback globally for all stacks. This option
+overrides on_failure since Cloudformation does not allow setting both on deployment.
+For more information and valid values see the `AWS Documentation`_.
+
+Examples include:
+
+``disable_rollback: "True"``
 
 parameters
 ~~~~~~~~~~
@@ -579,6 +596,7 @@ Examples
 .. _hooks: #hooks
 .. _notifications: #notifications
 .. _on_failure: #on-failure
+.. _disable_rollback: #disable-rollback
 .. _parameters: #parameters
 .. _protected: #protected
 .. _role_arn: #role-arn

--- a/sceptre/cli/create.py
+++ b/sceptre/cli/create.py
@@ -10,9 +10,15 @@ from sceptre.cli.helpers import stack_status_exit_code
 @click.argument("path")
 @click.argument("change-set-name", required=False)
 @click.option("-y", "--yes", is_flag=True, help="Assume yes to all questions.")
+@click.option(
+    "-dr",
+    "--disable-rollback",
+    is_flag=True,
+    help="Disable the auto rollback and keep resources successfully created or updated",
+)
 @click.pass_context
 @catch_exceptions
-def create_command(ctx, path, change_set_name, yes):
+def create_command(ctx, path, change_set_name, yes, disable_rollback: bool):
     """
     Creates a stack for a given config PATH. Or if CHANGE_SET_NAME is specified
     creates a change set for stack in PATH.
@@ -24,9 +30,12 @@ def create_command(ctx, path, change_set_name, yes):
     :type change_set_name: str
     :param yes: A flag to assume yes to all questions.
     :type yes: bool
+    :param disable_rollback: A flag to disable cloudformation rollback.
+    :type disable_rollback: bool
     """
     context = SceptreContext(
         command_path=path,
+        command_params=ctx.params,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),

--- a/sceptre/cli/create.py
+++ b/sceptre/cli/create.py
@@ -14,7 +14,7 @@ from sceptre.cli.helpers import stack_status_exit_code
 @click.option(
     "--disable-rollback/--enable-rollback",
     default=None,
-    help="Disable the auto rollback and keep resources successfully created or updated",
+    help="Disable or enable the cloudformation automatic rollback",
 )
 @click.pass_context
 @catch_exceptions

--- a/sceptre/cli/create.py
+++ b/sceptre/cli/create.py
@@ -1,5 +1,6 @@
 import click
 
+from typing import Optional
 from sceptre.context import SceptreContext
 from sceptre.cli.helpers import catch_exceptions, confirmation
 from sceptre.plan.plan import SceptrePlan
@@ -30,7 +31,6 @@ def create_command(ctx, path, change_set_name, yes, disable_rollback: Optional[b
     :param yes: A flag to assume yes to all questions.
     :type yes: bool
     :param disable_rollback: A flag to disable cloudformation rollback.
-    :type disable_rollback: bool
     """
     context = SceptreContext(
         command_path=path,

--- a/sceptre/cli/create.py
+++ b/sceptre/cli/create.py
@@ -12,9 +12,9 @@ from sceptre.cli.helpers import stack_status_exit_code
 @click.argument("change-set-name", required=False)
 @click.option("-y", "--yes", is_flag=True, help="Assume yes to all questions.")
 @click.option(
-  "--disable-rollback/--enable-rollback",
-  default=None,
-  help="Disable the auto rollback and keep resources successfully created or updated",
+    "--disable-rollback/--enable-rollback",
+    default=None,
+    help="Disable the auto rollback and keep resources successfully created or updated",
 )
 @click.pass_context
 @catch_exceptions

--- a/sceptre/cli/create.py
+++ b/sceptre/cli/create.py
@@ -11,14 +11,13 @@ from sceptre.cli.helpers import stack_status_exit_code
 @click.argument("change-set-name", required=False)
 @click.option("-y", "--yes", is_flag=True, help="Assume yes to all questions.")
 @click.option(
-    "-dr",
-    "--disable-rollback",
-    is_flag=True,
-    help="Disable the auto rollback and keep resources successfully created or updated",
+  "--disable-rollback/--enable-rollback",
+  default=None,
+  help="Disable the auto rollback and keep resources successfully created or updated",
 )
 @click.pass_context
 @catch_exceptions
-def create_command(ctx, path, change_set_name, yes, disable_rollback: bool):
+def create_command(ctx, path, change_set_name, yes, disable_rollback: Optional[bool]):
     """
     Creates a stack for a given config PATH. Or if CHANGE_SET_NAME is specified
     creates a change set for stack in PATH.

--- a/sceptre/cli/delete.py
+++ b/sceptre/cli/delete.py
@@ -30,6 +30,7 @@ def delete_command(ctx, path, change_set_name, yes):
     """
     context = SceptreContext(
         command_path=path,
+        command_params=ctx.params,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),

--- a/sceptre/cli/describe.py
+++ b/sceptre/cli/describe.py
@@ -34,6 +34,7 @@ def describe_change_set(ctx, path, change_set_name, verbose):
     """
     context = SceptreContext(
         command_path=path,
+        command_params=ctx.params,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
@@ -66,6 +67,7 @@ def describe_policy(ctx, path):
     """
     context = SceptreContext(
         command_path=path,
+        command_params=ctx.params,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),

--- a/sceptre/cli/diff.py
+++ b/sceptre/cli/diff.py
@@ -111,6 +111,7 @@ def diff_command(
 
     context = SceptreContext(
         command_path=path,
+        command_params=ctx.params,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),

--- a/sceptre/cli/drift.py
+++ b/sceptre/cli/drift.py
@@ -37,6 +37,7 @@ def drift_detect(ctx: Context, path: str):
     """
     context = SceptreContext(
         command_path=path,
+        command_params=ctx.params,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
@@ -84,6 +85,7 @@ def drift_show(ctx, path, drifted):
     """
     context = SceptreContext(
         command_path=path,
+        command_params=ctx.params,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),

--- a/sceptre/cli/dump.py
+++ b/sceptre/cli/dump.py
@@ -29,6 +29,7 @@ def dump_config(ctx, path):
     """
     context = SceptreContext(
         command_path=path,
+        command_params=ctx.params,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         output_format=ctx.obj.get("output_format"),

--- a/sceptre/cli/execute.py
+++ b/sceptre/cli/execute.py
@@ -1,5 +1,6 @@
 import click
 
+from typing import Optional
 from sceptre.context import SceptreContext
 from sceptre.cli.helpers import catch_exceptions, confirmation
 from sceptre.plan.plan import SceptrePlan
@@ -9,9 +10,14 @@ from sceptre.plan.plan import SceptrePlan
 @click.argument("path")
 @click.argument("change-set-name")
 @click.option("-y", "--yes", is_flag=True, help="Assume yes to all questions.")
+@click.option(
+    "--disable-rollback/--enable-rollback",
+    default=None,
+    help="Disable or enable the cloudformation automatic rollback",
+)
 @click.pass_context
 @catch_exceptions
-def execute_command(ctx, path, change_set_name, yes):
+def execute_command(ctx, path, change_set_name, yes, disable_rollback: Optional[bool]):
     """
     Executes a Change Set.
     \f

--- a/sceptre/cli/execute.py
+++ b/sceptre/cli/execute.py
@@ -25,6 +25,7 @@ def execute_command(ctx, path, change_set_name, yes):
     """
     context = SceptreContext(
         command_path=path,
+        command_params=ctx.params,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),

--- a/sceptre/cli/launch.py
+++ b/sceptre/cli/launch.py
@@ -24,9 +24,17 @@ logger = logging.getLogger(__name__)
     is_flag=True,
     help="If set, will delete all stacks in the command path marked as obsolete.",
 )
+@click.option(
+    "-dr",
+    "--disable-rollback",
+    is_flag=True,
+    help="Disable the auto rollback and keep resources successfully created or updated",
+)
 @click.pass_context
 @catch_exceptions
-def launch_command(ctx: Context, path: str, yes: bool, prune: bool):
+def launch_command(
+    ctx: Context, path: str, yes: bool, prune: bool, disable_rollback: bool
+):
     """
     Launch a Stack or StackGroup for a given config PATH. This command is intended as a catch-all
     command that will apply any changes from Stack Configs indicated via the path.
@@ -36,11 +44,13 @@ def launch_command(ctx: Context, path: str, yes: bool, prune: bool):
     * Any stacks that already exist will be updated (if there are any changes)
     * If any stacks are marked with "ignore: True", those stacks will neither be created nor updated
     * If any stacks are marked with "obsolete: True", those stacks will neither be created nor updated.
-      Furthermore, if the "-p"/"--prune" flag is used, these stacks will be deleted prior to any
+    * If the "-p"/"--prune" flag is used, these stacks will be deleted prior to any
       other launch commands
+    * If the "-dr"/"--disable-rollback" flag is used, automatic cloudformation rollback will be disabled
     """
     context = SceptreContext(
         command_path=path,
+        command_params=ctx.params,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),

--- a/sceptre/cli/launch.py
+++ b/sceptre/cli/launch.py
@@ -25,15 +25,14 @@ logger = logging.getLogger(__name__)
     help="If set, will delete all stacks in the command path marked as obsolete.",
 )
 @click.option(
-    "-dr",
-    "--disable-rollback",
-    is_flag=True,
-    help="Disable the auto rollback and keep resources successfully created or updated",
+  "--disable-rollback/--enable-rollback",
+  default=None,
+  help="Disable the auto rollback and keep resources successfully created or updated",
 )
 @click.pass_context
 @catch_exceptions
 def launch_command(
-    ctx: Context, path: str, yes: bool, prune: bool, disable_rollback: bool
+    ctx: Context, path: str, yes: bool, prune: bool, disable_rollback: Optional[bool]
 ):
     """
     Launch a Stack or StackGroup for a given config PATH. This command is intended as a catch-all

--- a/sceptre/cli/launch.py
+++ b/sceptre/cli/launch.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import List, Optional
 
 import click
 from click import Context
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 )
 @click.option(
   "--disable-rollback/--enable-rollback",
-  default=None,
+  default=False,
   help="Disable the auto rollback and keep resources successfully created or updated",
 )
 @click.pass_context
@@ -43,9 +43,8 @@ def launch_command(
     * Any stacks that already exist will be updated (if there are any changes)
     * If any stacks are marked with "ignore: True", those stacks will neither be created nor updated
     * If any stacks are marked with "obsolete: True", those stacks will neither be created nor updated.
-    * If the "-p"/"--prune" flag is used, these stacks will be deleted prior to any
+    * Furthermore, if the "-p"/"--prune" flag is used, these stacks will be deleted prior to any
       other launch commands
-    * If the "-dr"/"--disable-rollback" flag is used, automatic cloudformation rollback will be disabled
     """
     context = SceptreContext(
         command_path=path,

--- a/sceptre/cli/launch.py
+++ b/sceptre/cli/launch.py
@@ -25,9 +25,9 @@ logger = logging.getLogger(__name__)
     help="If set, will delete all stacks in the command path marked as obsolete.",
 )
 @click.option(
-  "--disable-rollback/--enable-rollback",
-  default=False,
-  help="Disable the auto rollback and keep resources successfully created or updated",
+    "--disable-rollback/--enable-rollback",
+    default=False,
+    help="Disable the auto rollback and keep resources successfully created or updated",
 )
 @click.pass_context
 @catch_exceptions

--- a/sceptre/cli/launch.py
+++ b/sceptre/cli/launch.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--disable-rollback/--enable-rollback",
     default=False,
-    help="Disable the auto rollback and keep resources successfully created or updated",
+    help="Disable or enable the cloudformation automatic rollback",
 )
 @click.pass_context
 @catch_exceptions

--- a/sceptre/cli/list.py
+++ b/sceptre/cli/list.py
@@ -30,6 +30,7 @@ def list_resources(ctx, path):
     """
     context = SceptreContext(
         command_path=path,
+        command_params=ctx.params,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
@@ -67,6 +68,7 @@ def list_outputs(ctx, path, export):
     """
     context = SceptreContext(
         command_path=path,
+        command_params=ctx.params,
         project_path=ctx.obj.get("project_path", None),
         user_variables=ctx.obj.get("user_variables", {}),
         options=ctx.obj.get("options", {}),
@@ -108,6 +110,7 @@ def list_change_sets(ctx, path, url):
     """
     context = SceptreContext(
         command_path=path,
+        command_params=ctx.params,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         output_format=ctx.obj.get("output_format"),
@@ -138,6 +141,7 @@ def list_stacks(ctx, path):
     """
     context = SceptreContext(
         command_path=path,
+        command_params=ctx.params,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         output_format=ctx.obj.get("output_format"),

--- a/sceptre/cli/policy.py
+++ b/sceptre/cli/policy.py
@@ -30,6 +30,7 @@ def set_policy_command(ctx, path, policy_file, built_in):
     """
     context = SceptreContext(
         command_path=path,
+        command_params=ctx.params,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),

--- a/sceptre/cli/prune.py
+++ b/sceptre/cli/prune.py
@@ -23,6 +23,7 @@ def prune_command(ctx, yes: bool, path):
     """
     context = SceptreContext(
         command_path=path,
+        command_params=ctx.params,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),

--- a/sceptre/cli/status.py
+++ b/sceptre/cli/status.py
@@ -20,6 +20,7 @@ def status_command(ctx, path):
     """
     context = SceptreContext(
         command_path=path,
+        command_params=ctx.params,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),

--- a/sceptre/cli/template.py
+++ b/sceptre/cli/template.py
@@ -32,6 +32,7 @@ def validate_command(ctx, no_placeholders, path):
     """
     context = SceptreContext(
         command_path=path,
+        command_params=ctx.params,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
@@ -74,6 +75,7 @@ def generate_command(ctx, no_placeholders, path):
     """
     context = SceptreContext(
         command_path=path,
+        command_params=ctx.params,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
@@ -109,6 +111,7 @@ def estimate_cost_command(ctx, path):
     """
     context = SceptreContext(
         command_path=path,
+        command_params=ctx.params,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),
@@ -142,6 +145,7 @@ def fetch_remote_template_command(ctx, path):
     """
     context = SceptreContext(
         command_path=path,
+        command_params=ctx.params,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),

--- a/sceptre/cli/update.py
+++ b/sceptre/cli/update.py
@@ -18,14 +18,13 @@ from sceptre.plan.plan import SceptrePlan
 @click.option("-v", "--verbose", is_flag=True, help="Display verbose output.")
 @click.option("-y", "--yes", is_flag=True, help="Assume yes to all questions.")
 @click.option(
-    "-dr",
-    "--disable-rollback",
-    is_flag=True,
-    help="Disable the auto rollback and keep resources successfully created or updated",
+  "--disable-rollback/--enable-rollback",
+  default=None,
+  help="Disable the auto rollback and keep resources successfully created or updated",
 )
 @click.pass_context
 @catch_exceptions
-def update_command(ctx, path, change_set, verbose, yes, disable_rollback: bool):
+def update_command(ctx, path, change_set, verbose, yes, disable_rollback: Optional[bool]):
     """
     Updates a stack for a given config PATH. Or perform an update via
     change-set when the change-set flag is set.

--- a/sceptre/cli/update.py
+++ b/sceptre/cli/update.py
@@ -17,9 +17,15 @@ from sceptre.plan.plan import SceptrePlan
 )
 @click.option("-v", "--verbose", is_flag=True, help="Display verbose output.")
 @click.option("-y", "--yes", is_flag=True, help="Assume yes to all questions.")
+@click.option(
+    "-dr",
+    "--disable-rollback",
+    is_flag=True,
+    help="Disable the auto rollback and keep resources successfully created or updated",
+)
 @click.pass_context
 @catch_exceptions
-def update_command(ctx, path, change_set, verbose, yes):
+def update_command(ctx, path, change_set, verbose, yes, disable_rollback: bool):
     """
     Updates a stack for a given config PATH. Or perform an update via
     change-set when the change-set flag is set.
@@ -37,6 +43,7 @@ def update_command(ctx, path, change_set, verbose, yes):
 
     context = SceptreContext(
         command_path=path,
+        command_params=ctx.params,
         project_path=ctx.obj.get("project_path"),
         user_variables=ctx.obj.get("user_variables"),
         options=ctx.obj.get("options"),

--- a/sceptre/cli/update.py
+++ b/sceptre/cli/update.py
@@ -2,6 +2,7 @@ from uuid import uuid1
 
 import click
 
+from typing import Optional
 from sceptre.context import SceptreContext
 from sceptre.cli.helpers import catch_exceptions, confirmation
 from sceptre.cli.helpers import write, stack_status_exit_code

--- a/sceptre/cli/update.py
+++ b/sceptre/cli/update.py
@@ -21,7 +21,7 @@ from sceptre.plan.plan import SceptrePlan
 @click.option(
     "--disable-rollback/--enable-rollback",
     default=None,
-    help="Disable the auto rollback and keep resources successfully created or updated",
+    help="Disable or enable the cloudformation automatic rollback",
 )
 @click.pass_context
 @catch_exceptions

--- a/sceptre/cli/update.py
+++ b/sceptre/cli/update.py
@@ -19,13 +19,15 @@ from sceptre.plan.plan import SceptrePlan
 @click.option("-v", "--verbose", is_flag=True, help="Display verbose output.")
 @click.option("-y", "--yes", is_flag=True, help="Assume yes to all questions.")
 @click.option(
-  "--disable-rollback/--enable-rollback",
-  default=None,
-  help="Disable the auto rollback and keep resources successfully created or updated",
+    "--disable-rollback/--enable-rollback",
+    default=None,
+    help="Disable the auto rollback and keep resources successfully created or updated",
 )
 @click.pass_context
 @catch_exceptions
-def update_command(ctx, path, change_set, verbose, yes, disable_rollback: Optional[bool]):
+def update_command(
+    ctx, path, change_set, verbose, yes, disable_rollback: Optional[bool]
+):
     """
     Updates a stack for a given config PATH. Or perform an update via
     change-set when the change-set flag is set.

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -552,11 +552,10 @@ class ConfigReader(object):
                 )
 
         s3_details = self._collect_s3_details(stack_name, config)
-        disable_rollback = (
-            True
-            if self.context.command_params.get("disable_rollback")
-            else config.get("disable_rollback", False)
-        )
+        # If disable/enable rollback was specified on the command line, use that. Otherwise,
+        # fall back to the stack config.
+        disable_rollback = self.context.command_params.get("disable_rollback")
+        disable_rollback = config.get("disable_rollback", False) if disable_rollback is None else disable_rollback
 
         stack = Stack(
             name=stack_name,

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -552,6 +552,11 @@ class ConfigReader(object):
                 )
 
         s3_details = self._collect_s3_details(stack_name, config)
+        disable_rollback = (
+            True
+            if self.context.command_params.get("disable_rollback")
+            else config.get("disable_rollback", False)
+        )
 
         stack = Stack(
             name=stack_name,
@@ -576,6 +581,7 @@ class ConfigReader(object):
             external_name=config.get("stack_name"),
             notifications=config.get("notifications"),
             on_failure=config.get("on_failure"),
+            disable_rollback=disable_rollback,
             stack_timeout=config.get("stack_timeout", 0),
             ignore=config.get("ignore", False),
             obsolete=config.get("obsolete", False),

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -555,7 +555,8 @@ class ConfigReader(object):
         # If disable/enable rollback was specified on the command line, use that. Otherwise,
         # fall back to the stack config.
         disable_rollback = self.context.command_params.get("disable_rollback")
-        disable_rollback = config.get("disable_rollback", False) if disable_rollback is None else disable_rollback
+        if disable_rollback is None:
+            disable_rollback = config.get("disable_rollback", False)
 
         stack = Stack(
             name=stack_name,

--- a/sceptre/context.py
+++ b/sceptre/context.py
@@ -73,7 +73,7 @@ class SceptreContext(object):
         self.normal_command_path = normalise_path(command_path)
 
         # the sceptre command parameters (e.g. sceptre launch <command params>)
-        self.command_params = command_params if command_params else {}
+        self.command_params = command_params or {}
 
         # config_file: stack group config. User definable later in v2
         # e.g. {project_path/config/command_path}/config_file

--- a/sceptre/context.py
+++ b/sceptre/context.py
@@ -50,6 +50,7 @@ class SceptreContext(object):
         self,
         project_path,
         command_path,
+        command_params=None,
         user_variables=None,
         options=None,
         output_format=None,
@@ -70,6 +71,9 @@ class SceptreContext(object):
         self.command_path = normalise_path(command_path)
 
         self.normal_command_path = normalise_path(command_path)
+
+        # the sceptre command parameters (e.g. sceptre launch <command params>)
+        self.command_params = command_params if command_params else {}
 
         # config_file: stack group config. User definable later in v2
         # e.g. {project_path/config/command_path}/config_file

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -82,8 +82,12 @@ class StackActions(object):
             ],
         }
 
-        if self.stack.on_failure:
+        # can specify either DisableRollback or OnFailure , but not both
+        if self.stack.disable_rollback:
+            create_stack_kwargs.update({"DisableRollback": self.stack.disable_rollback})
+        elif self.stack.on_failure:
             create_stack_kwargs.update({"OnFailure": self.stack.on_failure})
+
         create_stack_kwargs.update(self.stack.template.get_boto_call_parameter())
         create_stack_kwargs.update(self._get_role_arn())
         create_stack_kwargs.update(self._get_stack_timeout())

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -80,6 +80,8 @@ class Stack(object):
     :param on_failure: This parameter describes the action taken by\
             CloudFormation when a Stack fails to create.
 
+    :param disable_rollback: If True, cloudformation will not rollback on deployment failures
+
     :param iam_role: The ARN of a role for Sceptre to assume before interacting\
             with the environment. If not supplied, Sceptre uses the user's AWS CLI\
             credentials.
@@ -154,6 +156,7 @@ class Stack(object):
         external_name: str = None,
         notifications: List[str] = None,
         on_failure: str = None,
+        disable_rollback=False,
         profile: str = None,
         stack_timeout: int = 0,
         iam_role_session_duration: int = 0,
@@ -184,6 +187,9 @@ class Stack(object):
         self.dependencies = dependencies or []
         self.protected = protected
         self.on_failure = on_failure
+        self.disable_rollback = self._ensure_boolean(
+            "disable_rollback", disable_rollback
+        )
         self.stack_group_config = stack_group_config or {}
         self.stack_timeout = stack_timeout
         self.profile = profile
@@ -242,6 +248,7 @@ class Stack(object):
             f"external_name={self.external_name}, "
             f"notifications={self.notifications}, "
             f"on_failure={self.on_failure}, "
+            f"disable_rollback={self.disable_rollback}, "
             f"stack_timeout={self.stack_timeout}, "
             f"stack_group_config={self.stack_group_config}, "
             f"ignore={self.ignore}, "
@@ -269,6 +276,7 @@ class Stack(object):
             and self.dependencies == stack.dependencies
             and self.protected == stack.protected
             and self.on_failure == stack.on_failure
+            and self.disable_rollback == stack.disable_rollback
             and self.stack_timeout == stack.stack_timeout
             and self.ignore == stack.ignore
             and self.obsolete == stack.obsolete

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -411,7 +411,7 @@ class TestConfigReader(object):
         self.context.command_params["disable_rollback"] = True
         config_reader = ConfigReader(self.context)
         all_stacks, command_stacks = config_reader.construct_stacks()
-        assert "disable_rollback=True" in str(all_stacks)
+        assert list(all_stacks)[0].disable_rollback
 
     def test_construct_stacks_with_disable_rollback_in_stack_config(self):
         project_path, config_dir = self.create_project()
@@ -429,7 +429,7 @@ class TestConfigReader(object):
         self.context.project_path = project_path
         config_reader = ConfigReader(self.context)
         all_stacks, command_stacks = config_reader.construct_stacks()
-        assert "disable_rollback=True" in str(all_stacks)
+        assert list(all_stacks)[0].disable_rollback
 
     @pytest.mark.parametrize(
         "filepaths, del_key",

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -26,7 +26,14 @@ class TestConfigReader(object):
         self.runner = CliRunner()
         self.test_project_path = os.path.join(os.getcwd(), "tests", "fixtures")
         self.context = SceptreContext(
-            project_path=self.test_project_path, command_path="A"
+            project_path=self.test_project_path,
+            command_path="A",
+            command_params={
+                "yes": True,
+                "path": "A.yaml",
+                "prune": False,
+                "disable_rollback": False,
+            },
         )
 
     def test_config_reader_correctly_initialised(self):
@@ -293,6 +300,7 @@ class TestConfigReader(object):
             external_name=None,
             notifications=None,
             on_failure=None,
+            disable_rollback=False,
             stack_timeout=0,
             required_version=">1.0",
             template_bucket_name="stack_group_template_bucket_name",

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -32,7 +32,7 @@ class TestConfigReader(object):
                 "yes": True,
                 "path": "A.yaml",
                 "prune": False,
-                "disable_rollback": False,
+                "disable_rollback": None,
             },
         )
 
@@ -394,6 +394,42 @@ class TestConfigReader(object):
         all_stacks, command_stacks = config_reader.construct_stacks()
         assert {str(stack) for stack in all_stacks} == expected_stacks
         assert {str(stack) for stack in command_stacks} == expected_command_stacks
+
+    def test_construct_stacks_with_disable_rollback_command_param(self):
+        project_path, config_dir = self.create_project()
+
+        rel_path = "A/1.yaml"
+        config = {
+            "region": "region",
+            "project_code": "project_code",
+            "template_path": rel_path,
+        }
+
+        abs_path = os.path.join(config_dir, rel_path)
+        self.write_config(abs_path, config)
+        self.context.project_path = project_path
+        self.context.command_params["disable_rollback"] = True
+        config_reader = ConfigReader(self.context)
+        all_stacks, command_stacks = config_reader.construct_stacks()
+        assert "disable_rollback=True" in str(all_stacks)
+
+    def test_construct_stacks_with_disable_rollback_in_stack_config(self):
+        project_path, config_dir = self.create_project()
+
+        rel_path = "A/1.yaml"
+        config = {
+            "region": "region",
+            "project_code": "project_code",
+            "template_path": rel_path,
+            "disable_rollback": True,
+        }
+
+        abs_path = os.path.join(config_dir, rel_path)
+        self.write_config(abs_path, config)
+        self.context.project_path = project_path
+        config_reader = ConfigReader(self.context)
+        all_stacks, command_stacks = config_reader.construct_stacks()
+        assert "disable_rollback=True" in str(all_stacks)
 
     @pytest.mark.parametrize(
         "filepaths, del_key",

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -13,6 +13,7 @@ class TestSceptreContext(object):
         self.context = SceptreContext(
             project_path="project_path/to/sceptre",
             command_path="command-path",
+            command_params=sentinel.command_params,
             user_variables=sentinel.user_variables,
             options=sentinel.options,
             output_format=sentinel.output_format,
@@ -27,6 +28,7 @@ class TestSceptreContext(object):
         context = SceptreContext(
             project_path="project_path",
             command_path="command-path",
+            command_params=sentinel.command_params,
             user_variables=sentinel.user_variables,
             options=sentinel.options,
             output_format=sentinel.output_format,
@@ -41,6 +43,7 @@ class TestSceptreContext(object):
         context = SceptreContext(
             project_path="project_path",
             command_path="command",
+            command_params=sentinel.command_params,
             user_variables=sentinel.user_variables,
             options=sentinel.options,
             output_format=sentinel.output_format,
@@ -55,6 +58,7 @@ class TestSceptreContext(object):
         context = SceptreContext(
             project_path="project_path",
             command_path="command",
+            command_params=sentinel.command_params,
             user_variables=sentinel.user_variables,
             options=sentinel.options,
             output_format=sentinel.output_format,
@@ -68,6 +72,7 @@ class TestSceptreContext(object):
         context = SceptreContext(
             project_path="project_path",
             command_path="command",
+            command_params={"params": "variables"},
             user_variables={"user": "variables"},
             options={"hello": "there"},
             output_format=sentinel.output_format,

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -31,6 +31,7 @@ def stack_factory(**kwargs):
         "external_name": sentinel.external_name,
         "notifications": [sentinel.notification],
         "on_failure": sentinel.on_failure,
+        "disable_rollback": False,
         "stack_timeout": sentinel.stack_timeout,
         "stack_group_config": {},
     }
@@ -60,6 +61,7 @@ class TestStack(object):
             external_name=sentinel.external_name,
             notifications=[sentinel.notification],
             on_failure=sentinel.on_failure,
+            disable_rollback=False,
             iam_role=sentinel.iam_role,
             iam_role_session_duration=sentinel.iam_role_session_duration,
             stack_timeout=sentinel.stack_timeout,
@@ -98,6 +100,7 @@ class TestStack(object):
         assert stack.tags == {}
         assert stack.notifications == []
         assert stack.on_failure is None
+        assert stack.disable_rollback is False
         assert stack.stack_group_config == {}
 
     def test_initialize_stack_with_template_handler(self):
@@ -131,6 +134,7 @@ class TestStack(object):
         assert stack.tags == {}
         assert stack.notifications == []
         assert stack.on_failure is None
+        assert stack.disable_rollback is False
         assert stack.stack_group_config == {}
 
     def test_raises_exception_if_path_and_handler_configured(self):
@@ -196,6 +200,7 @@ class TestStack(object):
             "external_name=sentinel.external_name, "
             "notifications=[sentinel.notification], "
             "on_failure=sentinel.on_failure, "
+            "disable_rollback=False, "
             "stack_timeout=sentinel.stack_timeout, "
             "stack_group_config={}, "
             "ignore=False, "


### PR DESCRIPTION
Allow user to disable a cloudformation rollback on a Sceptre deployment.
