### PR TITLE
Fix broken build caused by pre-commit bot

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/awslabs/cfn-python-lint
-    rev: v1.2.5a9
+    rev: v0.86.4
     hooks:
       - id: cfn-python-lint
         args:
@@ -47,7 +47,7 @@ repos:
         language_version: python3.10
         args: ['--check']
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.28.4
+    rev: 0.28.2
     hooks:
       - id: check-github-workflows
       - id: check-github-actions

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: yamllint
   - repo: https://github.com/awslabs/cfn-python-lint
-    rev: v0.86.4
+    rev: v1.2.5a9
     hooks:
       - id: cfn-python-lint
         args:
@@ -47,7 +47,7 @@ repos:
         language_version: python3.10
         args: ['--check']
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 0.28.2
+    rev: 0.28.4
     hooks:
       - id: check-github-workflows
       - id: check-github-actions

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         exclude: |
           (?x)(
             ^integration-tests/sceptre-project/config/|
-            ^integration-tests/sceptre-project/templates/jinja/|
+            ^integration-tests/sceptre-project/templates/|
             ^tests/fixtures-vpc/config/|
             ^tests/fixtures/config/|
             ^temp/|

--- a/README.md
+++ b/README.md
@@ -282,3 +282,4 @@ See our [Contributing Guide](CONTRIBUTING.md)
 [![GoDaddy](sponsors/godaddy_logo.png "GoDaddy")](https://www.godaddy.com)
 
 [![Cloudreach](sponsors/cloudreach_logo.png "Cloudreach")](https://www.cloudreach.com)
+

--- a/README.md
+++ b/README.md
@@ -282,4 +282,3 @@ See our [Contributing Guide](CONTRIBUTING.md)
 [![GoDaddy](sponsors/godaddy_logo.png "GoDaddy")](https://www.godaddy.com)
 
 [![Cloudreach](sponsors/cloudreach_logo.png "Cloudreach")](https://www.cloudreach.com)
-


### PR DESCRIPTION
The pre-commit bot added 906005d36c9b773894c075203b898f42988e229f which broke the build. Root cause is the lastest version of the CFN Lint emits errors about some of the integration test CloudFormation code. This tweaks the linter config to ignore these files. 

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`poetry run tox`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`poetry run pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
