### PR TITLE
[Resolves #1213] Add shell option to cmd hook

### DIFF
--- a/docs/_source/docs/hooks.rst
+++ b/docs/_source/docs/hooks.rst
@@ -57,7 +57,7 @@ Syntax:
    # Another shell.
    <hook_point>:
      - !cmd
-         command: <shell_command>
+         run: <shell_command>
          shell: <shell_name_or_path>
 
 Pass the command string as the only argument to use the default shell.
@@ -85,7 +85,7 @@ A successful command prints its standard output messages between status messages
    [2023-09-03 01:06:31] - test - Updating Stack
    [2023-09-03 01:06:31] - test - No updates to perform.
 
-Pass named arguments to use a different shell. Here the command string is called ``command`` and the
+Pass named arguments to use a different shell. Here the command string is called ``run`` and the
 shell executable is called ``shell``.
 
 Write the executable name as you would type it at an interactive prompt to start the shell. For
@@ -97,7 +97,7 @@ absolute path such as ``/bin/bash``.
    hooks:
      before_update:
        - !cmd
-           command: echo "Hello, $0!"
+           run: echo "Hello, $0!"
            shell: bash
 
 .. code-block:: text
@@ -115,7 +115,7 @@ You can use PowerShell in the same way.
    hooks:
      before_update:
        - !cmd
-           command: Write-Output "Hello, Posh!"
+           run: Write-Output "Hello, Posh!"
            shell: pwsh
 
 .. code-block:: text
@@ -126,7 +126,7 @@ You can use PowerShell in the same way.
    [2023-09-04 00:44:34] - test - Updating Stack
    [2023-09-04 00:44:34] - test - No updates to perform.
 
-If the shell command fails, so does Sceptre. The command output sits between Sceptre's status
+If the shell command fails, so does Sceptre. Its output sits between Sceptre's status
 messages and a Python traceback.
 
 .. code-block:: yaml

--- a/docs/_source/docs/hooks.rst
+++ b/docs/_source/docs/hooks.rst
@@ -52,13 +52,13 @@ Syntax:
 
    # Default shell.
    <hook_point>:
-     - !cmd <command string>
+     - !cmd <shell_command>
 
    # Another shell.
    <hook_point>:
      - !cmd
-         args: <command string>
-         executable: <shell command>
+         args: <shell_command>
+         executable: <shell_name_or_path>
 
 Pass the command string as the only argument to use the default shell.
 

--- a/docs/_source/docs/hooks.rst
+++ b/docs/_source/docs/hooks.rst
@@ -57,8 +57,8 @@ Syntax:
    # Another shell.
    <hook_point>:
      - !cmd
-         args: <shell_command>
-         executable: <shell_name_or_path>
+         command: <shell_command>
+         shell: <shell_name_or_path>
 
 Pass the command string as the only argument to use the default shell.
 
@@ -95,8 +95,8 @@ in system path, you can write ``bash``; otherwise, you need to write the absolut
    hooks:
      before_update:
        - !cmd
-           args: "if foo; then baz; else qux; fi"
-           executable: "bash"
+           command: "if foo; then baz; else qux; fi"
+           shell: "bash"
 
 This example fails because none of the ``foo``, ``baz``, and ``quz`` commands exist. Its standard error messages sit between Sceptre's status messages and a Python traceback.
 

--- a/docs/_source/docs/hooks.rst
+++ b/docs/_source/docs/hooks.rst
@@ -50,15 +50,15 @@ Syntax:
 
 .. code-block:: yaml
 
-  # Default shell.
-  <hook_point>:
-    - !cmd <command string>
+   # Default shell.
+   <hook_point>:
+     - !cmd <command string>
 
-  # Another shell.
-  <hook_point>:
-    - !cmd
-        args: <command string>
-        executable: <shell command>
+   # Another shell.
+   <hook_point>:
+     - !cmd
+         args: <command string>
+         executable: <shell command>
 
 Pass the command string as the only argument to use the default shell.
 
@@ -70,19 +70,19 @@ quotes and backslashes to escape filenames with spaces in them.
 
 .. code-block:: yaml
 
-  hooks:
-    before_update:
-      - !cmd "echo 'Hello, world!'"
+   hooks:
+     before_update:
+       - !cmd "echo 'Hello, world!'"
 
 This example succeeds. Its standard output messages appear between status messages from Sceptre.
 
 .. code-block::
 
-  [2023-09-03 01:06:28] - test - Launching Stack
-  [2023-09-03 01:06:29] - test - Stack is in the CREATE_COMPLETE state
-  Hello, world!
-  [2023-09-03 01:06:31] - test - Updating Stack
-  [2023-09-03 01:06:31] - test - No updates to perform.
+   [2023-09-03 01:06:28] - test - Launching Stack
+   [2023-09-03 01:06:29] - test - Stack is in the CREATE_COMPLETE state
+   Hello, world!
+   [2023-09-03 01:06:31] - test - Updating Stack
+   [2023-09-03 01:06:31] - test - No updates to perform.
 
 Pass named arguments ``args`` and ``executable`` to use a different shell.
 
@@ -92,23 +92,23 @@ in system path, you can write ``bash``; otherwise, you need to write the absolut
 
 .. code-block:: yaml
 
-  hooks:
-    before_update:
-      - !cmd
-          args: "if foo; then baz; else qux; fi"
-          executable: "bash"
+   hooks:
+     before_update:
+       - !cmd
+           args: "if foo; then baz; else qux; fi"
+           executable: "bash"
 
 This example fails because none of the ``foo``, ``baz``, and ``quz`` commands exist. Its standard error messages sit between Sceptre's status messages and a Python traceback.
 
 .. code-block:: text
 
-  [2023-09-03 02:00:21] - test - Launching Stack
-  [2023-09-03 02:00:22] - test - Stack is in the CREATE_COMPLETE state
-  bash: foo: command not found
-  bash: qux: command not found
-  Traceback (most recent call last):
-  <snip>
-  subprocess.CalledProcessError: Command 'if foo; then baz; else qux; fi' returned non-zero exit status 127.
+   [2023-09-03 02:00:21] - test - Launching Stack
+   [2023-09-03 02:00:22] - test - Stack is in the CREATE_COMPLETE state
+   bash: foo: command not found
+   bash: qux: command not found
+   Traceback (most recent call last):
+   <snip>
+   subprocess.CalledProcessError: Command 'if foo; then baz; else qux; fi' returned non-zero exit status 127.
 
 
 asg_scaling_processes

--- a/docs/_source/docs/hooks.rst
+++ b/docs/_source/docs/hooks.rst
@@ -51,11 +51,11 @@ Syntax:
 .. code-block:: yaml
 
   # Default shell.
-  before_update:
+  <hook_point>:
     - !cmd <command string>
 
   # Another shell.
-  before_update:
+  <hook_point>:
     - !cmd
         args: <command string>
         executable: <shell command>

--- a/docs/_source/docs/hooks.rst
+++ b/docs/_source/docs/hooks.rst
@@ -65,16 +65,17 @@ Pass the command string as the only argument to use the default shell.
 On POSIX the default shell is ``sh``. On Windows it's usually ``cmd.exe``, but ``%ComSpec%`` may
 override that.
 
-Format the command string exactly as you would type it at the shell prompt. This includes
-quotes and backslashes to escape filenames with spaces in them.
+Write the command string as you would type it at the shell prompt. This includes quotes and
+backslashes to escape filenames with spaces in them. To minimize escaping, you can use YAML plain
+strings like the following examples.
 
 .. code-block:: yaml
 
    hooks:
      before_update:
-       - !cmd "echo 'Hello, world!'"
+       - !cmd echo "Hello, world!"
 
-This example succeeds. Its standard output messages appear between status messages from Sceptre.
+A successful command prints its standard output messages between status messages from Sceptre.
 
 .. code-block::
 
@@ -84,32 +85,64 @@ This example succeeds. Its standard output messages appear between status messag
    [2023-09-03 01:06:31] - test - Updating Stack
    [2023-09-03 01:06:31] - test - No updates to perform.
 
-Pass named arguments ``args`` and ``executable`` to use a different shell.
+Pass named arguments to use a different shell. Here the command string is called ``command`` and the
+shell executable is called ``shell``.
 
-Format the executable name exactly as you would type it to start the shell. For example, if Bash is
-in system path, you can write ``bash``; otherwise, you need to write the absolute path such as
-``/bin/bash``.
+Write the executable name as you would type it at an interactive prompt to start the shell. For
+example, if Bash is in the system path, you can write ``bash``; otherwise, you need to write the
+absolute path such as ``/bin/bash``.
 
 .. code-block:: yaml
 
    hooks:
      before_update:
        - !cmd
-           command: "if foo; then baz; else qux; fi"
-           shell: "bash"
-
-This example fails because none of the ``foo``, ``baz``, and ``quz`` commands exist. Its standard error messages sit between Sceptre's status messages and a Python traceback.
+           command: echo "Hello, $0!"
+           shell: bash
 
 .. code-block:: text
 
-   [2023-09-03 02:00:21] - test - Launching Stack
-   [2023-09-03 02:00:22] - test - Stack is in the CREATE_COMPLETE state
-   bash: foo: command not found
-   bash: qux: command not found
+   [2023-09-04 00:29:42] - test - Launching Stack
+   [2023-09-04 00:29:43] - test - Stack is in the CREATE_COMPLETE state
+   Hello, bash!
+   [2023-09-04 00:29:43] - test - Updating Stack
+   [2023-09-04 00:29:43] - test - No updates to perform.
+
+You can use PowerShell in the same way.
+
+.. code-block:: yaml
+
+   hooks:
+     before_update:
+       - !cmd
+           command: Write-Output "Hello, Posh!"
+           shell: pwsh
+
+.. code-block:: text
+
+   [2023-09-04 00:44:32] - test - Launching Stack
+   [2023-09-04 00:44:33] - test - Stack is in the CREATE_COMPLETE state
+   Hello, Posh!
+   [2023-09-04 00:44:34] - test - Updating Stack
+   [2023-09-04 00:44:34] - test - No updates to perform.
+
+If the shell command fails, so does Sceptre. The command output sits between Sceptre's status
+messages and a Python traceback.
+
+.. code-block:: yaml
+
+   hooks:
+     before_update:
+       - !cmd missing_command
+
+.. code-block:: text
+
+   [2023-09-04 00:46:25] - test - Launching Stack
+   [2023-09-04 00:46:26] - test - Stack is in the CREATE_COMPLETE state
+   /bin/sh: 1: missing_command: not found
    Traceback (most recent call last):
    <snip>
-   subprocess.CalledProcessError: Command 'if foo; then baz; else qux; fi' returned non-zero exit status 127.
-
+   subprocess.CalledProcessError: Command 'missing_command' returned non-zero exit status 127.
 
 asg_scaling_processes
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/_source/docs/hooks.rst
+++ b/docs/_source/docs/hooks.rst
@@ -46,6 +46,20 @@ cmd
 
 Executes a command through the shell.
 
+Syntax:
+
+.. code-block:: yaml
+
+  # Default shell.
+  before_update:
+    - !cmd <command string>
+
+  # Another shell.
+  before_update:
+    - !cmd
+        args: <command string>
+        executable: <shell command>
+
 Pass the command string as the only argument to use the default shell.
 
 On POSIX the default shell is ``sh``. On Windows it's usually ``cmd.exe``, but ``%ComSpec%`` may
@@ -60,7 +74,7 @@ quotes and backslashes to escape filenames with spaces in them.
     before_update:
       - !cmd "echo 'Hello, world!'"
 
-The command's standard output messages appear between status messages from Sceptre.
+This example succeeds. Its standard output messages appear between status messages from Sceptre.
 
 .. code-block::
 
@@ -84,7 +98,7 @@ in system path, you can write ``bash``; otherwise, you need to write the absolut
           args: "if foo; then baz; else qux; fi"
           executable: "bash"
 
-The ``if`` command fails because none of the ``foo``, ``baz``, and ``quz`` commands exist. The command's standard error messages sit between Sceptre's status messages and a Python traceback. Here the traceback is snipped.
+This example fails because none of the ``foo``, ``baz``, and ``quz`` commands exist. Its standard error messages sit between Sceptre's status messages and a Python traceback.
 
 .. code-block:: text
 
@@ -93,7 +107,7 @@ The ``if`` command fails because none of the ``foo``, ``baz``, and ``quz`` comma
   bash: foo: command not found
   bash: qux: command not found
   Traceback (most recent call last):
-  ...
+  <snip>
   subprocess.CalledProcessError: Command 'if foo; then baz; else qux; fi' returned non-zero exit status 127.
 
 

--- a/docs/_source/docs/hooks.rst
+++ b/docs/_source/docs/hooks.rst
@@ -44,23 +44,58 @@ Available Hooks
 cmd
 ~~~
 
-Executes the argument string in the shell as a Python subprocess.
+Executes a command through the shell.
 
-For more information about how this works, see the `subprocess documentation`_
+Pass the command string as the only argument to use the default shell.
 
-Syntax:
+On POSIX the default shell is ``sh``. On Windows it's usually ``cmd.exe``, but ``%ComSpec%`` may
+override that.
 
-.. code-block:: yaml
-
-   <hook_point>:
-     - !cmd <shell_command>
-
-Example:
+Format the command string exactly as you would type it at the shell prompt. This includes
+quotes and backslashes to escape filenames with spaces in them.
 
 .. code-block:: yaml
 
-   before_create:
-     - !cmd "echo hello"
+  hooks:
+    before_update:
+      - !cmd "echo 'Hello, world!'"
+
+The command's standard output messages appear between status messages from Sceptre.
+
+.. code-block::
+
+  [2023-09-03 01:06:28] - test - Launching Stack
+  [2023-09-03 01:06:29] - test - Stack is in the CREATE_COMPLETE state
+  Hello, world!
+  [2023-09-03 01:06:31] - test - Updating Stack
+  [2023-09-03 01:06:31] - test - No updates to perform.
+
+Pass named arguments ``args`` and ``executable`` to use a different shell.
+
+Format the executable name exactly as you would type it to start the shell. For example, if Bash is
+in system path, you can write ``bash``; otherwise, you need to write the absolute path such as
+``/bin/bash``.
+
+.. code-block:: yaml
+
+  hooks:
+    before_update:
+      - !cmd
+          args: "if foo; then baz; else qux; fi"
+          executable: "bash"
+
+The ``if`` command fails because none of the ``foo``, ``baz``, and ``quz`` commands exist. The command's standard error messages sit between Sceptre's status messages and a Python traceback. Here the traceback is snipped.
+
+.. code-block:: text
+
+  [2023-09-03 02:00:21] - test - Launching Stack
+  [2023-09-03 02:00:22] - test - Stack is in the CREATE_COMPLETE state
+  bash: foo: command not found
+  bash: qux: command not found
+  Traceback (most recent call last):
+  ...
+  subprocess.CalledProcessError: Command 'if foo; then baz; else qux; fi' returned non-zero exit status 127.
+
 
 asg_scaling_processes
 ~~~~~~~~~~~~~~~~~~~~~

--- a/sceptre/hooks/cmd.py
+++ b/sceptre/hooks/cmd.py
@@ -20,14 +20,22 @@ class Cmd(Hook):
         """
         envs = self.stack.connection_manager.create_session_environment_variables()
 
-        if self.argument is None:
-            raise InvalidHookArgumentTypeError()
-
-        if isinstance(self.argument, str) or self.argument is None:
+        if isinstance(self.argument, str) and self.argument != "":
             args = self.argument
             executable = None
-        elif isinstance(self.argument, dict):
+        elif (
+            isinstance(self.argument, dict)
+            and set(self.argument) == {"args", "executable"}
+            and isinstance(self.argument["args"], str)
+            and isinstance(self.argument["executable"], str)
+        ):
             args = self.argument["args"]
             executable = self.argument["executable"]
+        else:
+            raise InvalidHookArgumentTypeError(
+                "A cmd hook requires either a string argument or an object with "
+                "args and executable keys with string values. "
+                f"You gave {self.argument!r}."
+            )
 
         subprocess.check_call(args, shell=True, env=envs, executable=executable)

--- a/sceptre/hooks/cmd.py
+++ b/sceptre/hooks/cmd.py
@@ -19,8 +19,16 @@ class Cmd(Hook):
         :raises: subprocess.CalledProcessError
         """
         envs = self.stack.connection_manager.create_session_environment_variables()
+
+        if isinstance(self.argument, str):
+            args = self.argument
+            executable = None
+        elif isinstance(self.argument, dict):
+            args = self.argument["args"]
+            executable = self.argument["executable"]
+
         try:
-            subprocess.check_call(self.argument, shell=True, env=envs)
+            subprocess.check_call(args, shell=True, env=envs, executable=executable)
         except TypeError:
             raise InvalidHookArgumentTypeError(
                 'The argument "{0}" is the wrong type - cmd hooks require '

--- a/sceptre/hooks/cmd.py
+++ b/sceptre/hooks/cmd.py
@@ -17,8 +17,9 @@ class Cmd(Hook):
 
         See hooks documentation for details.
 
-        :raises: sceptre.exceptions.InvalidHookArgumentTypeError
-        :raises: subprocess.CalledProcessError
+        :raises: sceptre.exceptions.InvalidHookArgumentTypeError invalid input
+        :raises: subprocess.CalledProcessError failed command
+        :raises: subprocess.FileNotFoundError shell doesn't exist
         """
         envs = self.stack.connection_manager.create_session_environment_variables()
 

--- a/sceptre/hooks/cmd.py
+++ b/sceptre/hooks/cmd.py
@@ -20,7 +20,7 @@ class Cmd(Hook):
         """
         envs = self.stack.connection_manager.create_session_environment_variables()
 
-        if isinstance(self.argument, str):
+        if isinstance(self.argument, str) or self.argument is None:
             args = self.argument
             executable = None
         elif isinstance(self.argument, dict):

--- a/sceptre/hooks/cmd.py
+++ b/sceptre/hooks/cmd.py
@@ -18,8 +18,9 @@ class Cmd(Hook):
         See hooks documentation for details.
 
         :raises: sceptre.exceptions.InvalidHookArgumentTypeError invalid input
-        :raises: subprocess.CalledProcessError failed command
-        :raises: subprocess.FileNotFoundError shell doesn't exist
+        :raises: CalledProcessError failed command
+        :raises: FileNotFoundError missing shell
+        :raises: PermissionError non-executable shell
         """
         envs = self.stack.connection_manager.create_session_environment_variables()
 

--- a/sceptre/hooks/cmd.py
+++ b/sceptre/hooks/cmd.py
@@ -13,9 +13,11 @@ class Cmd(Hook):
 
     def run(self):
         """
-        Runs the argument string in a subprocess.
+        Executes a command through the shell.
 
-        :raises: sceptre.exceptions.InvalidTaskArgumentTypeException
+        See hooks documentation for details.
+
+        :raises: sceptre.exceptions.InvalidHookArgumentTypeError
         :raises: subprocess.CalledProcessError
         """
         envs = self.stack.connection_manager.create_session_environment_variables()

--- a/sceptre/hooks/cmd.py
+++ b/sceptre/hooks/cmd.py
@@ -23,16 +23,18 @@ class Cmd(Hook):
         envs = self.stack.connection_manager.create_session_environment_variables()
 
         if isinstance(self.argument, str) and self.argument != "":
-            args = self.argument
-            executable = None
+            command = self.argument
+            shell = None
+
         elif (
             isinstance(self.argument, dict)
             and set(self.argument) == {"command", "shell"}
             and isinstance(self.argument["command"], str)
             and isinstance(self.argument["shell"], str)
         ):
-            args = self.argument["command"]
-            executable = self.argument["shell"]
+            command = self.argument["command"]
+            shell = self.argument["shell"]
+
         else:
             raise InvalidHookArgumentTypeError(
                 "A cmd hook requires either a string argument or an object with "
@@ -40,4 +42,4 @@ class Cmd(Hook):
                 f"You gave `{self.argument!r}`."
             )
 
-        subprocess.check_call(args, shell=True, env=envs, executable=executable)
+        subprocess.check_call(command, shell=True, env=envs, executable=shell)

--- a/sceptre/hooks/cmd.py
+++ b/sceptre/hooks/cmd.py
@@ -20,6 +20,9 @@ class Cmd(Hook):
         """
         envs = self.stack.connection_manager.create_session_environment_variables()
 
+        if self.argument is None:
+            raise InvalidHookArgumentTypeError()
+
         if isinstance(self.argument, str) or self.argument is None:
             args = self.argument
             executable = None
@@ -27,10 +30,4 @@ class Cmd(Hook):
             args = self.argument["args"]
             executable = self.argument["executable"]
 
-        try:
-            subprocess.check_call(args, shell=True, env=envs, executable=executable)
-        except TypeError:
-            raise InvalidHookArgumentTypeError(
-                'The argument "{0}" is the wrong type - cmd hooks require '
-                "arguments of type string.".format(self.argument)
-            )
+        subprocess.check_call(args, shell=True, env=envs, executable=executable)

--- a/sceptre/hooks/cmd.py
+++ b/sceptre/hooks/cmd.py
@@ -23,23 +23,23 @@ class Cmd(Hook):
         envs = self.stack.connection_manager.create_session_environment_variables()
 
         if isinstance(self.argument, str) and self.argument != "":
-            command = self.argument
+            command_to_run = self.argument
             shell = None
 
         elif (
             isinstance(self.argument, dict)
-            and set(self.argument) == {"command", "shell"}
-            and isinstance(self.argument["command"], str)
+            and set(self.argument) == {"run", "shell"}
+            and isinstance(self.argument["run"], str)
             and isinstance(self.argument["shell"], str)
         ):
-            command = self.argument["command"]
+            command_to_run = self.argument["run"]
             shell = self.argument["shell"]
 
         else:
             raise InvalidHookArgumentTypeError(
                 "A cmd hook requires either a string argument or an object with "
-                "`command` and `shell` keys with string values. "
+                "`run` and `shell` keys with string values. "
                 f"You gave `{self.argument!r}`."
             )
 
-        subprocess.check_call(command, shell=True, env=envs, executable=shell)
+        subprocess.check_call(command_to_run, shell=True, env=envs, executable=shell)

--- a/sceptre/hooks/cmd.py
+++ b/sceptre/hooks/cmd.py
@@ -32,6 +32,7 @@ class Cmd(Hook):
             and isinstance(self.argument["run"], str)
             and isinstance(self.argument["shell"], str)
             and self.argument["run"] != ""
+            and self.argument["shell"] != ""
         ):
             command_to_run = self.argument["run"]
             shell = self.argument["shell"]

--- a/sceptre/hooks/cmd.py
+++ b/sceptre/hooks/cmd.py
@@ -31,6 +31,7 @@ class Cmd(Hook):
             and set(self.argument) == {"run", "shell"}
             and isinstance(self.argument["run"], str)
             and isinstance(self.argument["shell"], str)
+            and self.argument["run"] != ""
         ):
             command_to_run = self.argument["run"]
             shell = self.argument["shell"]

