### PR TITLE
[Resolves #1396] Add bugfix for failing test_hook_writes_to_stderr

### DIFF
--- a/tests/test_hooks/test_cmd.py
+++ b/tests/test_hooks/test_cmd.py
@@ -154,7 +154,7 @@ def test_hook_writes_to_stderr(stack, capfd):
     cap = capfd.readouterr()
 
     assert cap.out.strip() == ""
-    assert cap.err.strip() == "/bin/sh: missing_command: command not found"
+    assert cap.err.strip() == expected_error
 
 
 def test_default_shell_is_sh(stack, capfd):

--- a/tests/test_hooks/test_cmd.py
+++ b/tests/test_hooks/test_cmd.py
@@ -2,6 +2,7 @@
 from subprocess import CalledProcessError
 from unittest.mock import Mock
 import pytest
+import platform
 
 from sceptre.exceptions import InvalidHookArgumentTypeError
 from sceptre.hooks.cmd import Cmd
@@ -140,9 +141,20 @@ def test_hook_writes_to_stdout(stack, capfd):
 def test_hook_writes_to_stderr(stack, capfd):
     with pytest.raises(Exception):
         Cmd("missing_command", stack).run()
+
+    os_name = platform.system()
+
+    if os_name == "Linux":
+        expected_error = "/bin/sh: 1: missing_command: not found"
+    elif os_name == "Darwin":
+        expected_error = "/bin/sh: missing_command: command not found"
+    else:
+        raise NotImplementedError(f"Test not implemented for OS: {os_name}")
+
     cap = capfd.readouterr()
+
     assert cap.out.strip() == ""
-    assert cap.err.strip() == "/bin/sh: 1: missing_command: not found"
+    assert cap.err.strip() == "/bin/sh: missing_command: command not found"
 
 
 def test_default_shell_is_sh(stack, capfd):


### PR DESCRIPTION
A test `test_hook_writes_to_stderr` has been added recently that makes platform-specific assumptions about the behaviour of `/bin/sh` and at present will only pass on Linux. This PR adds a fix to pass the test on the MacOS platform.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`poetry run tox`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`poetry run pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
