### PR TITLE
[Resolves #1358] Fix installer for version 3.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,21 +3,21 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.4.0
     hooks:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.0
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
     hooks:
       - id: flake8
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.26.1
+    rev: v1.32.0
     hooks:
       - id: yamllint
   - repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.61.5
+    rev: v0.78.1
     hooks:
       - id: cfn-python-lint
         args:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Categories: Added, Removed, Changed, Fixed, Nonfunctional, Deprecated
 
 ## Unreleased
 
+## 3.2.1 (2023.06.20)
+  - [Resolves #1358] Fix installer for version 3.2
+
 ## 3.2.0 (2022.09.20)
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM python:3.7-alpine
+FROM python:3.9-alpine
 RUN apk add --no-cache bash
 WORKDIR /app
 COPY setup.cfg setup.py README.md CHANGELOG.md ./
 COPY sceptre/ ./sceptre
+RUN python setup.py install
+# RUN pip install wheel
 RUN pip install .
 WORKDIR /project
 ENTRYPOINT ["sceptre"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /app
 COPY setup.cfg setup.py README.md CHANGELOG.md ./
 COPY sceptre/ ./sceptre
 RUN python setup.py install
-# RUN pip install wheel
 RUN pip install .
 WORKDIR /project
 ENTRYPOINT ["sceptre"]

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -7,8 +7,9 @@ Jinja2>=3.0,<4
 jsonschema>=3.2,<3.3
 networkx>=2.6,<2.7
 packaging>=16.8,<22.0
-PyYaml>=5.1,<6.0
+PyYaml>=5.1,<5.3.0
 sceptre-cmd-resolver>=1.1.3,<2
 sceptre-file-resolver>=1.0.4,<2
 six>=1.11.0,<2.0.0
 troposphere>=4,<5
+urllib3==1.25.11

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -12,4 +12,4 @@ sceptre-cmd-resolver>=1.1.3,<2
 sceptre-file-resolver>=1.0.4,<2
 six>=1.11.0,<2.0.0
 troposphere>=4,<5
-urllib3==1.25.11
+urllib3<2.0

--- a/sceptre/__init__.py
+++ b/sceptre/__init__.py
@@ -6,7 +6,7 @@ import warnings
 
 __author__ = 'Cloudreach'
 __email__ = 'sceptre@cloudreach.com'
-__version__ = '3.2.0'
+__version__ = '3.2.1'
 
 
 # Set up logging to ``/dev/null`` like a library is supposed to.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.2.0
+current_version = 3.2.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)|(?P<release_candidate>.*)
 commit = True
 tag = True

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ install_requirements = [
     "sceptre-file-resolver>=1.0.4,<2",
     "six>=1.11.0,<2.0.0",
     "networkx>=2.6,<2.7",
-    "urllib3==1.25.11"
+    "urllib3<2.0"
 ]
 
 extra_requirements = {

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ install_requirements = [
     "sceptre-cmd-resolver>=1.1.3,<2",
     "sceptre-file-resolver>=1.0.4,<2",
     "six>=1.11.0,<2.0.0",
-    "networkx>=2.6,<2.7"
+    "networkx>=2.6,<2.7",
+    "urllib3==1.25.11"
 ]
 
 extra_requirements = {


### PR DESCRIPTION
Make the 3.2.x release buildable again to prepare
for a patch release.

  * pre-commit linters were failing so update them to work
  * update libraries and docker version to fix the cython issue