--- a/sceptre/hooks/cmd.py
+++ b/sceptre/hooks/cmd.py
@@ -25,17 +25,17 @@ class Cmd(Hook):
             executable = None
         elif (
             isinstance(self.argument, dict)
-            and set(self.argument) == {"args", "executable"}
-            and isinstance(self.argument["args"], str)
-            and isinstance(self.argument["executable"], str)
+            and set(self.argument) == {"command", "shell"}
+            and isinstance(self.argument["command"], str)
+            and isinstance(self.argument["shell"], str)
         ):
-            args = self.argument["args"]
-            executable = self.argument["executable"]
+            args = self.argument["command"]
+            executable = self.argument["shell"]
         else:
             raise InvalidHookArgumentTypeError(
                 "A cmd hook requires either a string argument or an object with "
-                "args and executable keys with string values. "
-                f"You gave {self.argument!r}."
+                "`command` and `shell` keys with string values. "
+                f"You gave `{self.argument!r}`."
             )
 
         subprocess.check_call(args, shell=True, env=envs, executable=executable)

--- a/tests/test_hooks/test_cmd.py
+++ b/tests/test_hooks/test_cmd.py
@@ -74,6 +74,18 @@ def test_dict_with_list_run_raises_exception(stack):
         Cmd({"run": ["echo", "hello"], "shell": "/bin/bash"}, stack).run()
 
 
