### PR TITLE
[Resolve #1263] Stack output caching

### DIFF
--- a/sceptre/resolvers/stack_output.py
+++ b/sceptre/resolvers/stack_output.py
@@ -1,21 +1,18 @@
 # -*- coding: utf-8 -*-
 
-import abc
-import six
+import functools
 import logging
 import shlex
 
 from botocore.exceptions import ClientError
 
+from sceptre.exceptions import DependencyStackMissingOutputError, StackDoesNotExistError
 from sceptre.helpers import normalise_path, sceptreise_path
 from sceptre.resolvers import Resolver
-from sceptre.exceptions import DependencyStackMissingOutputError
-from sceptre.exceptions import StackDoesNotExistError
 
 TEMPLATE_EXTENSION = ".yaml"
 
 
-@six.add_metaclass(abc.ABCMeta)
 class StackOutputBase(Resolver):
     """
     A abstract base class which provides methods for getting Stack outputs.
@@ -50,6 +47,7 @@ class StackOutputBase(Resolver):
                 )
             )
 
+    @functools.lru_cache(maxsize=4096)
     def _get_stack_outputs(
         self, stack_name, profile=None, region=None, sceptre_role=None
     ):


### PR DESCRIPTION
This PR caches the stack outputs of each cache so that we're not making redundant requests for the same stack outputs over and over again (which is what we currently do now in every instance we use !stack_output or !stack_output_external).

Thanks to @dboitnot for the very simple solution suggestion!

(I've not written any tests because I believe that if existing unit and integration tests pass, this should be considered very "safe".)

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
