### PR TITLE
[Resolve #1336] Add bugfix in Stack Differ

### DIFF
--- a/sceptre/diffing/stack_differ.py
+++ b/sceptre/diffing/stack_differ.py
@@ -169,7 +169,10 @@ class StackDiffer(Generic[DiffType]):
         for key, value in stack.parameters.items():
             if isinstance(value, list):
                 value = ",".join(item.rstrip("\n") for item in value)
-            formatted_parameters[key] = value.rstrip("\n")
+            if isinstance(value, str):
+                formatted_parameters[key] = value.rstrip("\n")
+            elif value is None:
+                formatted_parameters[key] = value
 
         return formatted_parameters
 
@@ -219,6 +222,7 @@ class StackDiffer(Generic[DiffType]):
             self._remove_deployed_default_parameters_that_arent_passed(
                 deployed_template_summary, generated_config, deployed_config
             )
+
         if not self.show_no_echo:
             # We don't actually want to show parameters Sceptre is passing that the local template
             # marks as NoEcho parameters (unless show_no_echo is set to true). Therefore those

--- a/sceptre/diffing/stack_differ.py
+++ b/sceptre/diffing/stack_differ.py
@@ -172,7 +172,7 @@ class StackDiffer(Generic[DiffType]):
             if isinstance(value, str):
                 formatted_parameters[key] = value.rstrip("\n")
             elif value is None:
-                formatted_parameters[key] = value
+                formatted_parameters[key] = ""
 
         return formatted_parameters
 

--- a/tests/test_diffing/test_stack_differ.py
+++ b/tests/test_diffing/test_stack_differ.py
@@ -332,6 +332,17 @@ class TestStackDiffer:
             self.expected_deployed_config, self.expected_generated_config
         )
 
+    def test_diff__deployed_stack_has_default_values_one_of_them_none__compares_different_configs(
+        self,
+    ):
+        self.deployed_parameters["new"] = "default value"
+        self.deployed_parameter_defaults["new"] = None
+        self.parameters_on_stack_config["new"] = ""
+        self.differ.diff(self.actions)
+        self.command_capturer.compare_stack_configurations.assert_called_with(
+            self.expected_deployed_config, self.expected_generated_config
+        )
+
     def test_diff__stack_exists_with_same_config_but_template_does_not__compares_identical_configs(
         self,
     ):


### PR DESCRIPTION
In the case of a parameter dictionary that contains nulls (None) the Boto3 library has been found to take care of converting None to "". This means that launching such a stack in CloudFormation with a parameter dict containing params set to None works fine, whereas this differ raised an exception when it tried to strip newlines.

This patch stops newlines being stripped in the case of a parameter that is set to None.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`poetry run tox`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`poetry run pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
