### PR TITLE
[Resolve #1367] Add a Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ clean-test:
 	rm -f test-results.xml
 
 lint:
-	pre-commit run --all-files --show-diff-on-failure
+	poetry run pre-commit run --all-files
 
 pre:
 	poetry install --all-extras -v


### PR DESCRIPTION
In commit ac9e439 that implemented Poetry, the Makefile was deleted. This has made it a bit harder to run tests and so on.

This restores a modified Makefile to assist with running the necessary poetry commands to run the tests and linter and so forth.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`poetry run tox`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`poetry run pre-commit run --all-files`).
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
