### PR TITLE
Add colouring for missing state DELETE_SKIPPED

### DIFF
--- a/sceptre/stack_status_colourer.py
+++ b/sceptre/stack_status_colourer.py
@@ -19,18 +19,19 @@ class StackStatusColourer(object):
     """
 
     STACK_STATUS_CODES = {
-        "PENDING": Fore.CYAN,
         "CREATE_COMPLETE": Fore.GREEN,
         "CREATE_FAILED": Fore.RED,
         "CREATE_IN_PROGRESS": Fore.YELLOW,
         "DELETE_COMPLETE": Fore.GREEN,
         "DELETE_FAILED": Fore.RED,
         "DELETE_IN_PROGRESS": Fore.YELLOW,
+        "DELETE_SKIPPED": Fore.CYAN,
         "IMPORT_COMPLETE": Fore.GREEN,
         "IMPORT_IN_PROGRESS": Fore.YELLOW,
         "IMPORT_ROLLBACK_COMPLETE": Fore.GREEN,
         "IMPORT_ROLLBACK_FAILED": Fore.RED,
         "IMPORT_ROLLBACK_IN_PROGRESS": Fore.YELLOW,
+        "PENDING": Fore.CYAN,
         "REVIEW_IN_PROGRESS": Fore.YELLOW,
         "ROLLBACK_COMPLETE": Fore.RED,
         "ROLLBACK_FAILED": Fore.RED,


### PR DESCRIPTION
Add colouring for missing state DELETE_SKIPPED

I use colour cyan because it appears that this is not a real state but shows up sometimes anyway e.g. when updating a SAM stack that contains a Lambda Layer Version.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
