### PR TITLE
Releasing v4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Categories: Added, Removed, Changed, Fixed, Nonfunctional, Deprecated
 
 ## Unreleased
 
+## 4.0.1 (2023.02.12)
+
+### Changed
+ - Supporting `!rcmd` resolver up to v2
+
 ## 4.0.0 (2023.02.08)
 
 ### Added

--- a/sceptre/__init__.py
+++ b/sceptre/__init__.py
@@ -7,7 +7,7 @@ import warnings
 
 __author__ = "Cloudreach"
 __email__ = "sceptre@cloudreach.com"
-__version__ = "4.0.0"
+__version__ = "4.0.1"
 
 
 # Set up logging to ``/dev/null`` like a library is supposed to.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.0.0
+current_version = 4.0.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)|(?P<release_candidate>.*)
 commit = True
 tag = True


### PR DESCRIPTION
## 4.0.1 (2023.02.12)

### Changed
 - Supporting `!rcmd` resolver up to v2