+def test_dict_with_empty_run_raises_exception(stack):
+    message = ERROR_MESSAGE.format(r"\{'run': '', 'shell': '/bin/bash'\}")
+    with pytest.raises(InvalidHookArgumentTypeError, match=message):
+        Cmd({"run": "", "shell": "/bin/bash"}, stack).run()
+
+
+def test_dict_with_null_run_raises_exception(stack):
+    message = ERROR_MESSAGE.format(r"\{'run': None, 'shell': '/bin/bash'\}")
+    with pytest.raises(InvalidHookArgumentTypeError, match=message):
+        Cmd({"run": None, "shell": "/bin/bash"}, stack).run()
+
+
 def test_dict_with_list_shell_raises_exception(stack):
     message = ERROR_MESSAGE.format(r"\{'run': 'echo hello', 'shell': \['/bin/bash'\]\}")
     with pytest.raises(InvalidHookArgumentTypeError, match=message):
@@ -87,16 +99,16 @@ def test_dict_with_bad_shell_raises_exception(stack):
         Cmd({"run": "echo hello", "shell": typo}, stack).run()
 
 
-def test_dict_with_empty_run_raises_exception(stack):
-    message = ERROR_MESSAGE.format(r"\{'run': '', 'shell': '/bin/bash'\}")
-    with pytest.raises(InvalidHookArgumentTypeError, match=message):
-        Cmd({"run": "", "shell": "/bin/bash"}, stack).run()
-
-
 def test_dict_with_empty_shell_raises_exception(stack):
     message = ERROR_MESSAGE.format(r"\{'run': 'echo hello', 'shell': ''\}")
     with pytest.raises(InvalidHookArgumentTypeError, match=message):
         Cmd({"run": "echo hello", "shell": ""}, stack).run()
