### PR TITLE
[Resolve #1344] Addressing issue with Generate hook and its deprecation

### DIFF
--- a/docs/_source/docs/hooks.rst
+++ b/docs/_source/docs/hooks.rst
@@ -1,30 +1,32 @@
 Hooks
 =====
 
-Hooks allows the ability for custom commands to be run when Sceptre actions
-occur.
+Hooks allows the ability for actions to be run when Sceptre actions occur.
 
 A hook is executed at a particular hook point when Sceptre is run.
 
-If required, users can create their own ``hooks``, as described in the section
-`Custom Hooks`_.
+If required, users can create their own ``hooks``, as described in the section `Custom Hooks`_.
 
 Hook points
 -----------
 
-``before_generate`` or ``after_generate`` - run hook before or after generating stack template.
-
-``before_create`` or ``after_create`` - run hook before or after Stack creation.
-
-``before_update`` or ``after_update`` - run hook before or after Stack update.
-
-``before_delete`` or ``after_delete`` - run hook before or after Stack deletion.
-
-``before_launch`` or ``after_launch`` - run hook before or after Stack launch.
-
-``before_validate`` or ``after_validate`` - run hook before or after Stack validation.
-
-``before_create_change_set`` or ``after_create_change_set`` - run hook before or after create change set.
+- ``before_create``/``after_create`` - Runs before/after Stack creation.
+- ``before_update``/``after_update`` - Runs before/after Stack update.
+- ``before_delete``/``after_delete`` - Runs before/after Stack deletion.
+- ``before_launch``/``after_launch`` - Runs before/after Stack launch.
+- ``before_create_change_set``/``after_create_change_set`` - Runs before/after create change set.
+- ``before_validate``/``after_validate`` - Runs before/after Stack validation.
+- ``before_diff``/``after_diff`` - Runs before/after diffing the deployed stack with the local
+  configuration.
+- ``before_drift_detect``/``after_drift_detect`` - Runs before/after detecting drift on the stack.
+- ``before_drift_show``/``after_drift_show`` - Runs before/after showing detected drift on the stack.
+- ``before_dump_config``/``after_dump_config`` - Runs before/after dumpint the Stack Config.
+- ``before_dump_template``/``after_dump_template`` - Runs before/after rendering the stack template.
+  This hook point is aliased to ``before/generate``/``after_generate``. This hook point will also
+  be triggered when diffing, since the template needs to be generated to diff the template.
+- ``before_generate``/``after_generate`` - Runs before/after rendering the stack template. This
+  hook point is aliased to ``before_dump_template``/``after_dump_template``. *Note:* ``generate`` *is
+  a deprecated command and will be removed in a future release.*
 
 Syntax:
 

--- a/docs/_source/docs/hooks.rst
+++ b/docs/_source/docs/hooks.rst
@@ -24,9 +24,7 @@ Hook points
 - ``before_dump_template``/``after_dump_template`` - Runs before/after rendering the stack template.
   This hook point is aliased to ``before/generate``/``after_generate``. This hook point will also
   be triggered when diffing, since the template needs to be generated to diff the template.
-- ``before_generate``/``after_generate`` - Runs before/after rendering the stack template. This
-  hook point is aliased to ``before_dump_template``/``after_dump_template``. *Note:* ``generate`` *is
-  a deprecated command and will be removed in a future release.*
+- ``before_generate``/``after_generate`` - Runs before/after rendering the stack template.
 
 Syntax:
 

--- a/docs/_source/docs/hooks.rst
+++ b/docs/_source/docs/hooks.rst
@@ -24,7 +24,8 @@ Hook points
 - ``before_dump_template``/``after_dump_template`` - Runs before/after rendering the stack template.
   This hook point is aliased to ``before/generate``/``after_generate``. This hook point will also
   be triggered when diffing, since the template needs to be generated to diff the template.
-- ``before_generate``/``after_generate`` - Runs before/after rendering the stack template.
+- ``before_generate``/``after_generate`` - Runs before/after rendering the stack template. This hook
+  point is aliased to ``before_dump_template``/``after_dump_template``.
 
 Syntax:
 

--- a/sceptre/cli/dump.py
+++ b/sceptre/cli/dump.py
@@ -77,6 +77,9 @@ def dump_config(ctx, to_file, path):
 def dump_template(ctx, to_file, no_placeholders, path):
     """
     Prints the template used for stack in PATH.
+
+    This command is essentially the same as the `generate` command, but with the option of also
+    outputting to file.
     \f
 
     :param path: Path to execute the command on.

--- a/sceptre/cli/dump.py
+++ b/sceptre/cli/dump.py
@@ -77,9 +77,6 @@ def dump_config(ctx, to_file, path):
 def dump_template(ctx, to_file, no_placeholders, path):
     """
     Prints the template used for stack in PATH.
-
-    This command is essentially the same as the `generate` command, but with the option of also
-    outputting to file.
     \f
 
     :param path: Path to execute the command on.

--- a/sceptre/cli/template.py
+++ b/sceptre/cli/template.py
@@ -65,17 +65,17 @@ def validate_command(ctx, no_placeholders, path):
 @click.argument("path")
 @click.pass_context
 @catch_exceptions
-def generate_command(ctx: click.Context, no_placeholders, path):
+def generate_command(ctx: click.Context, no_placeholders: bool, path: str):
     """
     Prints the template used for stack in PATH.
 
-    This command is aliased to the dump template command; It's the same as running
-    `sceptre dump template`, for legacy support reasons.
+    This command is aliased to the dump template command for legacy support reasons. It's the same
+    as running `sceptre dump template`.
+
     \f
     :param no_placeholders: If True, will disable placeholders for unresolvable resolvers. By
         default, placeholders will be active.
     :param path: Path to execute the command on.
-    :type path: str
     """
     ctx.forward(dump_template)
 

--- a/sceptre/cli/template.py
+++ b/sceptre/cli/template.py
@@ -69,7 +69,8 @@ def generate_command(ctx: click.Context, no_placeholders, path):
     """
     Prints the template used for stack in PATH.
 
-    This command is aliased to running `sceptre dump template` for historical support reasons.
+    This command is aliased to the dump template command; It's the same as running
+    `sceptre dump template`, for legacy support reasons.
     \f
     :param no_placeholders: If True, will disable placeholders for unresolvable resolvers. By
         default, placeholders will be active.

--- a/sceptre/cli/template.py
+++ b/sceptre/cli/template.py
@@ -2,6 +2,7 @@ import logging
 import webbrowser
 import click
 
+from sceptre.cli.dump import dump_template
 from sceptre.cli.helpers import catch_exceptions, write
 from sceptre.context import SceptreContext
 from sceptre.helpers import null_context
@@ -64,34 +65,18 @@ def validate_command(ctx, no_placeholders, path):
 @click.argument("path")
 @click.pass_context
 @catch_exceptions
-def generate_command(ctx, no_placeholders, path):
+def generate_command(ctx: click.Context, no_placeholders, path):
     """
     Prints the template used for stack in PATH.
-    \f
 
+    This command is aliased to running `sceptre dump template` for historical support reasons.
+    \f
+    :param no_placeholders: If True, will disable placeholders for unresolvable resolvers. By
+        default, placeholders will be active.
     :param path: Path to execute the command on.
     :type path: str
     """
-    context = SceptreContext(
-        command_path=path,
-        command_params=ctx.params,
-        project_path=ctx.obj.get("project_path"),
-        user_variables=ctx.obj.get("user_variables"),
-        options=ctx.obj.get("options"),
-        output_format=ctx.obj.get("output_format"),
-        ignore_dependencies=ctx.obj.get("ignore_dependencies"),
-    )
-
-    plan = SceptrePlan(context)
-
-    execution_context = (
-        null_context() if no_placeholders else use_resolver_placeholders_on_error()
-    )
-    with execution_context:
-        responses = plan.generate()
-
-    output = [template for template in responses.values()]
-    write(output, context.output_format)
+    ctx.forward(dump_template)
 
 
 @click.command(name="estimate-cost", short_help="Estimates the cost of the template.")

--- a/sceptre/cli/template.py
+++ b/sceptre/cli/template.py
@@ -67,7 +67,6 @@ def validate_command(ctx, no_placeholders, path):
 @click.argument("path")
 @click.pass_context
 @catch_exceptions
-@deprecated("4.2.0", "5.0.0", __version__, "Use dump template instead.")
 def generate_command(ctx, no_placeholders, path):
     """
     Prints the template used for stack in PATH.

--- a/sceptre/cli/template.py
+++ b/sceptre/cli/template.py
@@ -2,9 +2,6 @@ import logging
 import webbrowser
 import click
 
-from deprecation import deprecated
-
-from sceptre import __version__
 from sceptre.cli.helpers import catch_exceptions, write
 from sceptre.context import SceptreContext
 from sceptre.helpers import null_context

--- a/sceptre/diffing/stack_differ.py
+++ b/sceptre/diffing/stack_differ.py
@@ -313,7 +313,7 @@ class StackDiffer(Generic[DiffType]):
                 generated_config.parameters[key] = self.NO_ECHO_REPLACEMENT
 
     def _generate_template(self, stack_actions: StackActions) -> str:
-        return stack_actions.generate()
+        return stack_actions.dump_template()
 
     def _get_deployed_template(
         self, stack_actions: StackActions, is_deployed: bool

--- a/sceptre/hooks/__init__.py
+++ b/sceptre/hooks/__init__.py
@@ -1,7 +1,7 @@
 import abc
 import logging
 from functools import wraps
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from sceptre.helpers import _call_func_on_values
 from sceptre.resolvers import CustomYamlTagBase
@@ -98,3 +98,26 @@ def add_stack_hooks(func):
         return response
 
     return decorated
+
+
+def add_stack_hooks_with_aliases(function_aliases: List[str]):
+    def decorator(func):
+        all_hook_names = [func.__name__] + function_aliases
+
+        @wraps(func)
+        def decorated(self, *args, **kwargs):
+            for hook in all_hook_names:
+                before_hook_name = f"before_{hook}"
+                execute_hooks(self.stack.hooks.get(before_hook_name))
+
+            response = func(self, *args, **kwargs)
+
+            for hook in all_hook_names:
+                after_hook_name = f"after_{hook}"
+                execute_hooks(after_hook_name)
+
+            return response
+
+        return decorated
+
+    return decorator

--- a/sceptre/hooks/__init__.py
+++ b/sceptre/hooks/__init__.py
@@ -101,6 +101,13 @@ def add_stack_hooks(func):
 
 
 def add_stack_hooks_with_aliases(function_aliases: List[str]):
+    """
+    Returns a decorator to trigger the before and after hooks, relative to the decorated function's
+    name AS WELL AS the passed function alias names.
+    :param function_aliases: The list of OTHER functions to trigger hooks around.
+    :return: The hook-triggering decorator.
+    """
+
     def decorator(func):
         all_hook_names = [func.__name__] + function_aliases
 

--- a/sceptre/hooks/__init__.py
+++ b/sceptre/hooks/__init__.py
@@ -114,7 +114,7 @@ def add_stack_hooks_with_aliases(function_aliases: List[str]):
 
             for hook in all_hook_names:
                 after_hook_name = f"after_{hook}"
-                execute_hooks(after_hook_name)
+                execute_hooks(self.stack.hooks.get(after_hook_name))
 
             return response
 

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -627,10 +627,10 @@ class StackActions:
 
         return new_summaries
 
-    @deprecated("4.2.0", "5.0.0", __version__, "Use dump template instead.")
     def generate(self):
         """
-        Returns the Template for the Stack
+        Returns the Template for the Stack. An alias for
+        dump_template for historical reasons.
         """
         return self.dump_template()
 
@@ -1158,6 +1158,7 @@ class StackActions:
     @add_stack_hooks_with_aliases([generate.__name__])
     def dump_template(self):
         """
-        Returns the Template for the Stack
+        Dump the template for the Stack. An alias for generate
+        for historical reasons.
         """
         return self.stack.template.body

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -30,7 +30,7 @@ from sceptre.exceptions import (
     UnknownStackStatusError,
 )
 from sceptre.helpers import extract_datetime_from_aws_response_headers
-from sceptre.hooks import add_stack_hooks
+from sceptre.hooks import add_stack_hooks, add_stack_hooks_with_aliases
 from sceptre.stack import Stack
 from sceptre.stack_status import StackChangeSetStatus, StackStatus
 
@@ -628,7 +628,6 @@ class StackActions:
         return new_summaries
 
     @deprecated("4.2.0", "5.0.0", __version__, "Use dump template instead.")
-    @add_stack_hooks
     def generate(self):
         """
         Returns the Template for the Stack
@@ -1156,7 +1155,7 @@ class StackActions:
         """
         return self.stack.config
 
-    @add_stack_hooks
+    @add_stack_hooks_with_aliases([generate.__name__])
     def dump_template(self):
         """
         Returns the Template for the Stack

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -17,9 +17,7 @@ import botocore
 from datetime import datetime, timedelta
 from dateutil.tz import tzutc
 from os import path
-from deprecation import deprecated
 
-from sceptre import __version__
 from sceptre.connection_manager import ConnectionManager
 
 from sceptre.exceptions import (

--- a/sceptre/plan/plan.py
+++ b/sceptre/plan/plan.py
@@ -11,7 +11,6 @@ import itertools
 
 from os import path, walk
 from typing import Dict, List, Set, Callable, Iterable, Optional
-from deprecation import deprecated
 
 from sceptre.config.graph import StackGraph
 from sceptre.config.reader import ConfigReader
@@ -21,7 +20,6 @@ from sceptre.exceptions import ConfigFileNotFoundError
 from sceptre.helpers import sceptreise_path
 from sceptre.plan.executor import SceptrePlanExecutor
 from sceptre.stack import Stack
-from sceptre import __version__
 
 
 def require_resolved(func) -> Callable:

--- a/sceptre/plan/plan.py
+++ b/sceptre/plan/plan.py
@@ -380,10 +380,10 @@ class SceptrePlan(object):
         self.resolve(command=self.estimate_cost.__name__)
         return self._execute(*args)
 
-    @deprecated("4.2.0", "5.0.0", __version__, "Use dump template instead.")
     def generate(self, *args):
         """
-        Returns a generated Template for a given Stack
+        Returns a generated Template for a given Stack. An alias for
+        dump_template for historical reasons.
 
         :returns: A dictionary of Stacks and their template body.
         :rtype: dict
@@ -447,7 +447,8 @@ class SceptrePlan(object):
 
     def dump_template(self, *args):
         """
-        Returns a generated Template for a given Stack
+        Dump the template for a stack. An alias
+        for generate for historical reasons.
         """
         self.resolve(command=self.dump_template.__name__)
         return self._execute(*args)

--- a/tests/test_diffing/test_stack_differ.py
+++ b/tests/test_diffing/test_stack_differ.py
@@ -179,7 +179,7 @@ class TestStackDiffer:
 
         self.command_capturer.compare_templates.assert_called_with(
             self.actions.fetch_remote_template.return_value,
-            self.actions.generate.return_value,
+            self.actions.dump_template.return_value,
         )
 
     def test_diff__template_diff_is_value_returned_by_implemented_differ(self):
@@ -216,7 +216,7 @@ class TestStackDiffer:
 
     def test_diff__returns_generated_template(self):
         diff = self.differ.diff(self.actions)
-        assert diff.generated_template == self.actions.generate.return_value
+        assert diff.generated_template == self.actions.dump_template.return_value
 
     def test_diff__deployed_stack_exists__returns_is_deployed_as_true(self):
         diff = self.differ.diff(self.actions)
@@ -244,7 +244,7 @@ class TestStackDiffer:
         self.differ.diff(self.actions)
 
         self.command_capturer.compare_templates.assert_called_with(
-            "{}", self.actions.generate.return_value
+            "{}", self.actions.dump_template.return_value
         )
 
     @pytest.mark.parametrize(
@@ -285,7 +285,7 @@ class TestStackDiffer:
         self.stack_status = status
         self.differ.diff(self.actions)
         self.command_capturer.compare_templates.assert_called_with(
-            "{}", self.actions.generate.return_value
+            "{}", self.actions.dump_template.return_value
         )
 
     def test_diff__deployed_stack_has_default_values__doesnt_pass_parameter__compares_identical_configs(

--- a/tests/test_hooks/test_hooks.py
+++ b/tests/test_hooks/test_hooks.py
@@ -2,7 +2,13 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock
 
-from sceptre.hooks import Hook, HookProperty, add_stack_hooks, execute_hooks
+from sceptre.hooks import (
+    Hook,
+    HookProperty,
+    add_stack_hooks,
+    execute_hooks,
+    add_stack_hooks_with_aliases,
+)
 from sceptre.resolvers import Resolver
 from sceptre.stack import Stack
 import logging
@@ -38,6 +44,29 @@ class TestHooksFunctions(object):
 
         assert mock_hook_before.run.call_count == 1
         assert mock_hook_after.run.call_count == 1
+
+    def test_add_stack_hooks_with_aliases(self):
+        mock_before_something = MagicMock(Hook)
+        mock_after_something = MagicMock(Hook)
+        mock_object = MagicMock()
+
+        mock_object.stack.hooks = {
+            "before_something": [mock_before_something],
+            "after_something": [mock_after_something],
+        }
+
+        @add_stack_hooks_with_aliases(["something"])
+        def mock_function(self):
+            return 123
+
+        mock_object.mock_function = mock_function
+        mock_object.mock_function.__name__ = "mock_function"
+
+        result = mock_function(mock_object)
+
+        assert mock_before_something.run.call_count == 1
+        assert mock_after_something.run.call_count == 1
+        assert result == 123
 
     def test_execute_hooks_with_not_a_list(self):
         execute_hooks(None)

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1,8 +1,6 @@
 import pytest
 from unittest.mock import MagicMock, patch, sentinel
 
-from deprecation import fail_if_not_removed
-
 from sceptre.context import SceptreContext
 from sceptre.stack import Stack
 from sceptre.config.reader import ConfigReader

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -63,9 +63,3 @@ class TestSceptrePlan(object):
             plan = MagicMock(spec=SceptrePlan)
             plan.context = self.mock_context
             plan.invalid_command()
-
-    @fail_if_not_removed
-    def test_generate_removed(self):
-        plan = MagicMock(spec=SceptrePlan)
-        plan.context = self.mock_context
-        plan.generate("test-attribute")


### PR DESCRIPTION
This addresses the current issue raised in #1344. 

Here is what this includes:
* The `dump_template` action ALSO triggers `before_generate` and `after_generate`
* The `generate` action ALSO triggers `before_dump_template` and `after_dump_template`
* The StackDiffer invokes `dump_template` rather than `generate`, preventing our own code from triggering deprecation warnings.
* The documentation for hook points is updated to include all current hooks, including notes about the aliasing.
* Deprecation of `generate` is removed after discussion in Slack. This deprecation would be too disruptive to many users, and we agreed instead to support a permanent alias of `generate` => `dump_template`.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`poetry run tox`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`poetry run pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
