### PR TITLE
[Resolve #1358] update PyYaml dependency

### DIFF
--- a/integration-tests/steps/stacks.py
+++ b/integration-tests/steps/stacks.py
@@ -131,7 +131,7 @@ def step_impl(context, stack_name):
     )
     yaml_file = Path(sceptre_context.full_config_path()) / f'{stack_name}.yaml'
     with yaml_file.open(mode='r') as f:
-        loaded = yaml.load(f)
+        loaded = yaml.load(f, yaml.Loader)
 
     original_config = deepcopy(loaded)
     loaded['stack_tags'] = {

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -7,7 +7,7 @@ Jinja2>=3.0,<4
 jsonschema>=3.2,<3.3
 networkx>=2.6,<2.7
 packaging>=16.8,<22.0
-PyYaml>=5.1,<5.3.0
+PyYaml>6.0,<7.0
 sceptre-cmd-resolver>=1.1.3,<2
 sceptre-file-resolver>=1.0.4,<2
 six>=1.11.0,<2.0.0

--- a/sceptre/__init__.py
+++ b/sceptre/__init__.py
@@ -6,7 +6,7 @@ import warnings
 
 __author__ = 'Cloudreach'
 __email__ = 'sceptre@cloudreach.com'
-__version__ = '3.2.1'
+__version__ = '3.2.2'
 
 
 # Set up logging to ``/dev/null`` like a library is supposed to.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.2.1
+current_version = 3.2.2
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)|(?P<release_candidate>.*)
 commit = True
 tag = True

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ install_requirements = [
     "click>=7.0,<9.0",
     "cfn-flip>=1.2.3,<2.0",
     "deepdiff>=5.5.0,<6.0",
-    "PyYaml>=5.1,<6.0",
+    "PyYaml>6.0,<7.0",
     "Jinja2>=3.0,<4",
     "jsonschema>=3.2,<3.3",
     "colorama>=0.3.9",


### PR DESCRIPTION
There is a fix for PyYaml post ver 6.0.  Update dependency to pick up the fix.

