### PR TITLE
[Resolve #1446] Print edges in cyclical dependency

### DIFF
--- a/sceptre/config/graph.py
+++ b/sceptre/config/graph.py
@@ -90,14 +90,18 @@ class StackGraph(object):
         :param stack: A Sceptre Stack
         :param dependencies: a collection of dependency paths
         """
-        self.logger.debug("Generate dependencies for stack {0}".format(stack))
+        self.logger.debug(f"Generate dependencies for stack {stack}")
         for dependency in set(dependencies):
             self.graph.add_edge(dependency, stack)
-            if not nx.is_directed_acyclic_graph(self.graph):
+            try:
+                cycle = nx.find_cycle(self.graph, orientation="original")
+                cycle_str = ", ".join([f"{edge[0]} -> {edge[1]}" for edge in cycle])
                 raise CircularDependenciesError(
-                    f"Dependency cycle detected: {stack} {dependency}"
+                    f"Dependency cycle detected: {cycle_str}"
                 )
-            self.logger.debug("  Added dependency: {}".format(dependency))
+            except nx.NetworkXNoCycle:
+                pass  # No cycle, continue
+            self.logger.debug(f"  Added dependency: {dependency}")
 
         if not dependencies:
             self.graph.add_node(stack)


### PR DESCRIPTION
This adds some code to print a clearer error message similar to Terraform's when a cyclical dependency is detected in the graph.

Before this change an error message would look like:
```
Dependency cycle detected: configmap-lambda eks-securitygroups
```

After this change it becomes:
```
Dependency cycle detected: eks-securitygroups -> configmap-lambda, configmap-lambda -> eks-securitygroups
```

An example of a Terraform error message would be:
```
Error: Cycle: aws_scheduler_schedule.gh_runners_ubuntu_stop, aws_iam_role.gh_runners_ubuntu_scheduler_role, aws_scheduler_schedule.gh_runners_ubuntu_start
```

And for comparison see this related section of the source code for Terraform:
https://github.com/hashicorp/terraform/blob/268c8e264d22604f2a4ec516ed4df7a5bdef421f/internal/dag/dag.go#L117-L148

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`poetry run tox`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`poetry run pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
