### PR TITLE
Fix integration tests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,6 +27,7 @@ jobs:
         run: poetry install --no-interaction --all-extras
       - name: run pre-commit
         run: poetry run pre-commit run --all-files --show-diff-on-failure
+
   packaging:
     runs-on: ubuntu-latest
     steps:
@@ -37,6 +38,7 @@ jobs:
         run: poetry install --no-interaction --all-extras
       - name: build package
         run: poetry build
+
   documentation:
     runs-on: ubuntu-latest
     steps:
@@ -47,6 +49,7 @@ jobs:
         run: poetry install --no-interaction --all-extras
       - name: build documentation
         run: poetry run make html --directory docs
+
   unit-tests:
     runs-on: ubuntu-latest
     strategy:
@@ -69,6 +72,7 @@ jobs:
         run: poetry run tox -e py
       - name: run python test report
         run: poetry run tox -e report
+
   docker-build:
     runs-on: ubuntu-latest
     steps:
@@ -78,6 +82,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+
   integration-tests:
     needs:
       - linting
@@ -112,7 +117,10 @@ jobs:
           role-session-name: GHA-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
           role-duration-seconds: ${{ env.AWS_ROLE_DURATION }}
       - name: run tests
-        run: AWS_DEFAULT_REGION=eu-west-1 poetry run behave integration-tests/features --junit --junit-directory build/behave
+        run: poetry run behave integration-tests/features --junit --junit-directory build/behave
+        env:
+          AWS_DEFAULT_REGION: eu-west-1
+
   docker-build-push:
     needs:
       - integration-tests
@@ -136,6 +144,7 @@ jobs:
           push: true
           tags: sceptreorg/sceptre:edge
           labels: ${{ steps.meta.outputs.labels }}
+
   docker-build-release:
     if: ${{ github.ref_type == 'tag' }}
     runs-on: ubuntu-latest
@@ -164,6 +173,7 @@ jobs:
           push: true
           tags: sceptreorg/sceptre:${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
   pypi-release:
     if: ${{ github.ref_type == 'tag' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -128,12 +128,13 @@ jobs:
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
+      # docker convention: edge tag refers to the very latest code
       - name: Build and push Docker image to sceptreorg/sceptre:${{ steps.meta.outputs.tags }}
         uses: docker/build-push-action@v5
         with:
           context: .
           push: true
-          tags: sceptreorg/sceptre:${{ steps.meta.outputs.tags }}
+          tags: sceptreorg/sceptre:edge
           labels: ${{ steps.meta.outputs.labels }}
   docker-build-release:
     if: ${{ github.ref_type == 'tag' }}
@@ -148,6 +149,7 @@ jobs:
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
+      # docker convention: latest tag refers to the last stable release
       - name: Build and push Docker image to sceptreorg/sceptre:latest
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,12 +9,12 @@ env:
 on:
   push:
     branches:
-      - 'master'
+      - '*'
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+([0-9]+)'
   pull_request:
     branches:
-      - 'master'
+      - '*'
 
 jobs:
   linting:
@@ -78,45 +78,45 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-
-# temporarily comment out to get GH action into place.  Will fix tests on a follow on PR.
-# https://github.com/Sceptre/sceptre/pull/1412#discussion_r1452566731
-#  integration-tests:
-#    needs:
-#      - unit-tests
-#    if: ${{ github.event_name != 'pull_request' }}
-#    runs-on: ubuntu-latest
-#    permissions:
-#      id-token: write
-#    steps:
-#      - uses: actions/checkout@v4
-#      - name: Install Poetry
-#        uses: snok/install-poetry@v1
-#      - name: Install dependencies
-#        run: poetry install --no-interaction --all-extras
-#      # Update poetry for https://github.com/python-poetry/poetry/issues/7184
-#      - name: update poetry
-#        run: poetry self update --no-ansi
-#      - name: Setup Python
-#        id: setup-python
-#        uses: actions/setup-python@v5
-#        with:
-#          python-version: '3.10'
-#          cache: 'poetry'
-#      - name: Assume AWS role
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          aws-region: ${{ env.AWS_REGION }}
-#          role-to-assume: ${{ env.AWS_ROLE }}
-#          role-session-name: GHA-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
-#          role-duration-seconds: ${{ env.AWS_ROLE_DURATION }}
-#      - name: run tests
-#        run: poetry run behave integration-tests/features --junit --junit-directory build/behave
-
+  integration-tests:
+    needs:
+      - linting
+      - packaging
+      - documentation
+      - unit-tests
+      - docker-build
+    if: ${{ github.ref_type == 'push' }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+      - name: Install dependencies
+        run: poetry install --no-interaction --all-extras
+      # Update poetry for https://github.com/python-poetry/poetry/issues/7184
+      - name: update poetry
+        run: poetry self update --no-ansi
+      - name: Setup Python
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: 'poetry'
+      - name: Assume AWS role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ env.AWS_ROLE }}
+          role-session-name: GHA-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+          role-duration-seconds: ${{ env.AWS_ROLE_DURATION }}
+      - name: run tests
+        run: AWS_DEFAULT_REGION=eu-west-1 poetry run behave integration-tests/features --junit --junit-directory build/behave
   docker-build-push:
     needs:
-      - docker-build
-    if: ${{ github.ref == 'refs/heads/master' }}
+      - integration-tests
+    if: ${{ (github.ref_type == 'push') && (github.ref == 'refs/heads/master') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -136,13 +136,6 @@ jobs:
           tags: sceptreorg/sceptre:${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
   docker-build-release:
-    needs:
-      - linting
-      - packaging
-      - documentation
-      - unit-tests
-      - docker-build
-#      - integration-tests
     if: ${{ github.ref_type == 'tag' }}
     runs-on: ubuntu-latest
     steps:
@@ -170,13 +163,6 @@ jobs:
           tags: sceptreorg/sceptre:${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
   pypi-release:
-    needs:
-      - linting
-      - packaging
-      - documentation
-      - unit-tests
-      - docker-build
-#      - integration-tests
     if: ${{ github.ref_type == 'tag' }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
* The integration tests were failing because it wasn't being run against the eu-west region.  The CONTRIBUTING.md[1] docs clearly state the the tests are setup to run in eu-west-* region.
* Update the CI workflow to trigger integration tests only after all other tests have completed and passed.
* Trigger build on any branch to allow admins to trigger an integration-tests job when pushing branches.
* Update docker tags.  I've heard that the docker convention for tags is `latest` tag refers to the latest stable release and `edge` tag refers to the latest code. 

[1] https://github.com/Sceptre/sceptre/blob/master/CONTRIBUTING.md#integration-tests

