### PR TITLE
Write rendered template to a temp file

### DIFF
--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -14,6 +14,7 @@ import fnmatch
 import logging
 import sys
 import yaml
+import tempfile
 
 from os import environ, path, walk
 from typing import Set, Tuple
@@ -413,6 +414,16 @@ class ConfigReader(object):
 
         return config
 
+    def _write_debug_file(self, content):
+        with tempfile.NamedTemporaryFile(
+            mode="w", delete=False, prefix="rendered_"
+        ) as temp_file:
+            temp_file.write(content)
+            temp_file.flush()
+
+        print(f"Debug file location: {temp_file.name}")
+        return temp_file.name
+
     def _render(self, directory_path, basename, stack_group_config):
         """
         Reads a configuration file, loads the config file as a template
@@ -467,8 +478,11 @@ class ConfigReader(object):
             try:
                 config = yaml.safe_load(rendered_template)
             except Exception as err:
+                debug_file_path = self._write_debug_file(rendered_template)
+
                 raise ValueError(
-                    "Error parsing {}:\n{}".format(abs_directory_path, err)
+                    f"Error parsing {abs_directory_path}:\n{err}\n"
+                    f"Rendered template saved to: {debug_file_path}"
                 )
 
             return config


### PR DESCRIPTION
In the event that the reader class is unable to parse the rendered config, this adds logic to write the rendered config to a file to assist the caller in understand what went wrong.

## PR Checklist

- [ ] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`make test`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
