### PR TITLE
bump version and update Changelog for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Categories: Added, Removed, Changed, Fixed, Nonfunctional, Deprecated
 
 ## Unreleased
 
+## 4.4.0 (2024.01.12)
+ - Add support for python 3.12 (#1390)
+ - Drop support for Python 3.7 (#1382)
+ - [Resolves #1327] Setup readthedocs (#1404)
+ - [Resolves #1377] Remove auto announcements to twitter (#1385)
+ - [Resolves #1383] Simplify stderr test for cmd hook (#1387)
+ - Remove project Makefile (#1403)
+ - docs: Update instructions to generate docs and remove requirements file for docs (#1398) (#1405)
+ - ci: use matrix for unit tests (#1395)
+
 ## 4.3.0 (2023.10.07)
  - [Resolve #1351] Add debugging to Jinja rendering (#1375)
  - [Resolves #1356] Add export=stackoutput and stackoutputexternal feature to list outputs (#1357)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sceptre"
-version = "4.3.0"
+version = "4.4.0"
 packages = [{ include = "sceptre" }]
 readme = "README.md"
 homepage = "https://github.com/Sceptre/sceptre"


### PR DESCRIPTION
Prep for a release to support python 3.12

Updates to our plugins[1] depend on a Sceptre core release with support for python 3.12 [2]

[1] PR https://github.com/Sceptre/sceptre-file-resolver/pull/12#issuecomment-1865415871
[2] PR https://github.com/Sceptre/sceptre/pull/1390

