### PR TITLE
[Resolves #1417] Add FormattedYaml template handler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ classifiers = [
 "file" = "sceptre.template_handlers.file:File"
 "s3" = "sceptre.template_handlers.s3:S3"
 "http" = "sceptre.template_handlers.http:Http"
+"formatted_yaml" = "sceptre.template_handlers.formatted_yaml:FormattedYaml"
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/sceptre/template_handlers/formatted_yaml.py
+++ b/sceptre/template_handlers/formatted_yaml.py
@@ -1,0 +1,68 @@
+"""
+This module contains a template handler that can load files from disk and
+format the content.
+"""
+import re
+import os
+from sceptre.template_handlers.file import File
+
+
+class FormattedYaml(File):
+    """
+    Template handler that can load files from disk.
+    Supports JSON, YAML, Jinja2 and Python.
+
+    This class extends the `File` class from the
+    `sceptre.template_handlers.file` module. It provides additional
+    functionality to format YAML content by removing trailing whitespaces
+    and blank lines, adding line breaks before lines that don't start with
+    spaces, tabs, or specific prefixes, and adding a newline at the end
+    of the file.
+    """
+
+    # Class attribute for line start exceptions
+    no_newline_prefixes = ["---", "AWSTemplateFormatVersion", "Description"]
+
+    def handle(self):
+        """
+        Handles the template by returning the template contents.
+
+        Returns:
+            str or bytes: The template contents.
+        """
+        contents = super().handle()
+        if isinstance(contents, str):
+            return self._format_yaml_content(contents)
+        return contents
+
+    def _format_yaml_content(self, input_string: str) -> str:
+        """
+        Formats the input string by removing trailing whitespaces
+        and blank lines, adding a line break before every line that
+        doesn't start with spaces, tabs, or specific prefixes, and adding
+        a newline at the end of the file.
+
+        Args:
+            input_string (str): The input string that needs to be formatted.
+
+        Returns:
+            str: The formatted string.
+        """
+        # Remove trailing whitespaces and blank lines
+        result = re.sub(r"^\s*\n", "", input_string, flags=re.MULTILINE)
+        result = re.sub(r"\s+$", "", result, flags=re.MULTILINE)
+
+        # Construct the pattern for line start exceptions
+        exceptions_pattern = "|".join(
+            re.escape(prefix) for prefix in self.no_newline_prefixes
+        )  # noqa: E501  pylint: disable=line-too-long
+        pattern = r"^(?!" + exceptions_pattern + r")([^\s\t].*)$"
+
+        # Add a line break before every line that doesn't start with
+        # spaces, tabs, or specific prefixes
+        result = re.sub(pattern, r"\n\1", result, flags=re.MULTILINE)
+
+        # Add a newline at the end of the file
+        result = result + os.linesep
+
+        return result

--- a/tests/test_template_handlers/test_formatted_yaml.py
+++ b/tests/test_template_handlers/test_formatted_yaml.py
@@ -1,0 +1,186 @@
+"""Tests for src/template_handler/formatted_yaml.py"""
+from unittest.mock import patch, mock_open
+
+import pytest
+
+from sceptre.template_handlers.formatted_yaml import FormattedYaml
+
+# pylint: disable=missing-function-docstring
+
+
+@pytest.fixture(name="formatted_yaml")
+def fixture_formatted_yaml():
+    return FormattedYaml("test")
+
+
+class TestFormattedYaml:
+    """
+    TestFormattedYaml class.
+
+    This class is used for testing the functionality of the
+    FormattedYaml class.
+    """
+
+    def test_format_yaml_content__remove_trailing_whitespaces_and_blank_lines(
+        self, formatted_yaml
+    ):
+        with patch("sceptre.template_handlers.file.File.handle") as mock_handle:
+            mock_handle.return_value = "  key1: value1  \n\n  key2: value2  \n\n"
+            result = formatted_yaml.handle()
+
+        expected_result = "  key1: value1\n  key2: value2\n"
+
+        assert result == expected_result
+
+    def test_format_yaml_content__add_blank_lines(self, formatted_yaml):
+        with patch("sceptre.template_handlers.file.File.handle") as mock_handle:
+            mock_handle.return_value = "  key1: value1\n  key2: value2"
+            result = formatted_yaml.handle()
+
+        expected_result = "  key1: value1\n  key2: value2\n"
+
+        assert result == expected_result
+
+    def test_format_yaml__directives(self, formatted_yaml):
+        with patch("sceptre.template_handlers.file.File.handle") as mock_handle:
+            mock_handle.return_value = "---\nkey1: value1\nkey2: value2"
+            result = formatted_yaml.handle()
+
+        expected_result = "---\n\nkey1: value1\n\nkey2: value2\n"
+
+        assert result == expected_result
+
+    def test_format_yaml__directives__ignores_certain_fields(self, formatted_yaml):
+        with patch("sceptre.template_handlers.file.File.handle") as mock_handle:
+            mock_handle.return_value = (
+                "---\n"
+                "AWSTemplateFormatVersion: '2010-09-09'\n"
+                "Description: Foo\n"
+                "key1: value1\n"
+                "key2: value2"
+            )
+            result = formatted_yaml.handle()
+
+        expected_result = (
+            "---\n"
+            "AWSTemplateFormatVersion: '2010-09-09'\n"
+            "Description: Foo\n\n"
+            "key1: value1\n\n"
+            "key2: value2\n"
+        )
+
+        assert result == expected_result
+
+
+class TestFile:
+    """
+    TestFile class.
+
+    This class is used for testing the functionality of the underlying
+    TestFile class.
+    """
+
+    @pytest.mark.parametrize(
+        "project_path,path,output_path",
+        [
+            (
+                "my_project_dir",
+                "my.template.yaml",
+                "my_project_dir/templates/my.template.yaml",
+            ),  # NOQA
+            (
+                "/src/my_project_dir",
+                "my.template.yaml",
+                "/src/my_project_dir/templates/my.template.yaml",
+            ),  # NOQA
+            (
+                "my_project_dir",
+                "/src/my_project_dir/templates/my.template.yaml",
+                "/src/my_project_dir/templates/my.template.yaml",
+            ),  # NOQA
+            (
+                "/src/my_project_dir",
+                "/src/my_project_dir/templates/my.template.yaml",
+                "/src/my_project_dir/templates/my.template.yaml",
+            ),  # NOQA
+        ],
+    )
+    @patch("builtins.open", new_callable=mock_open, read_data="some_data")
+    def test_handler_open(self, mocked_open, project_path, path, output_path):
+        template_handler = FormattedYaml(
+            name="file_handler",
+            arguments={"path": path},
+            stack_group_config={"project_path": project_path},
+        )
+        template_handler.handle()
+        mocked_open.assert_called_with(output_path)
+
+    @pytest.mark.parametrize(
+        "project_path,path,output_path",
+        [
+            (
+                "my_project_dir",
+                "my.template.yaml.j2",
+                "my_project_dir/templates/my.template.yaml.j2",
+            ),  # NOQA
+            (
+                "/src/my_project_dir",
+                "my.template.yaml.j2",
+                "/src/my_project_dir/templates/my.template.yaml.j2",
+            ),  # NOQA
+            (
+                "my_project_dir",
+                "/src/my_project_dir/templates/my.template.yaml.j2",
+                "/src/my_project_dir/templates/my.template.yaml.j2",
+            ),  # NOQA
+            (
+                "/src/my_project_dir",
+                "/src/my_project_dir/templates/my.template.yaml.j2",
+                "/src/my_project_dir/templates/my.template.yaml.j2",
+            ),  # NOQA
+        ],
+    )
+    @patch("sceptre.template_handlers.helper.render_jinja_template")
+    def test_handler_render(self, mocked_render, project_path, path, output_path):
+        template_handler = FormattedYaml(
+            name="file_handler",
+            arguments={"path": path},
+            stack_group_config={"project_path": project_path},
+        )
+        template_handler.handle()
+        mocked_render.assert_called_with(output_path, {"sceptre_user_data": None}, {})
+
+    @pytest.mark.parametrize(
+        "project_path,path,output_path",
+        [
+            (
+                "my_project_dir",
+                "my.template.yaml.py",
+                "my_project_dir/templates/my.template.yaml.py",
+            ),  # NOQA
+            (
+                "/src/my_project_dir",
+                "my.template.yaml.py",
+                "/src/my_project_dir/templates/my.template.yaml.py",
+            ),  # NOQA
+            (
+                "my_project_dir",
+                "/src/my_project_dir/templates/my.template.yaml.py",
+                "/src/my_project_dir/templates/my.template.yaml.py",
+            ),  # NOQA
+            (
+                "/src/my_project_dir",
+                "/src/my_project_dir/templates/my.template.yaml.py",
+                "/src/my_project_dir/templates/my.template.yaml.py",
+            ),  # NOQA
+        ],
+    )
+    @patch("sceptre.template_handlers.helper.call_sceptre_handler")
+    def test_handler_handler(self, mocked_handler, project_path, path, output_path):
+        template_handler = FormattedYaml(
+            name="file_handler",
+            arguments={"path": path},
+            stack_group_config={"project_path": project_path},
+        )
+        template_handler.handle()
+        mocked_handler.assert_called_with(output_path, None)


### PR DESCRIPTION
This adds the `formatted_yaml` template handler that subclasses the `file` template handler to reformat the YAML in a clean and standard way.

Note that this feature was written by @mrowlingfox  

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`poetry run tox`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`poetry run pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
