### PR TITLE
[Resolve #1483] Handle errors in change sets

### DIFF
--- a/integration-tests/features/describe-change-set.feature
+++ b/integration-tests/features/describe-change-set.feature
@@ -10,8 +10,7 @@ Feature: Describe change sets
     Given stack "1/A" exists in "CREATE_COMPLETE" state
     and stack "1/A" has no change sets
     When the user describes change set "A" for stack "1/A"
-    Then a "ClientError" is raised
-    and the user is told "change set does not exist"
+    Then the user is told "Failed describing Change Set"
 
   Scenario: describe a change set that exists with ignore dependencies
     Given stack "1/A" exists in "CREATE_COMPLETE" state

--- a/integration-tests/features/execute-change-set.feature
+++ b/integration-tests/features/execute-change-set.feature
@@ -11,8 +11,7 @@ Feature: Execute change set
     Given stack "1/A" exists in "CREATE_COMPLETE" state
     And stack "1/A" does not have change set "A"
     When the user executes change set "A" for stack "1/A"
-    Then a "ClientError" is raised
-    And the user is told "change set does not exist"
+    Then the user is told "change set does not exist"
 
   Scenario: execute a change set that exists with ignore dependencies
     Given stack "1/A" exists in "CREATE_COMPLETE" state

--- a/integration-tests/steps/helpers.py
+++ b/integration-tests/steps/helpers.py
@@ -17,14 +17,15 @@ def step_impl(context, message):
         msg = context.error.response["Error"]["Message"]
         assert msg.endswith("does not exist")
     elif message == "change set does not exist":
-        msg = context.error.response["Error"]["Message"]
-        assert msg.endswith("does not exist")
+        assert context.log_capture.find_event("does not exist")
     elif message == "the template is valid":
         for stack, status in context.response.items():
             assert status["ResponseMetadata"]["HTTPStatusCode"] == 200
     elif message == "the template is malformed":
         msg = context.error.response["Error"]["Message"]
         assert msg.startswith("Template format error")
+    elif message == "Failed describing Change Set":
+        assert context.log_capture.find_event(message)
     else:
         raise Exception("Step has incorrect message")
 

--- a/sceptre/cli/helpers.py
+++ b/sceptre/cli/helpers.py
@@ -337,6 +337,9 @@ def simplify_change_set_description(response):
     :returns: A more concise description of the change set.
     :rtype: dict
     """
+    if not response:
+        return {"ChangeSetName": "ChangeSetNotFound"}
+
     desired_response_items = [
         "ChangeSetName",
         "CreationTime",

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -585,7 +585,9 @@ class StackActions:
 
         return_val = 0
 
-        if status == "FAILED" and self._change_set_creation_failed_due_to_no_changes(reason):
+        if status == "FAILED" and self._change_set_creation_failed_due_to_no_changes(
+            reason
+        ):
             self.logger.info(
                 "Skipping ChangeSet on Stack: {} - there are no changes".format(
                     change_set.get("StackName")

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -591,7 +591,9 @@ class StackActions:
 
         return_val = 0
 
-        if status == "FAILED" and self.change_set_creation_failed_due_to_no_changes(reason):
+        if status == "FAILED" and self.change_set_creation_failed_due_to_no_changes(
+            reason
+        ):
             self.logger.info(
                 "Skipping ChangeSet on Stack: {} - there are no changes".format(
                     change_set.get("StackName")

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -480,9 +480,6 @@ class StackActions:
             )
 
     def _create_change_set(self, change_set_name, create_change_set_kwargs):
-        """
-        Wrap create_change_set.
-        """
         self.logger.debug(
             "%s - Creating Change Set '%s'", self.stack.name, change_set_name
         )
@@ -524,9 +521,6 @@ class StackActions:
             )
 
     def _delete_change_set(self, change_set_name):
-        """
-        Wrap delete_change_set.
-        """
         self.logger.debug(
             "%s - Deleting Change Set '%s'", self.stack.name, change_set_name
         )
@@ -591,9 +585,7 @@ class StackActions:
 
         return_val = 0
 
-        if status == "FAILED" and self.change_set_creation_failed_due_to_no_changes(
-            reason
-        ):
+        if status == "FAILED" and self._change_set_creation_failed_due_to_no_changes(reason):
             self.logger.info(
                 "Skipping ChangeSet on Stack: {} - there are no changes".format(
                     change_set.get("StackName")
@@ -628,8 +620,9 @@ class StackActions:
         status = self._wait_for_completion(boto_response=response)
         return status
 
-    def change_set_creation_failed_due_to_no_changes(self, reason: str) -> bool:
-        """Indicates the change set failed when it was created because there were actually
+    def _change_set_creation_failed_due_to_no_changes(self, reason: str) -> bool:
+        """
+        Indicates the change set failed when it was created because there were actually
         no changes introduced from the change set.
 
         :param reason: The reason reported by CloudFormation for the Change Set failure
@@ -1164,9 +1157,6 @@ class StackActions:
                 self.logger.debug(f"{self.stack.name} - {key} - {response[key]}")
 
     def _detect_stack_drift(self) -> dict:
-        """
-        Run detect_stack_drift.
-        """
         self.logger.info(f"{self.stack.name} - Detecting Stack Drift")
 
         return self.connection_manager.call(
@@ -1176,9 +1166,6 @@ class StackActions:
         )
 
     def _describe_stack_drift_detection_status(self, detection_id: str) -> dict:
-        """
-        Run describe_stack_drift_detection_status.
-        """
         self.logger.info(f"{self.stack.name} - Describing Stack Drift Detection Status")
 
         return self.connection_manager.call(

--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -591,7 +591,7 @@ class StackActions:
 
         return_val = 0
 
-        if status == "FAILED" and self._change_set_failed_no_changes(reason):
+        if status == "FAILED" and self.change_set_creation_failed_due_to_no_changes(reason):
             self.logger.info(
                 "Skipping ChangeSet on Stack: {} - there are no changes".format(
                     change_set.get("StackName")
@@ -626,7 +626,7 @@ class StackActions:
         status = self._wait_for_completion(boto_response=response)
         return status
 
-    def _change_set_failed_no_changes(self, reason: str) -> bool:
+    def change_set_creation_failed_due_to_no_changes(self, reason: str) -> bool:
         """Indicates the change set failed when it was created because there were actually
         no changes introduced from the change set.
 


### PR DESCRIPTION
## Description

This adds code to handle the case of failures in stack groups that have missing or errored stacks when creating, describing and executing change-sets.

Before this, any stack group that contained a stack that had been deleted, or had errored out, resulted in all change set operations on that stack group failing.

The reason for this is no error or exception handling had ever been added for change sets, but assumed all stacks in the stack group were clean and could respond to the change set APIs.

For example, deleting change sets might error out with:

```
% sceptre delete -y network.yaml sceptre-network
The Change Set will be delete on the following stacks, if applicable:
network

"An error occurred (ValidationError) when calling the DeleteChangeSet
operation: Stack [test-e2e-direct-connect] does not exist"
```

This is particularly an issue for sites that employ as best practice analysis of change sets for safety prior to launching updates.

This patch adds the missing error handling for `delete_change_set`, `create_change_set`, `describe_change_set` and
`execute_change_set`.

## Testing

I have tested this locally using a stack group with 4 stacks. I deleted one of these stacks. Then:

_delete_change_set_:
<img width="1213" alt="Screenshot 2024-07-06 at 5 17 56 pm" src="https://github.com/Sceptre/sceptre/assets/2305330/a70c0c47-96b0-42cd-93e0-ce61debf2600">

_create_change_set_:
<img width="1222" alt="Screenshot 2024-07-06 at 5 18 29 pm" src="https://github.com/Sceptre/sceptre/assets/2305330/4b95addc-4e67-489d-ba4e-ab2d52caecff">

_describe_change_set_:
<img width="1171" alt="Screenshot 2024-07-06 at 5 21 12 pm" src="https://github.com/Sceptre/sceptre/assets/2305330/f7b2ec2a-4372-4e6e-afe9-c834f065c0d4">

Now I delete that stack/change-set again and rerun:
<img width="1260" alt="Screenshot 2024-07-06 at 5 22 32 pm" src="https://github.com/Sceptre/sceptre/assets/2305330/c0ac7846-d384-46f3-8374-a05c4616a920">

Create again and then:

_execute_change_set:
<img width="1383" alt="Screenshot 2024-07-06 at 5 24 00 pm" src="https://github.com/Sceptre/sceptre/assets/2305330/2bdbefc4-b57c-4723-80b4-8230eb6d8c02">

Note that I did this testing on the release branch which included 
https://github.com/Sceptre/sceptre/pull/1480

## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`poetry run tox`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`poetry run pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
