### PR TITLE
[Resolve #1443] Add parameter type checking

### DIFF
--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -286,7 +286,10 @@ class Stack:
                 isinstance(value, str)
                 or (
                     isinstance(value, list)
-                    and all(isinstance(item, str) for item in value)
+                    and all(
+                        isinstance(item, str) or isinstance(item, Resolver)
+                        for item in value
+                    )
                 )
                 or isinstance(value, Resolver)
             )

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -278,7 +278,7 @@ class Stack:
 
     def _ensure_parameters(
         self, parameters: Dict[str, Any]
-    ) -> Dict[str, Union[str, List[str], Resolver]]:
+    ) -> Dict[str, Union[str, List[Union[str, Resolver]], Resolver]]:
         """Ensure CloudFormation parameters are of valid types"""
 
         def is_valid(value: Any) -> bool:

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -9,7 +9,7 @@ This module implements a Stack class, which stores a Stack's data.
 
 import logging
 
-from typing import List, Any, Optional
+from typing import List, Dict, Any, Optional
 from deprecation import deprecated
 
 from sceptre import __version__
@@ -262,7 +262,7 @@ class Stack:
         )
 
         self.s3_details = s3_details
-        self.parameters = parameters or {}
+        self.parameters = self._ensure_parameters(parameters or {})
         self.sceptre_user_data = sceptre_user_data or {}
         self.notifications = notifications or []
 
@@ -274,6 +274,13 @@ class Stack:
                 f"{self.name}: Value for {config_name} must be a boolean, not a {type(value).__name__}"
             )
         return value
+
+    def _ensure_parameters(self, parameters: Dict[str, Any]) -> Dict[str, str]:
+        if not all(isinstance(value, str) for value in parameters.values()):
+            raise InvalidConfigFileError(
+                f"{self.name}: Values for parameters must be strings, got {parameters}"
+            )
+        return parameters
 
     def __repr__(self):
         return (

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -9,7 +9,7 @@ This module implements a Stack class, which stores a Stack's data.
 
 import logging
 
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Union, Any, Optional
 from deprecation import deprecated
 
 from sceptre import __version__
@@ -26,6 +26,7 @@ from sceptre.resolvers import (
     ResolvableValueProperty,
     RecursiveResolve,
     PlaceholderType,
+    Resolver,
 )
 from sceptre.template import Template
 
@@ -275,10 +276,24 @@ class Stack:
             )
         return value
 
-    def _ensure_parameters(self, parameters: Dict[str, Any]) -> Dict[str, str]:
-        if not all(isinstance(value, str) for value in parameters.values()):
+    def _ensure_parameters(
+        self, parameters: Dict[str, Any]
+    ) -> Dict[str, Union[str, List[str], Resolver]]:
+        """Ensure CloudFormation parameters are of valid types"""
+
+        def is_valid(value: Any) -> bool:
+            return (
+                isinstance(value, str)
+                or (
+                    isinstance(value, list)
+                    and all(isinstance(item, str) for item in value)
+                )
+                or isinstance(value, Resolver)
+            )
+
+        if not all(is_valid(value) for value in parameters.values()):
             raise InvalidConfigFileError(
-                f"{self.name}: Values for parameters must be strings, got {parameters}"
+                f"{self.name}: Values for parameters must be strings, lists or resolvers, got {parameters}"
             )
         return parameters
 

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -218,7 +218,7 @@ class TestStack(object):
             region="region",
             parameters=parameters,
         )
