### PR TITLE
fix deployment to dockerhub

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -113,10 +113,32 @@ jobs:
 #      - name: run tests
 #        run: poetry run behave integration-tests/features --junit --junit-directory build/behave
 
-  docker-build-push:
+  docker-build-push-latest:
     needs:
       - docker-build
-    if: ${{ (github.ref == 'refs/heads/master') || (github.ref_type == 'tag') }}
+    if: ${{ github.ref == 'refs/heads/master' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: latest
+          labels: ${{ steps.meta.outputs.labels }}
+  docker-build-push-tag:
+    needs:
+      - docker-build
+    if: ${{ github.ref_type == 'tag' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -61,7 +61,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-          cache: 'poetry'
       - name: Install Poetry
         uses: snok/install-poetry@v1
       - name: Install dependencies

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -163,7 +163,7 @@ jobs:
       - packaging
       - documentation
       - unit-tests
-      - docker-build-push
+      - docker-build-push-tag
 #      - integration-tests
     if: ${{ github.ref_type == 'tag' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,16 +56,16 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-      - name: Install dependencies
-        run: poetry install --no-interaction --all-extras
       - name: Setup Python
         id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           cache: 'poetry'
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+      - name: Install dependencies
+        run: poetry install --no-interaction --all-extras
       - name: run python tests
         run: poetry run tox -e py
       - name: run python test report


### PR DESCRIPTION
The docker metadata action returns the branch (i.e. `master`) when a
push occurs. That causes docker push to fail because there's not master
tag in the registry.  We need to change to make it push to `latest`
tag in dockerhub registry.