### PR TITLE
stop duplicate gate workflow runs

### DIFF
--- a/.github/workflows/branch-integration-tests.yaml
+++ b/.github/workflows/branch-integration-tests.yaml
@@ -1,0 +1,14 @@
+name: branch-integration-tests
+
+on:
+  push:
+    branches:
+      - '*'
+
+jobs:
+  integration-tests:
+    if: ${{ github.ref != 'refs/heads/master' }}
+    uses: "./.github/workflows/integration-tests.yaml"
+    with:
+      # role generated from https://github.com/Sceptre/sceptre-aws/blob/master/config/prod/gh-oidc-sceptre-tests.yaml
+      role-to-assume: "arn:aws:iam::743644221192:role/gh-oidc-sceptre-tests"

--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -7,7 +7,7 @@ on:
     types:
       - completed
     branches:
-      - '*'
+      - master
 
 jobs:
   integration-tests:


### PR DESCRIPTION
The integration tests is triggered twice on force pushes to master. We only want it to run once.

* trigger integration tests on merges to master branch
* trigger integration tests on creation of branches from PRs
* do not trigger integration tests twice
