### PR TITLE
[Resolve #1343]  Add feature to print out CloudFormation hook status to Sceptre output when logging new stack events

### DIFF
--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -840,17 +840,23 @@ class StackActions:
         events.reverse()
         new_events = [event for event in events if event["Timestamp"] > after_datetime]
         for event in new_events:
-            self.logger.info(
-                " ".join(
+            stack_event_status = [
+                self.stack.name,
+                event["LogicalResourceId"],
+                event["ResourceType"],
+                event["ResourceStatus"],
+                event.get("ResourceStatusReason", ""),
+            ]
+            if "HookStatus" in event:
+                stack_event_status.extend(
                     [
-                        self.stack.name,
-                        event["LogicalResourceId"],
-                        event["ResourceType"],
-                        event["ResourceStatus"],
-                        event.get("ResourceStatusReason", ""),
+                        event["HookType"],
+                        event["HookStatus"],
+                        event.get("HookStatusReason", ""),
+                        event["HookFailureMode"],
                     ]
                 )
-            )
+            self.logger.info(" ".join(stack_event_status))
             after_datetime = event["Timestamp"]
         return after_datetime
 


### PR DESCRIPTION
[Resolve #1343] Add feature to print out CloudFormation hook status to Sceptre output when logging new stack events

    This pull request brings the ability for Sceptre to print out CloudFormation hook status when logging new stack events. They are "HookType","HookStatus","HookStatusReason" and "HookFailureMode". The information facilitates early picking up of CloudFormation hook issues/failures.

    Added CloudFormation hook information to `_log_new_events` method in `sceptre/plan/actions.py` module and its matching unit tests in `tests/test_actions.py` module.

    More details and discussion please refer [Ability to show the cloudformation hook status and message in the sceptre output #1343](https://github.com/Sceptre/sceptre/issues/1343) and [1343 logging hook status #1369](https://github.com/Sceptre/sceptre/pull/1369).

[1]:https://aws.amazon.com/about-aws/whats-new/2022/02/aws-announces-general-availability-aws-cloudformation-hooks/
[2]:https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_StackEvent.html