### PR TITLE
[Resolve #1304] Adding StackLoggerAdapter to hooks, resolvers, and template handlers

### DIFF
--- a/sceptre/logging.py
+++ b/sceptre/logging.py
@@ -1,0 +1,14 @@
+from logging import LoggerAdapter, Logger
+from typing import MutableMapping, Any, Tuple
+
+
+class StackLoggerAdapter(LoggerAdapter):
+    def __init__(self, logger: Logger, stack_name: str, extra: dict = None):
+        super().__init__(logger, extra or {})
+        self.stack_name = stack_name
+
+    def process(
+        self, msg: str, kwargs: MutableMapping[str, Any]
+    ) -> Tuple[Any, MutableMapping[str, Any]]:
+        msg = f"{self.stack_name} - {msg}"
+        return super().process(msg, kwargs)

--- a/sceptre/resolvers/__init__.py
+++ b/sceptre/resolvers/__init__.py
@@ -34,6 +34,9 @@ class Resolver(abc.ABC):
 
     def __init__(self, argument: Any = None, stack: "stack.Stack" = None):
         self.logger = logging.getLogger(__name__)
+        if stack is not None:
+            self.logger = StackLoggerAdapter(self.logger, stack.name)
+
         self.argument = argument
         self.stack = stack
 
@@ -62,7 +65,6 @@ class Resolver(abc.ABC):
         :param stack: The stack to set on the cloned resolver
         """
         clone = type(self)(self.argument, stack)
-        clone.logger = StackLoggerAdapter(clone.logger, stack.name)
         return clone
 
 

--- a/sceptre/resolvers/__init__.py
+++ b/sceptre/resolvers/__init__.py
@@ -6,6 +6,7 @@ from threading import RLock
 from typing import Any, TYPE_CHECKING, Type, Union, TypeVar
 
 from sceptre.helpers import _call_func_on_values
+from sceptre.logging import StackLoggerAdapter
 from sceptre.resolvers.placeholders import (
     create_placeholder_value,
     are_placeholders_enabled,
@@ -60,7 +61,9 @@ class Resolver(abc.ABC):
 
         :param stack: The stack to set on the cloned resolver
         """
-        return type(self)(self.argument, stack)
+        clone = type(self)(self.argument, stack)
+        clone.logger = StackLoggerAdapter(clone.logger, stack.name)
+        return clone
 
 
 class ResolvableProperty(abc.ABC):

--- a/sceptre/template.py
+++ b/sceptre/template.py
@@ -15,6 +15,7 @@ import sys
 import sceptre.helpers
 
 from sceptre.exceptions import TemplateHandlerNotFoundError
+from sceptre.logging import StackLoggerAdapter
 
 
 class Template(object):
@@ -54,8 +55,7 @@ class Template(object):
         connection_manager=None,
         s3_details=None,
     ):
-        self.logger = logging.getLogger(__name__)
-
+        self.logger = StackLoggerAdapter(logging.getLogger(__name__), name)
         self.name = name
         self.handler_config = handler_config
         if self.handler_config is not None and self.handler_config.get("type") is None:

--- a/tests/test_hooks/test_asg_scaling_processes.py
+++ b/tests/test_hooks/test_asg_scaling_processes.py
@@ -14,6 +14,7 @@ from sceptre.stack import Stack
 class TestASGScalingProcesses(object):
     def setup_method(self, test_method):
         self.stack = MagicMock(spec=Stack)
+        self.stack.name = "my/stack.yaml"
         self.stack.connection_manager = MagicMock(spec=ConnectionManager)
         self.stack.external_name = "external_name"
         self.asg_scaling_processes = ASGScalingProcesses(None, self.stack)

--- a/tests/test_hooks/test_cmd.py
+++ b/tests/test_hooks/test_cmd.py
@@ -12,6 +12,7 @@ from sceptre.stack import Stack
 class TestCmd(object):
     def setup_method(self, test_method):
         self.stack = Mock(Stack)
+        self.stack.name = "my/stack.yaml"
         self.cmd = Cmd(stack=self.stack)
 
     def test_run_with_non_str_argument(self):

--- a/tests/test_hooks/test_hooks.py
+++ b/tests/test_hooks/test_hooks.py
@@ -71,6 +71,7 @@ class TestHook(object):
 class MockClass(object):
     hook_property = HookProperty("hook_property")
     config = MagicMock()
+    name = "my/stack.yaml"
 
 
 class TestHookPropertyDescriptor(object):
