### PR TITLE
Pushlish using pypi api token

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,10 +251,8 @@ workflows:
           requires:
             - unit-tests
           filters:
-            tags:
-              only: /^v([0-9]+)\.([0-9]+)\.([0-9]+)(?:([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?$/
             branches:
-              ignore: /.*/
+              ignore: /^pull\/.*/
       - deploy-docs-branch:
           context: sceptre-core
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ jobs:
           name: Test upload to PyPi
           command: |
             poetry config repositories.test-pypi "https://test.pypi.org/legacy/"
-            poetry publish --build -r test-pypi -u $PYPI_TEST_USER -p $PYPI_TEST_PASSWORD
+            poetry publish --build -r test-pypi -u __token__ -p $TEST_PYPI_API_TOKEN
 
   deploy-pypi-prod:
     executor: python/default
@@ -166,7 +166,7 @@ jobs:
       - checkout
       - run:
           name: Upload to PyPi
-          command: poetry publish --build -u $PYPI_PROD_USER -p $PYPI_PROD_PASSWORD
+          command: poetry publish --build -u __token__ -p $PYPI_API_TOKEN
 
   deploy-latest-dockerhub:
     executor: docker-publisher


### PR DESCRIPTION
*  Changed to publish using the API token instead of user authentication.  Got the following error when attempting to publish to pypi.
```
403 Username/Password authentication is no longer supported. Migrate to
API Tokens or Trusted Publishers instead. See https://pypi.org/help/#apitoken and
https://pypi.org/help/#trusted-publishers. Access was denied to this resource
```

* publish to pypi test was not executing.  fix so that it runs
as part of the test job in CI.