+
+
+def test_dict_with_null_shell_raises_exception(stack):
+    message = ERROR_MESSAGE.format(r"\{'run': 'echo hello', 'shell': None\}")
+    with pytest.raises(InvalidHookArgumentTypeError, match=message):
+        Cmd({"run": "echo hello", "shell": None}, stack).run()
 
 
 def test_input_exception_reprs_input(stack):

--- a/tests/test_hooks/test_cmd.py
+++ b/tests/test_hooks/test_cmd.py
@@ -88,7 +88,12 @@ def test_dict_with_list_shell_raises_exception(stack):
 
 
 def test_dict_with_typo_shell_raises_exception(stack):
-    message = r"^\[Errno 2\] No such file or directory: '/bin/bsah'$"
+    import platform
+
+    if platform.python_version().startswith("3.7."):
+        message = r"^\[Errno 2\] No such file or directory: '/bin/bsah': '/bin/bsah'$"
+    else:
+        message = r"^\[Errno 2\] No such file or directory: '/bin/bsah'$"
     with pytest.raises(FileNotFoundError, match=message):
         typo = "/bin/bsah"
         Cmd({"run": "echo hello", "shell": typo}, stack).run()

--- a/tests/test_hooks/test_cmd.py
+++ b/tests/test_hooks/test_cmd.py
@@ -109,3 +109,13 @@ def test_executable_sets_the_shell(stack, capfd):
     cap = capfd.readouterr()
     assert cap.out.strip() == "/bin/bash"
     assert cap.err.strip() == ""
