### PR TITLE
[Resolve #1293] Improve the Stack Config Jinja Syntax Error Message to include the Stack Name

### DIFF
--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -443,7 +443,7 @@ class ConfigReader(object):
             except Exception as err:
                 raise SceptreException(
                     f"{Path(directory_path, basename).as_posix()} - {err}"
-                )
+                ) from err
 
             self.templating_vars.update(stack_group_config)
             rendered_template = template.render(

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -26,6 +26,7 @@ from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 
 from sceptre import __version__
+from sceptre.exceptions import SceptreException
 from sceptre.exceptions import DependencyDoesNotExistError
 from sceptre.exceptions import InvalidConfigFileError
 from sceptre.exceptions import InvalidSceptreDirectoryError
@@ -436,7 +437,14 @@ class ConfigReader(object):
                 stack_group_config.get("j2_environment", {}),
             )
             j2_environment = Environment(**j2_environment_config)
-            template = j2_environment.get_template(basename)
+
+            try:
+                template = j2_environment.get_template(basename)
+            except Exception as err:
+                raise SceptreException(
+                    f"{Path(directory_path, basename).as_posix()} - {err}"
+                )
+
             self.templating_vars.update(stack_group_config)
             rendered_template = template.render(
                 self.templating_vars,


### PR DESCRIPTION
Improves the stack config Jinja syntax error message to include the stack name.

### Original Error Message

```
expected token 'end of print statement', got 'bar'
```

### New Error Message

```
dev/stack.yaml - expected token 'end of print statement', got 'bar'
```

- Resolves #1293

## PR Checklist

- [ ] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
