### PR TITLE
Making the ConnectionManager a more "friendly" interface for hooks, resolvers, and template handlers

### DIFF
--- a/docs/_source/docs/faq.rst
+++ b/docs/_source/docs/faq.rst
@@ -139,16 +139,6 @@ to perform any AWS actions you need:
        ).stdout
 
 
-How do I build a Serverless application using Sceptre and SAM?
---------------------------------------------------------------
-
-There is now a SAM Template Handler that lets you incorporate SAM applications into environments that
-are managed and deployed using Sceptre. For more information on how to install and use SAM in your
-Sceptre project, see the `sceptre-sam-handler`_ page on PyPI.
-
-
-.. _sceptre-sam-handler: https://pypi.org/project/sceptre-sam-handler/
-
 My CI/CD process uses ``sceptre launch``. How do I delete stacks that aren't needed anymore?
 ---------------------------------------------------------------------------------------------
 

--- a/docs/_source/docs/faq.rst
+++ b/docs/_source/docs/faq.rst
@@ -83,6 +83,32 @@ used.
 
 .. _AWS documentation: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html
 
+.. _using_connection_manager:
+
+How do I call AWS services in my custom hook/resolver/template handler?
+-----------------------------------------------------------------------
+In order to call AWS services in your custom resolver properly, you should use the configurations of
+on the stack where the resolver is being used (unless you need to use a different configuration).
+
+There is a simple interface available for doing this, the
+:py:class:`sceptre.connection_manager.ConnectionManager`. The ConnectionManager is an interface that
+will be pre-configured with the stack's profile, region, and iam_role and will be ready for you to use.
+It is accessible on hooks and resolvers via ``self.stack.connection_manager`` and on
+template_handlers via ``self.connection_manager``.
+
+There are three public methods on the :
+
+- :py:meth:`sceptre.connection_manager.ConnectionManager.call` can be used to directly call a boto3
+  API method on any api service and return the result from boto3. This is perfect when you just need
+  to invoke a boto3 client method without any additional capabilities.
+- :py:meth:`sceptre.connection_manager.ConnectionManager.get_session` can be used to get a boto3 Session
+  object. This is very useful if you need to work with Boto3 Resource objects (like an s3 Bucket) or
+  if you need to create and pass the bot3 session, client, or resource to a third-party framework.
+- :py:meth:`sceptre.connection_manager.ConnectionManager.create_session_environment_variables` creates
+  a dictionary of environment variables used by AWS sdks with all the relevant connection information.
+  This is extremely useful if you are needing to invoke other SDKs using ``subprocess`` and still need
+  the Stack's connection information honored.
+
 How do I build a Serverless application using Sceptre and SAM?
 --------------------------------------------------------------
 

--- a/docs/_source/docs/hooks.rst
+++ b/docs/_source/docs/hooks.rst
@@ -231,3 +231,9 @@ Assume a Sceptre `copy` hook that calls the `cp command`_:
 .. _documentation: http://docs.aws.amazon.com/autoscaling/latest/userguide/as-suspend-resume-processes.html
 .. _this is great place to start: https://docs.python.org/3/distributing/
 .. _cp command: http://man7.org/linux/man-pages/man1/cp.1.html
+
+Calling AWS services in your custom hook
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For details on calling AWS services or invoking AWS-related third party tools in your hooks, see
+:ref:`using_connection_manager`.

--- a/docs/_source/docs/hooks.rst
+++ b/docs/_source/docs/hooks.rst
@@ -236,4 +236,4 @@ Calling AWS services in your custom hook
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For details on calling AWS services or invoking AWS-related third party tools in your hooks, see
-:ref:`using_connection_manager`.
+:ref:`using_connection_manager`

--- a/docs/_source/docs/resolvers.rst
+++ b/docs/_source/docs/resolvers.rst
@@ -301,7 +301,7 @@ Calling AWS services in your custom resolver
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For details on calling AWS services or invoking AWS-related third party tools in your resolver, see
-:ref:`using_connection_manager`.
+:ref:`using_connection_manager`
 
 
 Resolver arguments

--- a/docs/_source/docs/resolvers.rst
+++ b/docs/_source/docs/resolvers.rst
@@ -297,6 +297,11 @@ This resolver can be used in a Stack config file with the following syntax:
    parameters:
      param1: !<custom_resolver_command_name> <value> <optional-aws-profile>
 
+Calling AWS services in your custom resolver
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For details on calling AWS services in your resolver, see :ref:`using_connection_manager`
+
 
 Resolver arguments
 ^^^^^^^^^^^^^^^^^^

