### PR TITLE
[Resolve #1464] Display launch order

### DIFF
--- a/sceptre/cli/launch.py
+++ b/sceptre/cli/launch.py
@@ -90,6 +90,30 @@ class Launcher:
             pruner = self._make_pruner(self._context, self._make_plan)
             pruner.print_operations()
 
+        dependencies = ""
+        for stack in deploy_plan:
+            if stack.ignore or (stack.obsolete and not prune):
+                dependencies += "{}Skip:\t{}{}\n".format(
+                    Fore.LIGHTWHITE_EX,
+                    stack.name,
+                    Style.RESET_ALL,
+                )
+            elif stack.obsolete and prune:
+                dependencies += "{}Delete:\t{}{}\n".format(
+                    Fore.RED,
+                    stack.name,
+                    Style.RESET_ALL,
+                )
+            else:
+                dependencies += "{}Deploy:\t{}{}\n".format(
+                    Fore.YELLOW,
+                    stack.name,
+                    Style.RESET_ALL,
+                )
+
+        print("The following operations will occur, in the following order:")
+        print(dependencies)
+
     def launch(self, prune: bool) -> int:
         deploy_plan = self._create_deploy_plan()
         stacks_to_skip = self._get_stacks_to_skip(deploy_plan, prune)


### PR DESCRIPTION
Resolves #1464.

<img width="547" alt="image" src="https://github.com/Sceptre/sceptre/assets/99300636/7d71e2d3-aa92-428f-aa6b-a8ef974762b7">

## PR Checklist

- [X] Wrote a good commit message & description [see guide below].
- [X] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [X] All unit tests (`poetry run tox`) are passing.
- [X] Used the same coding conventions as the rest of the project.
- [X] The new code passes pre-commit validations (`poetry run pre-commit run --all-files`).
- [X] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