@@ -81,7 +82,7 @@ class TestHookPropertyDescriptor(object):
         mock_hook = MagicMock(spec=MockHook)
 
         self.mock_object.hook_property = [mock_hook]
-        assert self.mock_object._hook_property == [mock_hook]
+        assert self.mock_object._hook_property == [mock_hook.clone.return_value]
 
     def test_getting_hook_property(self):
         self.mock_object._hook_property = self.mock_object

--- a/tests/test_resolvers/test_resolver.py
+++ b/tests/test_resolvers/test_resolver.py
@@ -41,6 +41,8 @@ class MockClass(object):
     )
     config = MagicMock()
 
+    name = "my/stack"
+
 
 class TestResolver(object):
     def setup_method(self, test_method):

--- a/tests/test_resolvers/test_stack_attr.py
+++ b/tests/test_resolvers/test_stack_attr.py
@@ -10,6 +10,7 @@ class TestResolver(object):
     def setup_method(self, test_method):
         self.stack_group_config = {}
         self.stack = Mock(spec=Stack, stack_group_config=self.stack_group_config)
+        self.stack.name = "my/stack.yaml"
 
         self.resolver = StackAttr(stack=self.stack)
 

--- a/tests/test_resolvers/test_stack_output.py
+++ b/tests/test_resolvers/test_stack_output.py
@@ -20,6 +20,7 @@ class TestStackOutputResolver(object):
     @patch("sceptre.resolvers.stack_output.StackOutput._get_output_value")
     def test_resolver(self, mock_get_output_value):
         stack = MagicMock(spec=Stack)
+        stack.name = "my/stack"
         stack.dependencies = []
         stack.project_code = "project-code"
         stack._connection_manager = MagicMock(spec=ConnectionManager)
@@ -52,6 +53,7 @@ class TestStackOutputResolver(object):
     @patch("sceptre.resolvers.stack_output.StackOutput._get_output_value")
     def test_resolver_with_existing_dependencies(self, mock_get_output_value):
         stack = MagicMock(spec=Stack)
+        stack.name = "my/stack"
         stack.dependencies = ["existing"]
         stack.project_code = "project-code"
         stack._connection_manager = MagicMock(spec=ConnectionManager)
@@ -84,6 +86,7 @@ class TestStackOutputResolver(object):
     @patch("sceptre.resolvers.stack_output.StackOutput._get_output_value")
     def test_resolve_with_implicit_stack_reference(self, mock_get_output_value):
         stack = MagicMock(spec=Stack)
+        stack.name = "my/stack"
         stack.dependencies = []
         stack.project_code = "project-code"
         stack.name = "account/dev/stack"
@@ -119,6 +122,7 @@ class TestStackOutputResolver(object):
         self, mock_get_output_value
     ):
         stack = MagicMock(spec=Stack)
+        stack.name = "my/stack"
         stack.dependencies = []
         stack.project_code = "project-code"
         stack.name = "stack"
@@ -154,6 +158,7 @@ class TestStackOutputExternalResolver(object):
     @patch("sceptre.resolvers.stack_output.StackOutputExternal._get_output_value")
     def test_resolve(self, mock_get_output_value):
         stack = MagicMock(spec=Stack)
+        stack.name = "my/stack"
         stack.dependencies = []
         stack._connection_manager = MagicMock(spec=ConnectionManager)
         stack_output_external_resolver = StackOutputExternal(
@@ -169,6 +174,7 @@ class TestStackOutputExternalResolver(object):
     @patch("sceptre.resolvers.stack_output.StackOutputExternal._get_output_value")
     def test_resolve_with_args(self, mock_get_output_value):
         stack = MagicMock(spec=Stack)
+        stack.name = "my/stack"
         stack.dependencies = []
         stack._connection_manager = MagicMock(spec=ConnectionManager)
         stack_output_external_resolver = StackOutputExternal(
@@ -200,6 +206,7 @@ class MockStackOutputBase(StackOutputBase):
 class TestStackOutputBaseResolver(object):
     def setup_method(self, test_method):
         self.stack = MagicMock(spec=Stack)
+        self.stack.name = "my/stack.yaml"
         self.stack._connection_manager = MagicMock(spec=ConnectionManager)
         self.base_stack_output_resolver = MockStackOutputBase(None, self.stack)
 


### PR DESCRIPTION
This converts the loggers for Hooks, Resolvers, and Template Handlers to be LoggerAdapters that prefix all log messages with the Stack name

## PR Checklist

- [ ] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