--- a/docs/_source/docs/resolvers.rst
+++ b/docs/_source/docs/resolvers.rst
@@ -300,7 +300,8 @@ This resolver can be used in a Stack config file with the following syntax:
 Calling AWS services in your custom resolver
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For details on calling AWS services in your resolver, see :ref:`using_connection_manager`
+For details on calling AWS services or invoking AWS-related third party tools in your resolver, see
+:ref:`using_connection_manager`.
 
 
 Resolver arguments

--- a/docs/_source/docs/template_handlers.rst
+++ b/docs/_source/docs/template_handlers.rst
@@ -220,3 +220,9 @@ This template handler can be used in a Stack config file with the following synt
 .. _Custom Template Handlers: #custom-template-handlers
 .. _Boto3: https://aws.amazon.com/sdk-for-python/
 .. _http_template_handler key: stack_group_config.html#http-template-handler
+
+Calling AWS services in your custom template_handler
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For details on calling AWS services or invoking AWS-related third party tools in your
+template handler, see :ref:`using_connection_manager`.

--- a/docs/_source/docs/template_handlers.rst
+++ b/docs/_source/docs/template_handlers.rst
@@ -225,4 +225,4 @@ Calling AWS services in your custom template_handler
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For details on calling AWS services or invoking AWS-related third party tools in your
-template handler, see :ref:`using_connection_manager`.
+template handler, see :ref:`using_connection_manager`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,3 @@ show_missing = true
 # https://github.com/pytest-dev/pytest-cov/issues/131
 # https://stackoverflow.com/questions/34870962/how-to-debug-py-test-in-pycharm-when-coverage-is-enabled
 addopts = "-s --cov --cov-report term --cov-report term-missing --cov-report xml"
-
-[tool.black]
-line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,6 @@ show_missing = true
 # https://github.com/pytest-dev/pytest-cov/issues/131
 # https://stackoverflow.com/questions/34870962/how-to-debug-py-test-in-pycharm-when-coverage-is-enabled
 addopts = "-s --cov --cov-report term --cov-report term-missing --cov-report xml"
+
+[tool.black]
+line-length = 120

--- a/sceptre/connection_manager.py
+++ b/sceptre/connection_manager.py
@@ -173,6 +173,12 @@ class ConnectionManager(object):
         subprocess in a hook, resolver, or template handler and allow that subprocess to work with
         the currently configured session.
 
+        The environment variables returned by this method should be everything needed for
+        subprocesses to properly interact with AWS using the ConnectionManager's configurations for
+        profile, iam_role, and region. By default, they include the other process environment
+        variables, such as PATH and any others. If you do not want the other environment variables,
+        you can toggle these off via include_system_envs=False.
+
         | Notes on including system envs:
         |   * The AWS_DEFAULT_REGION, AWS_REGION, AWS_ACCESS_KEY_ID, and AWS_SECRET_ACCESS_KEY
         |     environment variables (if they are set in the Sceptre process) will be overwritten in

--- a/sceptre/connection_manager.py
+++ b/sceptre/connection_manager.py
@@ -64,7 +64,9 @@ def _retry_boto_call(func):
                     attempts += 1
                 else:
                     raise
-        raise RetryLimitExceededError("Exceeded request limit {0} times. Aborting.".format(max_retries))
+        raise RetryLimitExceededError(
+            "Exceeded request limit {0} times. Aborting.".format(max_retries)
+        )
 
     return decorated
 
@@ -215,7 +217,9 @@ class ConnectionManager(object):
 
         return envs
 
-    def _get_session(self, profile: Optional[str], region: Optional[str], iam_role: Optional[str]) -> boto3.Session:
+    def _get_session(
+        self, profile: Optional[str], region: Optional[str], iam_role: Optional[str]
+    ) -> boto3.Session:
         with self._session_lock:
             self.logger.debug("Getting Boto3 session")
             key = (region, profile, iam_role)
@@ -252,7 +256,9 @@ class ConnectionManager(object):
                         "RoleSessionName": session_name,
                     }
                     if self.iam_role_session_duration:
-                        assume_role_kwargs["DurationSeconds"] = self.iam_role_session_duration
+                        assume_role_kwargs[
+                            "DurationSeconds"
+                        ] = self.iam_role_session_duration
                     sts_response = sts_client.assume_role(**assume_role_kwargs)
 
                     credentials = sts_response["Credentials"]
@@ -265,7 +271,9 @@ class ConnectionManager(object):
 
                     if session.get_credentials() is None:
                         raise InvalidAWSCredentialsError(
-                            "Session credentials were not found. Role: {0}. Region: {1}.".format(iam_role, region)
+                            "Session credentials were not found. Role: {0}. Region: {1}.".format(
+                                iam_role, region
+                            )
                         )
 
                     self._boto_sessions[key] = session
