### PR TITLE
[Resolves #1383] Simplify stderr test for cmd hook

### DIFF
--- a/tests/test_hooks/test_cmd.py
+++ b/tests/test_hooks/test_cmd.py
@@ -138,11 +138,10 @@ def test_hook_writes_to_stdout(stack, capfd):
 
 
 def test_hook_writes_to_stderr(stack, capfd):
-    with pytest.raises(Exception):
-        Cmd("missing_command", stack).run()
+    Cmd("echo hello >&2", stack).run()
     cap = capfd.readouterr()
     assert cap.out.strip() == ""
-    assert cap.err.strip() == "/bin/sh: 1: missing_command: not found"
+    assert cap.err.strip() == "hello"
 
 
 def test_default_shell_is_sh(stack, capfd):


### PR DESCRIPTION
The old test expected `/bin/sh` to write Dash's error message. This works on
Ubuntu 20.

It old test failed  when `/bin/sh` pointed to `/bin/bash`. This happens on
macOS.

The new test no longer depends on system-defined side effects of a missing
command. It just writes to the standard error stream and checks that the same
text comes out.
