### PR TITLE
reconfigure pre-commit validation

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,17 +17,6 @@ on:
       - '*'
 
 jobs:
-  linting:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-      - name: Install dependencies
-        run: poetry install --no-interaction --all-extras
-      - name: run pre-commit
-        run: poetry run pre-commit run --all-files --show-diff-on-failure
-
   packaging:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We have setup pre-commit.ci[1] to offload the execution of pre-commit. This is supposed to be faster and easier to maintaine than running it with GH actions.

[1] https://pre-commit.ci/

