### PR TITLE
[Resolve #1344] Restore before_generate hook

### DIFF
--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -628,6 +628,7 @@ class StackActions:
         return new_summaries
 
     @deprecated("4.2.0", "5.0.0", __version__, "Use dump template instead.")
+    @add_stack_hooks
     def generate(self):
         """
         Returns the Template for the Stack


### PR DESCRIPTION
Stack hooks were removed from the deprecated generate command in error. This restores the missing hook.


## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`poetry run tox`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`poetry run pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