@@ -275,7 +283,9 @@ class ConnectionManager(object):
                     session.get_credentials().method,
                     {
                         "AccessKeyId": mask_key(session.get_credentials().access_key),
-                        "SecretAccessKey": mask_key(session.get_credentials().secret_key),
+                        "SecretAccessKey": mask_key(
+                            session.get_credentials().secret_key
+                        ),
                         "Region": session.region_name,
                     },
                 )
@@ -300,7 +310,9 @@ class ConnectionManager(object):
             key = (service, region, profile, stack_name, iam_role)
             if self._clients.get(key) is None:
                 self.logger.debug("No %s client found, creating one...", service)
-                self._clients[key] = self._get_session(profile, region, iam_role).client(service)
+                self._clients[key] = self._get_session(
+                    profile, region, iam_role
+                ).client(service)
 
             return self._clients[key]
 

--- a/sceptre/connection_manager.py
+++ b/sceptre/connection_manager.py
@@ -167,7 +167,7 @@ class ConnectionManager(object):
         profile: Optional[str] = STACK_DEFAULT,
         region: Optional[str] = STACK_DEFAULT,
         iam_role: Optional[str] = STACK_DEFAULT,
-        include_system_envs: bool = False,
+        include_system_envs: bool = True,
     ) -> Dict[str, str]:
         """Creates the standard AWS environment variables that would need to be passed to a
         subprocess in a hook, resolver, or template handler and allow that subprocess to work with
@@ -183,8 +183,8 @@ class ConnectionManager(object):
             configured iam_role (if there is one).
         :param include_system_envs: If True, will return a dict with all the system environment
             variables included. This is useful for creating a complete dict of environment variables
-            to pass to a subprocess. By default, this method will ONLY return the relevant AWS
-            environment variables.
+            to pass to a subprocess. If set to False, this method will ONLY return the relevant AWS
+            environment variables. Defaults to True.
 
         :returns: A dict of environment variables with the appropriate credentials available for use.
         """

--- a/sceptre/connection_manager.py
+++ b/sceptre/connection_manager.py
@@ -81,13 +81,10 @@ class ConnectionManager(object):
     the various AWS services that Sceptre needs to interact with.
 
     :param profile: The AWS credentials profile that should be used.
-    :type profile: str
     :param iam_role: The iam_role that should be assumed in the account.
-    :type iam_role: str
     :param stack_name: The CloudFormation stack name for this connection.
-    :type stack_name: str
     :param region: The region to use.
-    :type region: str
+    :param iam_role_session_duration: The duration to assume the specified iam_role per session.
     """
 
     _session_lock = threading.Lock()
@@ -98,11 +95,11 @@ class ConnectionManager(object):
 
     def __init__(
         self,
-        region,
-        profile=None,
-        stack_name=None,
-        iam_role=None,
-        iam_role_session_duration=None,
+        region: str,
+        profile: Optional[str] = None,
+        stack_name: Optional[str] = None,
+        iam_role: Optional[str] = None,
+        iam_role_session_duration: Optional[int] = None,
     ):
 
         self.logger = logging.getLogger(__name__)

--- a/sceptre/connection_manager.py
+++ b/sceptre/connection_manager.py
@@ -173,6 +173,14 @@ class ConnectionManager(object):
         subprocess in a hook, resolver, or template handler and allow that subprocess to work with
         the currently configured session.
 
+        | Notes on including system envs:
+        |   * The AWS_DEFAULT_REGION, AWS_REGION, AWS_ACCESS_KEY_ID, and AWS_SECRET_ACCESS_KEY
+        |     environment variables (if they are set in the Sceptre process) will be overwritten in
+        |     the returned dict with the correct values from the newly created Session.
+        |   * If the AWS_SESSION_TOKEN environment variable is currently set for the process, this
+        |     will be overwritten with the new session's token (if there is one) or removed from the
+        |     returned environment variables dict (if the new session doesn't have a token).
+
         :param profile: The name of the AWS Profile as configured in the local environment. Passing
             None will result in no profile being specified. Defaults to the ConnectionManager's
             configured profile (if there is one).

--- a/sceptre/hooks/cmd.py
+++ b/sceptre/hooks/cmd.py
@@ -18,8 +18,9 @@ class Cmd(Hook):
         :raises: sceptre.exceptions.InvalidTaskArgumentTypeException
         :raises: subprocess.CalledProcessError
         """
+        envs = self.stack.connection_manager.create_session_environment_variables()
         try:
