### PR TITLE
Update sceptre-circleci docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
 aliases:
   - &docs-job
     docker:
-      - image: sceptreorg/sceptre-circleci:1.1.0
+      - image: sceptreorg/sceptre-circleci:2.0.0
         environment:
           REPOSITORY_PATH: '/home/circleci/docs'
           DEPLOYMENT_GIT_SSH: 'git@github.com:Sceptre/sceptre.github.io.git'
@@ -35,7 +35,7 @@ aliases:
 jobs:
   build:
     docker:
-      - image: sceptreorg/sceptre-circleci:1.1.0
+      - image: sceptreorg/sceptre-circleci:2.0.0
     steps:
       - checkout
       - run:
@@ -72,7 +72,7 @@ jobs:
 
   lint-and-unit-tests:
     docker:
-      - image: sceptreorg/sceptre-circleci:1.1.0
+      - image: sceptreorg/sceptre-circleci:2.0.0
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -107,7 +107,7 @@ jobs:
   integration-tests:
     parallelism: 2
     docker:
-      - image: sceptreorg/sceptre-circleci:1.1.0
+      - image: sceptreorg/sceptre-circleci:2.0.0
         environment:
           AWS_DEFAULT_REGION: eu-west-1
     steps:
@@ -158,7 +158,7 @@ jobs:
 
   deploy-pypi:
     docker:
-      - image: sceptreorg/sceptre-circleci:1.1.0
+      - image: sceptreorg/sceptre-circleci:2.0.0
     steps:
       - attach_workspace:
           at: /home/circleci


### PR DESCRIPTION
Update to build and test with a docker image that's based on the official circleci python docker image.

depends on https://github.com/Sceptre/sceptre-circleci/pull/18

