### PR TITLE
bump version and update Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Categories: Added, Removed, Changed, Fixed, Nonfunctional, Deprecated
 
 ## Unreleased
 
+## 5.0.0 (2023.12.21)
+ - ci: use matrix for unit tests (#1395)
+ - Remove template_path config parameter (#1386)
+ - Add support for python 3.12 (#1390)
+ - Update docker container for CI (#1393)
+ - [Resolves #1377] Remove auto announcements to twitter (#1385)
+ - [Resolves #1383] Simplify stderr test for cmd hook (#1387)
+ - Drop support for Python 3.7 (#1382)
+ - Update templates.rst (#1378)
+
 ## 4.3.0 (2023.10.07)
  - [Resolve #1351] Add debugging to Jinja rendering (#1375)
  - [Resolves #1356] Add export=stackoutput and stackoutputexternal feature to list outputs (#1357)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sceptre"
-version = "4.3.0"
+version = "5.0.0"
 packages = [{ include = "sceptre" }]
 readme = "README.md"
 homepage = "https://github.com/Sceptre/sceptre"


### PR DESCRIPTION
Updates to our plugins depend on a Sceptre core release, e.g. https://github.com/Sceptre/sceptre-file-resolver/pull/12#issuecomment-1865415871