-            subprocess.check_call(self.argument, shell=True)
+            subprocess.check_call(self.argument, shell=True, env=envs)
         except TypeError:
             raise InvalidHookArgumentTypeError(
                 'The argument "{0}" is the wrong type - cmd hooks require '

--- a/tests/test_connection_manager.py
+++ b/tests/test_connection_manager.py
@@ -31,6 +31,10 @@ class TestConnectionManager(object):
         self.session_class = create_autospec(Session)
         self.mock_session: Union[Mock, Session] = self.session_class.return_value
 
+        ConnectionManager._boto_sessions = {}
+        ConnectionManager._clients = {}
+        ConnectionManager._stack_keys = {}
+
         self.connection_manager = ConnectionManager(
             region=self.region,
             stack_name=self.stack_name,
@@ -39,10 +43,6 @@ class TestConnectionManager(object):
             session_class=self.session_class,
             get_envs_func=lambda: self.environment_variables,
         )
-
-        self.connection_manager._boto_sessions = {}
-        self.connection_manager._clients = {}
-        self.connection_manager._stack_keys = {}
 
     def test_connection_manager_initialised_with_no_optional_parameters(self):
         connection_manager = ConnectionManager(region=sentinel.region)

--- a/tests/test_hooks/test_cmd.py
+++ b/tests/test_hooks/test_cmd.py
@@ -1,16 +1,18 @@
 # -*- coding: utf-8 -*-
+import subprocess
+from unittest.mock import patch, Mock
 
 import pytest
-from unittest.mock import patch
-import subprocess
 
-from sceptre.hooks.cmd import Cmd
 from sceptre.exceptions import InvalidHookArgumentTypeError
+from sceptre.hooks.cmd import Cmd
+from sceptre.stack import Stack
 
 
 class TestCmd(object):
     def setup_method(self, test_method):
-        self.cmd = Cmd()
+        self.stack = Mock(Stack)
+        self.cmd = Cmd(stack=self.stack)
 
     def test_run_with_non_str_argument(self):
         self.cmd.argument = None
@@ -21,7 +23,10 @@ class TestCmd(object):
     def test_run_with_str_argument(self, mock_call):
         self.cmd.argument = "echo hello"
         self.cmd.run()
-        mock_call.assert_called_once_with("echo hello", shell=True)
+        expected_envs = (
+            self.stack.connection_manager.create_session_environment_variables.return_value
+        )
+        mock_call.assert_called_once_with("echo hello", shell=True, env=expected_envs)
 
     @patch("sceptre.hooks.cmd.subprocess.check_call")
     def test_run_with_erroring_command(self, mock_call):


### PR DESCRIPTION
## The problem

When developing custom hooks, resolvers, and template_handlers, it is often necessary to invoke AWS services. The _correct_ way to do this is via the stack's ConnectionManager so that they can work according to the project and stack configurations for AWS connections (particularly with regard to the profile, region, and iam_role).

I consider the ease of developing custom hooks, resolvers, and template_handlers one of Sceptre's great strengths that distinguishes it from other competing utilities. However, over my time developing these custom extensions, it has not often been straight-forward to invoke AWS services. I've noticed a few ugly bits that I have only been able to make work because of my fairly deep knowledge of the inner workings of Sceptre:

* There isn't really any documentation on the correct way to do this stuff. It's likely that a lot of the custom extensions to Sceptre out there do these things the wrong way. The _correct_ way to use boto3 (with regard to the Stack configs), for example, isn't really clear. **We need better docs.**
* If you only need to make a simple call to a boto3 service method, you can use `self.stack.connection_manager.call()` and that works pretty well. **It's still not documented, though.** 
* HOWEVER, if you need to use a [boto3 resource object,](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html) like an [S3 Bucket resource](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#bucket), the only way to do this is via a private, undocumented method `_get_session` on the ConnectionManager. And to use that private method, you have to know when and how to use, override, or ignore the default ConnectionManager configurations. **We need a public interface for getting a session.**
* If your hook/resolver/template handler needs to invoke a third-party tool via `subprocess`, the only way to get authentication to work correctly is to (1) get a session (see the second point above), then (2) use that to get credentials on that session, then (3) create environment variables that can be passed to Subprocess. The means of doing this correctly has taken me a lot of trial and error, isn't documented, and is rather gross. **We need an easy way to get authenticated credential environment variables for our Stack Configs to integrate with third party tools.**

A few examples of places I've had to do this recently, to demonstrate how "ugly" this process is can be found at:
* https://github.com/Sceptre/sceptre-sam-handler/blob/main/sam_handler/handler.py#L96~L133
* https://github.com/Sceptre/sceptre-cdk-handler/blob/main/sceptre_cdk_handler/cdk_builder.py#L118~L163

## How this PR fixes this:
1. I include real docs on how to call AWS services and integrate with third party tools.
2. I've created a _public_ `get_session()` method that has the "smarts" to normally be used for default purposes with customizability.
3. I've created a new method for creating the environment variables for the session for easy third party integration.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