+
+
+def test_shell_has_session_environment_variables(stack, capfd):
+    stack.connection_manager.create_session_environment_variables = Mock(
+        return_value={"AWS_PROFILE": "sceptre_profile"}
+    )
+    Cmd("env | grep -E '^AWS_PROFILE='", stack).run()
+    cap = capfd.readouterr()
+    assert cap.out.strip() == "AWS_PROFILE=sceptre_profile"
+    assert cap.err.strip() == ""

--- a/tests/test_hooks/test_cmd.py
+++ b/tests/test_hooks/test_cmd.py
@@ -92,11 +92,17 @@ def test_dict_with_list_shell_raises_exception(stack):
         Cmd({"run": "echo hello", "shell": ["/bin/bash"]}, stack).run()
 
 
-def test_dict_with_bad_shell_raises_exception(stack):
+def test_dict_with_typo_shell_raises_exception(stack):
     message = r"^\[Errno 2\] No such file or directory: '/bin/bsah'$"
     with pytest.raises(FileNotFoundError, match=message):
         typo = "/bin/bsah"
         Cmd({"run": "echo hello", "shell": typo}, stack).run()
+
+
+def test_dict_with_non_executable_shell_raises_exception(stack):
+    message = r"^\[Errno 13\] Permission denied: '/'$"
+    with pytest.raises(PermissionError, match=message):
+        Cmd({"run": "echo hello", "shell": "/"}, stack).run()
 
 
 def test_dict_with_empty_shell_raises_exception(stack):

--- a/tests/test_hooks/test_cmd.py
+++ b/tests/test_hooks/test_cmd.py
@@ -8,105 +8,104 @@ from sceptre.hooks.cmd import Cmd
 from sceptre.stack import Stack
 
 
-class TestCmd(object):
-    def setup_method(self, test_method):
-        self.stack = Stack(
-            "stack1",
-            "project1",
-            "region1",
-            template_handler_config={"template": "path.yaml"},
-        )
+@pytest.fixture()
+def stack():
+    stack = Stack(
+        "stack1",
+        "project1",
+        "region1",
+        template_handler_config={"template": "path.yaml"},
+    )
 
-        # Otherwise the test works only when the environment variables already
-        # set a valid AWS session.
-        self.stack.connection_manager.create_session_environment_variables = Mock(
-            return_value={}
-        )
+    # Otherwise the test works only when the environment variables already set a
+    # valid AWS session.
+    stack.connection_manager.create_session_environment_variables = Mock(
+        return_value={}
+    )
 
-        self.cmd = Cmd(stack=self.stack)
+    return stack
 
-    def test_null_input_raises_exception(self):
-        self.cmd.argument = None
-        with pytest.raises(InvalidHookArgumentTypeError):
-            self.cmd.run()
 
-    def test_empty_string_raises_exception(self):
-        self.cmd.argument = ""
-        with pytest.raises(InvalidHookArgumentTypeError):
-            self.cmd.run()
+def test_null_input_raises_exception(stack):
+    with pytest.raises(InvalidHookArgumentTypeError):
+        Cmd(None, stack).run()
 
-    def test_list_raises_exception(self):
-        self.cmd.argument = ["echo", "hello"]
-        with pytest.raises(InvalidHookArgumentTypeError):
-            self.cmd.run()
 
-    def test_dict_without_executable_raises_exception(self):
-        self.cmd.argument = {"args": "echo hello"}
-        with pytest.raises(InvalidHookArgumentTypeError):
-            self.cmd.run()
+def test_empty_string_raises_exception(stack):
+    with pytest.raises(InvalidHookArgumentTypeError):
+        Cmd("", stack).run()
 
-    def test_dict_without_args_raises_exception(self):
-        self.cmd.argument = {"executable": "/bin/bash"}
-        with pytest.raises(InvalidHookArgumentTypeError):
-            self.cmd.run()
 
-    def test_dict_with_list_args_raises_exception(self):
-        self.cmd.argument = {"args": ["echo", "hello"], "executable": "/bin/bash"}
-        with pytest.raises(InvalidHookArgumentTypeError):
-            self.cmd.run()
+def test_list_raises_exception(stack):
+    with pytest.raises(InvalidHookArgumentTypeError):
+        Cmd(["echo", "hello"], stack).run()
 
-    def test_dict_with_list_executable_raises_exception(self):
-        self.cmd.argument = {"args": "echo hello", "executable": ["/bin/bash"]}
-        with pytest.raises(InvalidHookArgumentTypeError):
-            self.cmd.run()
 
-    def test_input_exception_reprs_input(self):
-        import datetime
+def test_dict_without_executable_raises_exception(stack):
+    with pytest.raises(InvalidHookArgumentTypeError):
+        Cmd({"args": "echo hello"}, stack).run()
 
-        self.cmd.argument = datetime.date(2023, 8, 31)
-        exception_message = (
-            r"A cmd hook requires either a string argument or an object with "
-            r"args and executable keys with string values\. You gave "
-            r"datetime.date\(2023, 8, 31\)\."
-        )
-        with pytest.raises(InvalidHookArgumentTypeError, match=exception_message):
-            self.cmd.run()
 
