### PR TITLE
[Resolve #1324] Bugfix for dump config and refactor ConfigReader

### DIFF
--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -374,7 +374,7 @@ class ConfigReader(object):
         return config
 
     def _recursive_read(
-        self, directory_path: str, filename: str, work_in_progress_config: dict
+        self, directory_path: str, filename: str, config: dict
     ) -> dict:
         """
         Traverses the directory_path, from top to bottom, reading in all
@@ -384,36 +384,35 @@ class ConfigReader(object):
 
         :param directory_path: Relative directory path to config to read.
         :param filename: File name for the config to read.
-        :param work_in_progress_config: The loaded config file for the StackGroup
+        :param config: The loaded config file for the StackGroup
         :returns: Representation of inherited config.
         """
 
         parent_directory = path.split(directory_path)[0]
 
         # Base condition for recursion
-        config = {}
+        new_config = {}
 
         if directory_path:
-            config = self._recursive_read(
-                parent_directory, filename, work_in_progress_config
+            new_config = self._recursive_read(
+                parent_directory, filename, config
             )
 
-        # Combine the work_in_progress_config with the nested config dict
-        config_group = work_in_progress_config.copy()
-        config_group.update(config)
+        # Combine the config with the nested config dict
+        config_group = config.copy()
+        config_group.update(new_config)
 
         # Read config file and overwrite inherited properties
-        child_config = self._render(directory_path, filename, config_group) or {}
+        config_copy = self._render(directory_path, filename, config_group) or {}
 
         for config_key, strategy in CONFIG_MERGE_STRATEGIES.items():
-            value = strategy(config.get(config_key), child_config.get(config_key))
+            value = strategy(new_config.get(config_key), config_copy.get(config_key))
 
             if value:
-                child_config[config_key] = value
+                config_copy[config_key] = value
 
-        config.update(child_config)
-
-        return config
+        new_config.update(config_copy)
+        return new_config
 
     def _render(self, directory_path, basename, config_group):
         """

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -16,7 +16,7 @@ import sys
 import yaml
 
 from os import environ, path, walk
-from typing import Set, Tuple, Dict, Any
+from typing import Set, Tuple
 from pathlib import Path
 from jinja2 import Environment
 from jinja2 import StrictUndefined
@@ -140,24 +140,6 @@ class ConfigReader(object):
             self.context.user_variables = {}
 
         self.templating_vars = {"var": self.context.user_variables}
-
-    def _fetch_stack_group_config(self, directory_path: str) -> Dict[str, Any]:
-        """
-        Fetches the stack_group_config for the given directory.
-
-        :param directory_path: The directory path to fetch the stack_group_config for.
-        :type directory_path: str
-        :returns: The stack_group_config for the given directory.
-        :rtype: dict
-        """
-        if not directory_path:
-            return {}
-
-        parent_directory, _ = path.split(directory_path)
-        stack_group_config_path = path.join(parent_directory, self.context.config_file)
-        stack_group_config = self.read(stack_group_config_path)
-
-        return stack_group_config
 
     @staticmethod
     def _iterate_entry_points(group):
@@ -364,10 +346,7 @@ class ConfigReader(object):
         }
 
         # Adding defaults from base config.
-        if base_config is None:
-            directory, _ = path.split(directory_path)
-            base_config = self._fetch_stack_group_config(directory)
-        elif base_config:
+        if base_config:
             config.update(base_config)
 
         # Check if file exists, but ignore config.yaml as can be inherited.

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -374,7 +374,7 @@ class ConfigReader(object):
         return config
 
     def _recursive_read(
-        self, directory_path: str, filename: str, config: dict
+        self, directory_path: str, filename: str, work_in_progress_config: dict
     ) -> dict:
         """
         Traverses the directory_path, from top to bottom, reading in all
@@ -384,7 +384,7 @@ class ConfigReader(object):
 
         :param directory_path: Relative directory path to config to read.
         :param filename: File name for the config to read.
-        :param config: The loaded config file for the StackGroup
+        :param work_in_progress_config: The loaded config file for the StackGroup
         :returns: Representation of inherited config.
         """
 
@@ -395,11 +395,11 @@ class ConfigReader(object):
 
         if directory_path:
             config = self._recursive_read(
-                parent_directory, filename, config
+                parent_directory, filename, work_in_progress_config
             )
 
-        # Combine the config with the nested config dict
-        config_group = config.copy()
+        # Combine the work_in_progress_config with the nested config dict
+        config_group = work_in_progress_config.copy()
         config_group.update(config)
 
         # Read config file and overwrite inherited properties
@@ -412,6 +412,7 @@ class ConfigReader(object):
                 child_config[config_key] = value
 
         config.update(child_config)
+
         return config
 
     def _render(self, directory_path, basename, config_group):

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -374,7 +374,7 @@ class ConfigReader(object):
         return config
 
     def _recursive_read(
-        self, directory_path: str, filename: str, work_in_progress_config: dict
+        self, directory_path: str, filename: str, config: dict
     ) -> dict:
         """
         Traverses the directory_path, from top to bottom, reading in all
@@ -384,7 +384,7 @@ class ConfigReader(object):
 
         :param directory_path: Relative directory path to config to read.
         :param filename: File name for the config to read.
-        :param work_in_progress_config: The loaded config file for the StackGroup
+        :param config: The loaded config file for the StackGroup
         :returns: Representation of inherited config.
         """
 
@@ -395,11 +395,11 @@ class ConfigReader(object):
 
         if directory_path:
             config = self._recursive_read(
-                parent_directory, filename, work_in_progress_config
+                parent_directory, filename, config
             )
 
-        # Combine the work_in_progress_config with the nested config dict
-        config_group = work_in_progress_config.copy()
+        # Combine the config with the nested config dict
+        config_group = config.copy()
         config_group.update(config)
 
         # Read config file and overwrite inherited properties
@@ -412,7 +412,6 @@ class ConfigReader(object):
                 child_config[config_key] = value
 
         config.update(child_config)
-
         return config
 
     def _render(self, directory_path, basename, config_group):

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -373,9 +373,7 @@ class ConfigReader(object):
         self.logger.debug("Config: %s", config)
         return config
 
-    def _recursive_read(
-        self, directory_path: str, filename: str, config: dict
-    ) -> dict:
+    def _recursive_read(self, directory_path: str, filename: str, config: dict) -> dict:
         """
         Traverses the directory_path, from top to bottom, reading in all
         relevant config files. If config attributes are encountered further
@@ -394,9 +392,7 @@ class ConfigReader(object):
         new_config = {}
 
         if directory_path:
-            new_config = self._recursive_read(
-                parent_directory, filename, config
-            )
+            new_config = self._recursive_read(parent_directory, filename, config)
 
         # Combine the config with the nested config dict
         config_group = config.copy()

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -150,7 +150,7 @@ class ConfigReader(object):
         :returns: The stack_group_config for the given directory.
         :rtype: dict
         """
-        if directory_path == "":
+        if not directory_path:
             return {}
 
         parent_directory, _ = path.split(directory_path)

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -141,6 +141,24 @@ class ConfigReader(object):
 
         self.templating_vars = {"var": self.context.user_variables}
 
+    def _fetch_stack_group_config(self, directory_path):
+        """
+        Fetches the stack_group_config for the given directory.
+
+        :param directory_path: The directory path to fetch the stack_group_config for.
+        :type directory_path: str
+        :returns: The stack_group_config for the given directory.
+        :rtype: dict
+        """
+        if directory_path == "":
+            return {}
+
+        parent_directory, _ = path.split(directory_path)
+        stack_group_config_path = path.join(parent_directory, self.context.config_file)
+        stack_group_config = self.read(stack_group_config_path)
+
+        return stack_group_config
+
     @staticmethod
     def _iterate_entry_points(group):
         """
@@ -346,7 +364,10 @@ class ConfigReader(object):
         }
 
         # Adding defaults from base config.
-        if base_config:
+        if base_config is None:
+            directory, _ = path.split(directory_path)
+            base_config = self._fetch_stack_group_config(directory)
+        elif base_config:
             config.update(base_config)
 
         # Check if file exists, but ignore config.yaml as can be inherited.

--- a/sceptre/config/reader.py
+++ b/sceptre/config/reader.py
@@ -16,7 +16,7 @@ import sys
 import yaml
 
 from os import environ, path, walk
-from typing import Set, Tuple
+from typing import Set, Tuple, Dict, Any
 from pathlib import Path
 from jinja2 import Environment
 from jinja2 import StrictUndefined
@@ -141,7 +141,7 @@ class ConfigReader(object):
 
         self.templating_vars = {"var": self.context.user_variables}
 
-    def _fetch_stack_group_config(self, directory_path):
+    def _fetch_stack_group_config(self, directory_path: str) -> Dict[str, Any]:
         """
         Fetches the stack_group_config for the given directory.
 

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -182,6 +182,27 @@ class TestConfigReader(object):
                 "base_config": "base_config",
             }
 
+    def test_read_reads_config_file_with_no_base_config(self):
+        with self.runner.isolated_filesystem():
+            project_path = os.path.abspath("./example")
+            config_dir = os.path.join(project_path, "config")
+            stack_group_dir = os.path.join(config_dir, "A")
+
+            os.makedirs(stack_group_dir)
+
+            config = {"config": "config"}
+            with open(os.path.join(stack_group_dir, "stack.yaml"), "w") as config_file:
+                yaml.safe_dump(config, stream=config_file, default_flow_style=False)
+
+            self.context.project_path = project_path
+            config = ConfigReader(self.context).read("A/stack.yaml", None)
+
+            assert config == {
+                "project_path": project_path,
+                "stack_group_path": "A",
+                "config": "config",
+            }
+
     def test_read_with_nonexistant_filepath(self):
         project_path, config_dir = self.create_project()
         self.context.project_path = project_path

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -2,7 +2,7 @@
 
 import errno
 import os
-from unittest.mock import patch, sentinel, MagicMock, ANY
+from unittest.mock import patch, sentinel, MagicMock
 
 import pytest
 import yaml
@@ -252,7 +252,7 @@ class TestConfigReader(object):
         self.context.command_path = "account/stack-group/region/vpc.yaml"
         stacks = ConfigReader(self.context).construct_stacks()
 
-        mock_Stack.assert_any_call(
+        mock_Stack.assert_called_once_with(
             name="account/stack-group/region/vpc",
             project_code="account_project_code",
             template_path=None,
@@ -282,7 +282,16 @@ class TestConfigReader(object):
             template_key_prefix=None,
             ignore=False,
             obsolete=False,
-            stack_group_config=ANY,
+            stack_group_config={
+                "project_path": "/Users/alexharvey/git/fox/sceptre/tests/fixtures-vpc",
+                "profile": "account_profile",
+                "project_code": "account_project_code",
+                "region": "region_region",
+                "required_version": ">1.0",
+                "template_bucket_name": "stack_group_template_bucket_name",
+                "custom_key": "custom_value",
+                "dependencies": ["top/level"],
+            }
         )
 
         assert stacks == ({sentinel.stack}, {sentinel.stack})

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -182,27 +182,6 @@ class TestConfigReader(object):
                 "base_config": "base_config",
             }
 
-    def test_read_reads_config_file_with_no_base_config(self):
-        with self.runner.isolated_filesystem():
-            project_path = os.path.abspath("./example")
-            config_dir = os.path.join(project_path, "config")
-            stack_group_dir = os.path.join(config_dir, "A")
-
-            os.makedirs(stack_group_dir)
-
-            config = {"config": "config"}
-            with open(os.path.join(stack_group_dir, "stack.yaml"), "w") as config_file:
-                yaml.safe_dump(config, stream=config_file, default_flow_style=False)
-
-            self.context.project_path = project_path
-            config = ConfigReader(self.context).read("A/stack.yaml", None)
-
-            assert config == {
-                "project_path": project_path,
-                "stack_group_path": "A",
-                "config": "config",
-            }
-
     def test_read_with_nonexistant_filepath(self):
         project_path, config_dir = self.create_project()
         self.context.project_path = project_path

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -2,7 +2,7 @@
 
 import errno
 import os
-from unittest.mock import patch, sentinel, MagicMock
+from unittest.mock import patch, sentinel, MagicMock, ANY
 
 import pytest
 import yaml
@@ -283,7 +283,7 @@ class TestConfigReader(object):
             ignore=False,
             obsolete=False,
             stack_group_config={
-                "project_path": "/Users/alexharvey/git/fox/sceptre/tests/fixtures-vpc",
+                "project_path": ANY,
                 "profile": "account_profile",
                 "project_code": "account_project_code",
                 "region": "region_region",

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -291,7 +291,7 @@ class TestConfigReader(object):
                 "template_bucket_name": "stack_group_template_bucket_name",
                 "custom_key": "custom_value",
                 "dependencies": ["top/level"],
-            }
+            },
         )
 
         assert stacks == ({sentinel.stack}, {sentinel.stack})


### PR DESCRIPTION
This is a substantial refactoring of the ConfigReader class to fix the
broken `dump config` command.
    
Changes here include:
  
- Change public `read()` method to expect a single input being the rel_path of the yaml file.  
- change `stack_group_config` from a second arg to `read()` to be a class instance variable instead, which is set up during class initialisation in `__init__() to ensure it is properly shared.
- Clean up some unused code.

TODO.

- I have removed a problematic unit test pending expected detailed discussion about how to test these changes!

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`make test`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
