### PR TITLE
CI: Remove install dependencies step

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,8 +23,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Poetry
         uses: snok/install-poetry@v1
-      - name: Install dependencies
-        run: poetry install --no-interaction --all-extras
       - name: build package
         run: poetry build
 
@@ -185,7 +183,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Poetry
         uses: snok/install-poetry@v1
-      - name: Install dependencies
-        run: poetry install --no-interaction --all-extras
       - name: Publish to pypi
         run: poetry publish --build -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
CI jobs that build python packages do not require a step to install poetry dependencies