-    def test_zero_exit_returns(self):
-        self.cmd.argument = "exit 0"
-        self.cmd.run()
+def test_dict_without_args_raises_exception(stack):
+    with pytest.raises(InvalidHookArgumentTypeError):
+        Cmd({"executable": "/bin/bash"}, stack).run()
 
-    def test_nonzero_exit_raises_exception(self):
-        self.cmd.argument = "exit 1"
-        with pytest.raises(CalledProcessError):
-            self.cmd.run()
 
-    def test_command_writes_to_stdout(self, capfd):
-        self.cmd.argument = "echo hello"
-        self.cmd.run()
+def test_dict_with_list_args_raises_exception(stack):
+    with pytest.raises(InvalidHookArgumentTypeError):
+        Cmd({"args": ["echo", "hello"], "executable": "/bin/bash"}, stack).run()
+
+
+def test_dict_with_list_executable_raises_exception(stack):
+    with pytest.raises(InvalidHookArgumentTypeError):
+        Cmd({"args": "echo hello", "executable": ["/bin/bash"]}, stack).run()
+
+
+def test_input_exception_reprs_input(stack):
+    import datetime
+
+    exception_message = (
+        r"A cmd hook requires either a string argument or an object with args and "
+        r"executable keys with string values\. You gave datetime.date\(2023, 8, 31\)\."
+    )
+    with pytest.raises(InvalidHookArgumentTypeError, match=exception_message):
+        Cmd(datetime.date(2023, 8, 31), stack).run()
+
+
+def test_zero_exit_returns(stack):
+    Cmd("exit 0", stack).run()
+
+
+def test_nonzero_exit_raises_exception(stack):
+    with pytest.raises(CalledProcessError):
+        Cmd("exit 1", stack).run()
+
+
+def test_command_writes_to_stdout(stack, capfd):
+    Cmd("echo hello", stack).run()
+    cap = capfd.readouterr()
+    assert cap.out.strip() == "hello"
+    assert cap.err.strip() == ""
+
+
+def test_shell_error_writes_to_stderr(stack, capfd):
+    try:
+        Cmd("missing_command", stack).run()
+    except CalledProcessError:
         cap = capfd.readouterr()
-        assert cap.out.strip() == "hello"
-        assert cap.err.strip() == ""
+        assert cap.out.strip() == ""
+        assert "missing_command: not found" in cap.err
 
-    def test_shell_error_writes_to_stderr(self, capfd):
-        self.cmd.argument = "missing_command"
-        try:
-            self.cmd.run()
-        except CalledProcessError:
-            cap = capfd.readouterr()
-            assert cap.out.strip() == ""
-            assert "missing_command: not found" in cap.err
 
-    def test_default_shell_is_sh(self, capfd):
-        self.cmd.argument = "echo $0"
-        self.cmd.run()
-        cap = capfd.readouterr()
-        assert cap.out.strip() == "/bin/sh"
-        assert cap.err.strip() == ""
+def test_default_shell_is_sh(stack, capfd):
+    Cmd("echo $0", stack).run()
+    cap = capfd.readouterr()
+    assert cap.out.strip() == "/bin/sh"
+    assert cap.err.strip() == ""
 
-    def test_executable_sets_the_shell(self, capfd):
-        self.cmd.argument = {"args": "echo $0", "executable": "/bin/bash"}
-        self.cmd.run()
-        cap = capfd.readouterr()
-        assert cap.out.strip() == "/bin/bash"
-        assert cap.err.strip() == ""
+
+def test_executable_sets_the_shell(stack, capfd):
+    Cmd({"args": "echo $0", "executable": "/bin/bash"}, stack).run()
+    cap = capfd.readouterr()
+    assert cap.out.strip() == "/bin/bash"
+    assert cap.err.strip() == ""

--- a/tests/test_hooks/test_cmd.py
+++ b/tests/test_hooks/test_cmd.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from subprocess import CalledProcessError
-
+from unittest.mock import Mock
 import pytest
 
 from sceptre.exceptions import InvalidHookArgumentTypeError
@@ -16,6 +16,13 @@ class TestCmd(object):
             "region1",
             template_handler_config={"template": "path.yaml"},
         )
+
+        # Otherwise the test works only when the environment variables already
+        # set a valid AWS session.
+        self.stack.connection_manager.create_session_environment_variables = Mock(
+            return_value={}
+        )
+
         self.cmd = Cmd(stack=self.stack)
 
     def test_run_with_non_str_argument(self):

--- a/tests/test_hooks/test_cmd.py
+++ b/tests/test_hooks/test_cmd.py
@@ -25,12 +25,12 @@ class TestCmd(object):
 
         self.cmd = Cmd(stack=self.stack)
 
-    def test_run_with_non_str_argument(self):
+    def test_run_with_null(self):
         self.cmd.argument = None
         with pytest.raises(InvalidHookArgumentTypeError):
             self.cmd.run()
 
-    def test_run_with_str_argument(self, capfd):
+    def test_run_with_correct_command(self, capfd):
         self.cmd.argument = "echo hello"
         self.cmd.run()
         cap = capfd.readouterr()

--- a/tests/test_hooks/test_cmd.py
+++ b/tests/test_hooks/test_cmd.py
@@ -116,7 +116,7 @@ def test_shell_has_session_environment_variables(stack, capfd):
     stack.connection_manager.create_session_environment_variables = Mock(
         return_value={"AWS_PROFILE": "sceptre_profile"}
     )
-    Cmd("env | grep -E '^AWS_PROFILE='", stack).run()
+    Cmd("echo $AWS_PROFILE", stack).run()
     cap = capfd.readouterr()
-    assert cap.out.strip() == "AWS_PROFILE=sceptre_profile"
+    assert cap.out.strip() == "sceptre_profile"
     assert cap.err.strip() == ""

--- a/tests/test_hooks/test_cmd.py
+++ b/tests/test_hooks/test_cmd.py
@@ -7,14 +7,9 @@ from sceptre.exceptions import InvalidHookArgumentTypeError
 from sceptre.hooks.cmd import Cmd
 from sceptre.stack import Stack
 
-ERROR_MESSAGE_PREFIX = (
-    r"A cmd hook requires either a string argument or an object with `run` and "
-    r"`shell` keys with string values\. You gave "
-)
-
 ERROR_MESSAGE = (
-    r"A cmd hook requires either a string argument or an object with `run` and "
-    r"`shell` keys with string values\. You gave `{0}`\."
+    r"^A cmd hook requires either a string argument or an object with `run` and "
+    r"`shell` keys with string values\. You gave `{0}`\.$"
 )
 
 

