### PR TITLE
Remove an external resolver integration test

### DIFF
--- a/integration-tests/features/stack-output-external-resolver.feature
+++ b/integration-tests/features/stack-output-external-resolver.feature
@@ -1,12 +1,5 @@
 Feature: Stack output external resolver
 
-# The CI changed to using Github OIDC therefore testing the use of profiles will no longer work
-#  Scenario: launch a stack referencing the external output of an existing stack with region and profile
-#    Given stack "external-stack-output/outputter" exists using "dependencies/independent_template.json"
-#    And stack "external-stack-output/resolver-with-profile-region" does not exist
-#    When the user launches stack "external-stack-output/resolver-with-profile-region"
-#    Then stack "external-stack-output/resolver-with-profile-region" exists in "CREATE_COMPLETE" state
-
   Scenario: launch a stack referencing the external output of an existing stack without explicit region or profile
     Given stack "external-stack-output/outputter" exists using "dependencies/independent_template.json"
     And stack "external-stack-output/resolver-no-profile-region" does not exist

--- a/integration-tests/features/stack-output-external-resolver.feature
+++ b/integration-tests/features/stack-output-external-resolver.feature
@@ -8,7 +8,7 @@ Feature: Stack output external resolver
 #    Then stack "external-stack-output/resolver-with-profile-region" exists in "CREATE_COMPLETE" state
 
   Scenario: launch a stack referencing the external output of an existing stack without explicit region or profile
-    Given stack "external-stack-output-stack-output/outputter" exists using "dependencies/independent_template.json"
+    Given stack "external-stack-output/outputter" exists using "dependencies/independent_template.json"
     And stack "external-stack-output/resolver-no-profile-region" does not exist
     When the user launches stack "external-stack-output/resolver-no-profile-region"
     Then stack "external-stack-output/resolver-no-profile-region" exists in "CREATE_COMPLETE" state

--- a/integration-tests/features/stack-output-external-resolver.feature
+++ b/integration-tests/features/stack-output-external-resolver.feature
@@ -1,10 +1,11 @@
 Feature: Stack output external resolver
 
-  Scenario: launch a stack referencing the external output of an existing stack with region and profile
-    Given stack "external-stack-output/outputter" exists using "dependencies/independent_template.json"
-    And stack "external-stack-output/resolver-with-profile-region" does not exist
-    When the user launches stack "external-stack-output/resolver-with-profile-region"
-    Then stack "external-stack-output/resolver-with-profile-region" exists in "CREATE_COMPLETE" state
+# The CI changed to using Github OIDC therefore testing the use of profiles will no longer work
+#  Scenario: launch a stack referencing the external output of an existing stack with region and profile
+#    Given stack "external-stack-output/outputter" exists using "dependencies/independent_template.json"
+#    And stack "external-stack-output/resolver-with-profile-region" does not exist
+#    When the user launches stack "external-stack-output/resolver-with-profile-region"
+#    Then stack "external-stack-output/resolver-with-profile-region" exists in "CREATE_COMPLETE" state
 
   Scenario: launch a stack referencing the external output of an existing stack without explicit region or profile
     Given stack "external-stack-output-stack-output/outputter" exists using "dependencies/independent_template.json"

--- a/integration-tests/sceptre-project/config/external-stack-output/resolver-with-profile-region.yaml
+++ b/integration-tests/sceptre-project/config/external-stack-output/resolver-with-profile-region.yaml
@@ -1,6 +1,0 @@
-template:
-  path: dependencies/dependent_template_local_export.json
-
-
-parameters:
-  DependentStackName: !stack_output_external "{{project_code}}-external-stack-output-outputter::StackName {{environment_variable.AWS_PROFILE|default('default')}}::eu-west-1"


### PR DESCRIPTION
An AWS profile was used to run integration tests in circleci.  We have moved to github actions and we've also moved to using GH OIDC instead of an AWS profile.  A test that validates the use of a profile was passing in circleci but is now failing in GH actions.  Since we no longer use a profile we cannot run tests to validate the usage of profiles therefore it has been removed.
