### PR TITLE
CI: add integration test workflow

### DIFF
--- a/.github/workflows/comment-integration-tests.yaml
+++ b/.github/workflows/comment-integration-tests.yaml
@@ -1,0 +1,12 @@
+name: comment-integration-tests
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  integration-tests:
+    if: ${{ contains(github.event.review.body, '/integration-tests') }}
+    uses: "./.github/workflows/integration-tests.yaml"
+    with:
+      role-to-assume: "arn:aws:iam::743644221192:role/gh-oidc-sceptre-tests"

--- a/.github/workflows/comment-integration-tests.yaml
+++ b/.github/workflows/comment-integration-tests.yaml
@@ -9,4 +9,5 @@ jobs:
     if: ${{ contains(github.event.review.body, '/integration-tests') }}
     uses: "./.github/workflows/integration-tests.yaml"
     with:
+      # role generated from https://github.com/Sceptre/sceptre-aws/blob/master/config/prod/gh-oidc-sceptre-tests.yaml
       role-to-assume: "arn:aws:iam::743644221192:role/gh-oidc-sceptre-tests"

--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -14,6 +14,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: "./.github/workflows/integration-tests.yaml"
     with:
+      # role generated from https://github.com/Sceptre/sceptre-aws/blob/master/config/prod/gh-oidc-sceptre-tests.yaml
       role-to-assume: "arn:aws:iam::743644221192:role/gh-oidc-sceptre-tests"
 
   docker-build-push:

--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -1,11 +1,5 @@
 name: gate
 
-env:
-  AWS_REGION: us-east-1
-  AWS_ROLE_DURATION: 3600
-  # role generated from https://github.com/Sceptre/sceptre-aws/blob/master/config/prod/gh-oidc-sceptre-tests.yaml
-  AWS_ROLE: arn:aws:iam::743644221192:role/gh-oidc-sceptre-tests
-
 on:
   workflow_run:
     workflows:
@@ -18,38 +12,9 @@ on:
 jobs:
   integration-tests:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: false
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-      - name: Install dependencies
-        run: poetry install --no-interaction --all-extras
-      # Update poetry for https://github.com/python-poetry/poetry/issues/7184
-      - name: update poetry
-        run: poetry self update --no-ansi
-      - name: Setup Python
-        id: setup-python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-          cache: 'poetry'
-      - name: Assume AWS role
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: ${{ env.AWS_REGION }}
-          role-to-assume: ${{ env.AWS_ROLE }}
-          role-session-name: GHA-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
-          role-duration-seconds: ${{ env.AWS_ROLE_DURATION }}
-      - name: run tests
-        run: poetry run behave integration-tests/features --junit --junit-directory build/behave
-        env:
-          AWS_DEFAULT_REGION: eu-west-1
+    uses: "./.github/workflows/integration-tests.yaml"
+    with:
+      role-to-assume: "arn:aws:iam::743644221192:role/gh-oidc-sceptre-tests"
 
   docker-build-push:
     needs:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,0 +1,49 @@
+name: integration-tests
+
+on:
+  workflow_call:
+    inputs:
+      aws-region:
+        type: string
+        default: us-east-1
+      role-to-assume:
+        required: true
+        type: string
+      role-duration-seconds:
+        type: number
+        default: 3600
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+      - name: Install dependencies
+        run: poetry install --no-interaction --all-extras
+      # Update poetry for https://github.com/python-poetry/poetry/issues/7184
+      - name: update poetry
+        run: poetry self update --no-ansi
+      - name: Setup Python
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: 'poetry'
+      - name: Assume AWS role
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ inputs.aws-region }}
+          role-to-assume: ${{ inputs.role-to-assume }}
+          role-session-name: GHA-${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
+          role-duration-seconds: ${{ inputs.role-duration-seconds }}
+      - name: run tests
+        run: poetry run behave integration-tests/features --junit --junit-directory build/behave
+        env:
+          AWS_DEFAULT_REGION: eu-west-1


### PR DESCRIPTION
Setup a workflow to trigger an integration test run from a review comment.

Integration tests take a long time to complete therefore it is typically only run as a final check before merging to the master branch.

The idea is to allow users to trigger an integration test run only after all other tests have passed AND a human review approval has been provided. Adding an `/integration-tests` string to a PR review will trigger the integration test run.