--- a/tests/test_hooks/test_cmd.py
+++ b/tests/test_hooks/test_cmd.py
@@ -73,12 +73,20 @@ def test_dict_with_bad_shell_raises_exception(stack):
         Cmd({"run": "echo hello", "shell": typo}, stack).run()
 
 
-def test_dict_with_empty_string_raises_exception(stack):
+def test_dict_with_empty_run_raises_exception(stack):
     exception_message = (
         ERROR_MESSAGE_PREFIX + r"`\{'run': '', 'shell': '/bin/bash'\}`\."
     )
     with pytest.raises(InvalidHookArgumentTypeError, match=exception_message):
         Cmd({"run": "", "shell": "/bin/bash"}, stack).run()
+
+
+def test_dict_with_empty_shell_raises_exception(stack):
+    exception_message = (
+        ERROR_MESSAGE_PREFIX + r"`\{'run': 'echo hello', 'shell': ''\}`\."
+    )
+    with pytest.raises(InvalidHookArgumentTypeError, match=exception_message):
+        Cmd({"run": "echo hello", "shell": ""}, stack).run()
 
 
 def test_input_exception_reprs_input(stack):

--- a/tests/test_hooks/test_cmd.py
+++ b/tests/test_hooks/test_cmd.py
@@ -43,22 +43,22 @@ def test_list_raises_exception(stack):
 
 def test_dict_without_shell_raises_exception(stack):
     with pytest.raises(InvalidHookArgumentTypeError):
-        Cmd({"command": "echo hello"}, stack).run()
+        Cmd({"run": "echo hello"}, stack).run()
 
 
-def test_dict_without_command_raises_exception(stack):
+def test_dict_without_run_raises_exception(stack):
     with pytest.raises(InvalidHookArgumentTypeError):
         Cmd({"shell": "/bin/bash"}, stack).run()
 
 
-def test_dict_with_list_command_raises_exception(stack):
+def test_dict_with_list_run_raises_exception(stack):
     with pytest.raises(InvalidHookArgumentTypeError):
-        Cmd({"command": ["echo", "hello"], "shell": "/bin/bash"}, stack).run()
+        Cmd({"run": ["echo", "hello"], "shell": "/bin/bash"}, stack).run()
 
 
 def test_dict_with_list_shell_raises_exception(stack):
     with pytest.raises(InvalidHookArgumentTypeError):
-        Cmd({"command": "echo hello", "shell": ["/bin/bash"]}, stack).run()
+        Cmd({"run": "echo hello", "shell": ["/bin/bash"]}, stack).run()
 
 
 def test_input_exception_reprs_input(stack):
@@ -66,7 +66,7 @@ def test_input_exception_reprs_input(stack):
 
     exception_message = (
         r"A cmd hook requires either a string argument or an object with "
-        r"`command` and `shell` keys with string values\. You gave "
+        r"`run` and `shell` keys with string values\. You gave "
         r"`datetime.date\(2023, 8, 31\)`\."
     )
     with pytest.raises(InvalidHookArgumentTypeError, match=exception_message):
@@ -106,7 +106,7 @@ def test_default_shell_is_sh(stack, capfd):
 
 
 def test_shell_parameter_sets_the_shell(stack, capfd):
-    Cmd({"command": "echo $0", "shell": "/bin/bash"}, stack).run()
+    Cmd({"run": "echo $0", "shell": "/bin/bash"}, stack).run()
     cap = capfd.readouterr()
     assert cap.out.strip() == "/bin/bash"
     assert cap.err.strip() == ""

--- a/tests/test_hooks/test_cmd.py
+++ b/tests/test_hooks/test_cmd.py
@@ -41,3 +41,9 @@ class TestCmd(object):
         self.cmd.argument = "missing_command_that_causes_shell_error"
         with pytest.raises(CalledProcessError):
             self.cmd.run()
+
+    def test_run_with_command_and_executable(self):
+        # TODO: Choose how to test this.
+        # Mock subprocess and check that executable message is sent?
+        # Spy Popen and check executable?
+        pytest.fail()

--- a/tests/test_hooks/test_cmd.py
+++ b/tests/test_hooks/test_cmd.py
@@ -43,30 +43,31 @@ def test_list_raises_exception(stack):
 
 def test_dict_without_executable_raises_exception(stack):
     with pytest.raises(InvalidHookArgumentTypeError):
-        Cmd({"args": "echo hello"}, stack).run()
+        Cmd({"command": "echo hello"}, stack).run()
 
 
 def test_dict_without_args_raises_exception(stack):
     with pytest.raises(InvalidHookArgumentTypeError):
-        Cmd({"executable": "/bin/bash"}, stack).run()
+        Cmd({"shell": "/bin/bash"}, stack).run()
 
 
 def test_dict_with_list_args_raises_exception(stack):
     with pytest.raises(InvalidHookArgumentTypeError):
-        Cmd({"args": ["echo", "hello"], "executable": "/bin/bash"}, stack).run()
+        Cmd({"command": ["echo", "hello"], "shell": "/bin/bash"}, stack).run()
 
 
 def test_dict_with_list_executable_raises_exception(stack):
     with pytest.raises(InvalidHookArgumentTypeError):
-        Cmd({"args": "echo hello", "executable": ["/bin/bash"]}, stack).run()
+        Cmd({"command": "echo hello", "shell": ["/bin/bash"]}, stack).run()
 
 
 def test_input_exception_reprs_input(stack):
     import datetime
 
     exception_message = (
-        r"A cmd hook requires either a string argument or an object with args and "
-        r"executable keys with string values\. You gave datetime.date\(2023, 8, 31\)\."
+        r"A cmd hook requires either a string argument or an object with "
+        r"`command` and `shell` keys with string values\. You gave "
+        r"`datetime.date\(2023, 8, 31\)`\."
     )
     with pytest.raises(InvalidHookArgumentTypeError, match=exception_message):
         Cmd(datetime.date(2023, 8, 31), stack).run()
@@ -105,7 +106,7 @@ def test_default_shell_is_sh(stack, capfd):
 
 
 def test_executable_sets_the_shell(stack, capfd):
-    Cmd({"args": "echo $0", "executable": "/bin/bash"}, stack).run()
+    Cmd({"command": "echo $0", "shell": "/bin/bash"}, stack).run()
     cap = capfd.readouterr()
     assert cap.out.strip() == "/bin/bash"
     assert cap.err.strip() == ""

--- a/tests/test_hooks/test_cmd.py
+++ b/tests/test_hooks/test_cmd.py
@@ -25,25 +25,88 @@ class TestCmd(object):
 
         self.cmd = Cmd(stack=self.stack)
 