-        assert stack.name == "stack_name"
+        assert isinstance(stack, Stack)
 
     def test_stack_repr(self):
         assert (

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -198,7 +198,7 @@ class TestStack(object):
 
     @pytest.mark.parametrize(
         "parameters",
-        [{"someNum": "1"}, {"someBool": "true"}, {"aBadList": ["1", "2", "3"]}],
+        [{"someNum": "1"}, {"someBool": "true"}, {"aList": ["1", "2", "3"]}],
     )
     def test_init__valid_types(self, parameters):
         stack = Stack(

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -40,6 +40,11 @@ def stack_factory(**kwargs):
     return Stack(**call_kwargs)
 
 
+class FakeResolver(Resolver):
+    def resolve(self):
+        return "Fake"
+
+
 class TestStack(object):
     def setup_method(self, test_method):
         self.stack = Stack(
@@ -198,7 +203,12 @@ class TestStack(object):
 
     @pytest.mark.parametrize(
         "parameters",
-        [{"someNum": "1"}, {"someBool": "true"}, {"aList": ["1", "2", "3"]}],
+        [
+            {"someNum": "1"},
+            {"someBool": "true"},
+            {"aList": ["aString", FakeResolver()]},
+            {"aResolver": FakeResolver()},
+        ],
     )
     def test_init__valid_types(self, parameters):
         stack = Stack(
@@ -275,14 +285,10 @@ class TestStack(object):
     def test_configuration_manager__sceptre_role_returns_value__returns_connection_manager_with_that_role(
         self,
     ):
-        class FakeResolver(Resolver):
-            def resolve(self):
-                return "role"
-
         self.stack.sceptre_role = FakeResolver()
 
         connection_manager = self.stack.connection_manager
-        assert connection_manager.sceptre_role == "role"
+        assert connection_manager.sceptre_role == "Fake"
 
     @fail_if_not_removed
     def test_iam_role__is_removed_on_removal_version(self):

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -191,7 +191,7 @@ class TestStack(object):
     @pytest.mark.parametrize(
         "parameters", [{"someNum": 1}, {"someBool": True}, {"aBadList": [1, 2, 3]}]
     )
-    def test_init__invalid_types_raise_invalid_config_file_error(self, parameters):
+    def test_init__invalid_parameters_raise_invalid_config_file_error(self, parameters):
         with pytest.raises(InvalidConfigFileError):
             Stack(
                 name="stack_name",
@@ -210,7 +210,7 @@ class TestStack(object):
             {"aResolver": FakeResolver()},
         ],
     )
-    def test_init__valid_types(self, parameters):
+    def test_init__valid_parameters_do_not(self, parameters):
         stack = Stack(
             name="stack_name",
             project_code="project_code",

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -183,11 +183,9 @@ class TestStack(object):
                 obsolete="true",
             )
 
-    @pytest.mark.parametrize("parameters", [
-        {"someNum": 1},
-        {"someBool": True},
-        {"aBadList": [1, 2, 3]}
-    ])
+    @pytest.mark.parametrize(
+        "parameters", [{"someNum": 1}, {"someBool": True}, {"aBadList": [1, 2, 3]}]
+    )
     def test_init__invalid_types_raise_invalid_config_file_error(self, parameters):
         with pytest.raises(InvalidConfigFileError):
             Stack(
@@ -195,21 +193,20 @@ class TestStack(object):
                 project_code="project_code",
                 template_handler_config={"type": "file"},
                 region="region",
-                parameters=parameters
+                parameters=parameters,
             )
 
-    @pytest.mark.parametrize("parameters", [
-        {"someNum": "1"},
-        {"someBool": "true"},
-        {"aBadList": ["1", "2", "3"]}
-    ])
+    @pytest.mark.parametrize(
+        "parameters",
+        [{"someNum": "1"}, {"someBool": "true"}, {"aBadList": ["1", "2", "3"]}],
+    )
     def test_init__valid_types(self, parameters):
         stack = Stack(
             name="stack_name",
             project_code="project_code",
             template_handler_config={"type": "file"},
             region="region",
-            parameters=parameters
+            parameters=parameters,
         )
         assert stack.name == "stack_name"
 

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -189,7 +189,13 @@ class TestStack(object):
             )
 
     @pytest.mark.parametrize(
-        "parameters", [{"someNum": 1}, {"someBool": True}, {"aBadList": [1, 2, 3]}]
+        "parameters",
+        [
+            {"someNum": 1},
+            {"someBool": True},
+            {"aBadList": [1, 2, 3]},
+            {"aDict": {"foo": "bar"}},
+        ],
     )
     def test_init__invalid_parameters_raise_invalid_config_file_error(self, parameters):
         with pytest.raises(InvalidConfigFileError):
@@ -210,7 +216,9 @@ class TestStack(object):
             {"aResolver": FakeResolver()},
         ],
     )
-    def test_init__valid_parameters_do_not(self, parameters):
+    def test_init__valid_parameters_do_not_raise_invalid_config_file_error(
+        self, parameters
+    ):
         stack = Stack(
             name="stack_name",
             project_code="project_code",

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -183,6 +183,36 @@ class TestStack(object):
                 obsolete="true",
             )
 
+    @pytest.mark.parametrize("parameters", [
+        {"someNum": 1},
+        {"someBool": True},
+        {"aBadList": [1, 2, 3]}
+    ])
+    def test_init__invalid_types_raise_invalid_config_file_error(self, parameters):
+        with pytest.raises(InvalidConfigFileError):
+            Stack(
+                name="stack_name",
+                project_code="project_code",
+                template_handler_config={"type": "file"},
+                region="region",
+                parameters=parameters
+            )
+
+    @pytest.mark.parametrize("parameters", [
+        {"someNum": "1"},
+        {"someBool": "true"},
+        {"aBadList": ["1", "2", "3"]}
+    ])
+    def test_init__valid_types(self, parameters):
+        stack = Stack(
+            name="stack_name",
+            project_code="project_code",
+            template_handler_config={"type": "file"},
+            region="region",
+            parameters=parameters
+        )
+        assert stack.name == "stack_name"
+
     def test_stack_repr(self):
         assert (
             self.stack.__repr__() == "sceptre.stack.Stack("


### PR DESCRIPTION
For historical reasons, Sceptre has never validated Stack config [parameters](https://docs.sceptre-project.org/latest/docs/stack_config.html#parameters) that are passed in to CloudFormation stack parameters. Blocks that contain bools, ints etc give rise to confusing failures. For example:

```yaml
parameters:
  someBool: true
```

Would lead to an error appearing like:

```
"Parameter validation failed:\nInvalid type for parameter Parameters[0].ParameterValue, value: 1, type: <class 'bool'>, valid types: <class 'str'>"  
```
In more complicated examples it is often quite unclear what Parameter[0] means.

A feature here is added at the time of Stack instantiation to perform validation of the input stack parameters in a similar manner to how the ignore and obsolete settings were already being checked.

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`poetry run tox`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`poetry run pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
