### PR TITLE
[Resolve #1484] Gracefully handle invalid parameters

### DIFF
--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -305,6 +305,11 @@ class Stack:
                 or isinstance(value, Resolver)
             )
 
+        if not isinstance(parameters, dict):
+            raise InvalidConfigFileError(
+                f"{self.name}: parameters must be a dictionary of key-value apirs, got {parameters}"
+            )
+
         casted_parameters = {k: cast_value(v) for k, v in parameters.items()}
 
         if not all(is_valid(value) for value in casted_parameters.values()):

--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -307,7 +307,7 @@ class Stack:
 
         if not isinstance(parameters, dict):
             raise InvalidConfigFileError(
-                f"{self.name}: parameters must be a dictionary of key-value apirs, got {parameters}"
+                f"{self.name}: parameters must be a dictionary of key-value pairs, got {parameters}"
             )
 
         casted_parameters = {k: cast_value(v) for k, v in parameters.items()}

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -204,6 +204,20 @@ class TestStack(object):
 
     @pytest.mark.parametrize(
         "parameters",
+        [["this", "is", "a", "list"], "a_string"],
+    )
+    def test_init__invalid_parameters__parameters_a_list(self, parameters):
+        with pytest.raises(InvalidConfigFileError):
+            Stack(
+                name="stack_name",
+                project_code="project_code",
+                template_handler_config={"type": "file"},
+                region="region",
+                parameters=parameters,
+            )
+
+    @pytest.mark.parametrize(
+        "parameters",
         [
             {"IntAsString": "1"},
             {"Int": 1},


### PR DESCRIPTION
This adds logic to `_cast_parameters` to also handle the case that the `parameters` dict itself is not a dict but some other invalid type.


## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [x] Added/Updated unit tests.
- [x] Added/Updated integration tests (if applicable).
- [x] All unit tests (`poetry run tox`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`poetry run pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