-    def test_run_with_null(self):
+    def test_null_input_raises_exception(self):
         self.cmd.argument = None
         with pytest.raises(InvalidHookArgumentTypeError):
             self.cmd.run()
 
-    def test_run_with_correct_command(self, capfd):
+    def test_empty_string_raises_exception(self):
+        self.cmd.argument = ""
+        with pytest.raises(InvalidHookArgumentTypeError):
+            self.cmd.run()
+
+    def test_list_raises_exception(self):
+        self.cmd.argument = ["echo", "hello"]
+        with pytest.raises(InvalidHookArgumentTypeError):
+            self.cmd.run()
+
+    def test_dict_without_executable_raises_exception(self):
+        self.cmd.argument = {"args": "echo hello"}
+        with pytest.raises(InvalidHookArgumentTypeError):
+            self.cmd.run()
+
+    def test_dict_without_args_raises_exception(self):
+        self.cmd.argument = {"executable": "/bin/bash"}
+        with pytest.raises(InvalidHookArgumentTypeError):
+            self.cmd.run()
+
+    def test_dict_with_list_args_raises_exception(self):
+        self.cmd.argument = {"args": ["echo", "hello"], "executable": "/bin/bash"}
+        with pytest.raises(InvalidHookArgumentTypeError):
+            self.cmd.run()
+
+    def test_dict_with_list_executable_raises_exception(self):
+        self.cmd.argument = {"args": "echo hello", "executable": ["/bin/bash"]}
+        with pytest.raises(InvalidHookArgumentTypeError):
+            self.cmd.run()
+
+    def test_input_exception_reprs_input(self):
+        import datetime
+
+        self.cmd.argument = datetime.date(2023, 8, 31)
+        exception_message = (
+            r"A cmd hook requires either a string argument or an object with "
+            r"args and executable keys with string values\. You gave "
+            r"datetime.date\(2023, 8, 31\)\."
+        )
+        with pytest.raises(InvalidHookArgumentTypeError, match=exception_message):
+            self.cmd.run()
+
+    def test_zero_exit_returns(self):
+        self.cmd.argument = "exit 0"
+        self.cmd.run()
+
+    def test_nonzero_exit_raises_exception(self):
+        self.cmd.argument = "exit 1"
+        with pytest.raises(CalledProcessError):
+            self.cmd.run()
+
+    def test_command_writes_to_stdout(self, capfd):
         self.cmd.argument = "echo hello"
         self.cmd.run()
         cap = capfd.readouterr()
         assert cap.out.strip() == "hello"
         assert cap.err.strip() == ""
 
-    def test_run_with_erroring_command(self):
-        self.cmd.argument = "missing_command_that_causes_shell_error"
-        with pytest.raises(CalledProcessError):
+    def test_shell_error_writes_to_stderr(self, capfd):
+        self.cmd.argument = "missing_command"
+        try:
             self.cmd.run()
+        except CalledProcessError:
+            cap = capfd.readouterr()
+            assert cap.out.strip() == ""
+            assert "missing_command: not found" in cap.err
 
-    def test_run_with_command_and_executable(self):
-        # TODO: Choose how to test this.
-        # Mock subprocess and check that executable message is sent?
-        # Spy Popen and check executable?
-        pytest.fail()
+    def test_default_shell_is_sh(self, capfd):
+        self.cmd.argument = "echo $0"
+        self.cmd.run()
+        cap = capfd.readouterr()
+        assert cap.out.strip() == "/bin/sh"
+        assert cap.err.strip() == ""
+
+    def test_executable_sets_the_shell(self, capfd):
+        self.cmd.argument = {"args": "echo $0", "executable": "/bin/bash"}
+        self.cmd.run()
+        cap = capfd.readouterr()
+        assert cap.out.strip() == "/bin/bash"
+        assert cap.err.strip() == ""

--- a/tests/test_hooks/test_cmd.py
+++ b/tests/test_hooks/test_cmd.py
@@ -41,22 +41,22 @@ def test_list_raises_exception(stack):
         Cmd(["echo", "hello"], stack).run()
 
 
-def test_dict_without_executable_raises_exception(stack):
+def test_dict_without_shell_raises_exception(stack):
     with pytest.raises(InvalidHookArgumentTypeError):
         Cmd({"command": "echo hello"}, stack).run()
 
 
-def test_dict_without_args_raises_exception(stack):
+def test_dict_without_command_raises_exception(stack):
     with pytest.raises(InvalidHookArgumentTypeError):
         Cmd({"shell": "/bin/bash"}, stack).run()
 
 
-def test_dict_with_list_args_raises_exception(stack):
+def test_dict_with_list_command_raises_exception(stack):
     with pytest.raises(InvalidHookArgumentTypeError):
         Cmd({"command": ["echo", "hello"], "shell": "/bin/bash"}, stack).run()
 
 
-def test_dict_with_list_executable_raises_exception(stack):
+def test_dict_with_list_shell_raises_exception(stack):
     with pytest.raises(InvalidHookArgumentTypeError):
         Cmd({"command": "echo hello", "shell": ["/bin/bash"]}, stack).run()
 
@@ -82,14 +82,14 @@ def test_nonzero_exit_raises_exception(stack):
         Cmd("exit 1", stack).run()
 
 
-def test_command_writes_to_stdout(stack, capfd):
+def test_hook_writes_to_stdout(stack, capfd):
     Cmd("echo hello", stack).run()
     cap = capfd.readouterr()
     assert cap.out.strip() == "hello"
     assert cap.err.strip() == ""
 
 
-def test_shell_error_writes_to_stderr(stack, capfd):
+def test_hook_writes_to_stderr(stack, capfd):
     try:
         Cmd("missing_command", stack).run()
     except CalledProcessError:
@@ -105,7 +105,7 @@ def test_default_shell_is_sh(stack, capfd):
     assert cap.err.strip() == ""
 
 
-def test_executable_sets_the_shell(stack, capfd):
+def test_shell_parameter_sets_the_shell(stack, capfd):
     Cmd({"command": "echo $0", "shell": "/bin/bash"}, stack).run()
     cap = capfd.readouterr()
     assert cap.out.strip() == "/bin/bash"


### PR DESCRIPTION
The cmd hook now accepts named arguments `run` and `shell` to run a command in a
given shell. For backwards compatibility it still supports the unnamed
argument to run a command in the default shell.

The documentation shows the expected output for examples of each argument style.

The unit tests no longer depend on the implementation of Cmd and test only the
behavior. This makes it easier to change how the hook controls the subprocess.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] ~Commit message~ PR title starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`poetry run tox`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`poetry run pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
