### PR TITLE
[Resolve #1498] Tweak diff output

### DIFF
--- a/sceptre/cli/diff.py
+++ b/sceptre/cli/diff.py
@@ -189,12 +189,12 @@ def output_buffer_with_normalized_bar_lengths(
     max_length = len(max(buffer, key=len))
     buffer.seek(0)
     full_length_star_bar = "*" * max_length
-    full_length_line_bar = "-" * max_length
+    full_length_tilde_bar = "~" * max_length
     for line in buffer:
         if DiffWriter.STAR_BAR in line:
             line = line.replace(DiffWriter.STAR_BAR, full_length_star_bar)
-        if DiffWriter.LINE_BAR in line:
-            line = line.replace(DiffWriter.LINE_BAR, full_length_line_bar)
+        if DiffWriter.TILDE_BAR in line:
+            line = line.replace(DiffWriter.TILDE_BAR, full_length_tilde_bar)
         output_stream.write(line)
 
 

--- a/sceptre/diffing/diff_writer.py
+++ b/sceptre/diffing/diff_writer.py
@@ -25,7 +25,7 @@ class DiffWriter(Generic[DiffType]):
     """
 
     STAR_BAR = "*" * 80
-    LINE_BAR = "-" * 80
+    TILDE_BAR = "~" * 80
 
     def __init__(
         self, stack_diff: StackDiff, output_stream: TextIO, output_format: str
@@ -59,26 +59,26 @@ class DiffWriter(Generic[DiffType]):
             self._output(f"No difference to deployed stack {self.stack_name}")
             return
 
-        self._output(f"--> Difference detected for stack {self.stack_name}!")
+        self._output(f"==> Difference detected for stack {self.stack_name}!")
 
         if not self.is_deployed:
             self._write_new_stack_details()
             return
 
-        self._output(self.LINE_BAR)
+        self._output(self.TILDE_BAR)
         self._write_config_difference()
-        self._output(self.LINE_BAR)
+        self._output(self.TILDE_BAR)
         self._write_template_difference()
 
     def _write_new_stack_details(self):
         stack_config_text = self._dump_stack_config(self.stack_diff.generated_config)
         self._output(
             "This stack is not deployed yet!",
-            self.LINE_BAR,
+            self.TILDE_BAR,
             "New Config:",
             "",
             stack_config_text,
-            self.LINE_BAR,
+            self.TILDE_BAR,
             "New Template:",
             "",
             self.stack_diff.generated_template,

--- a/tests/test_diffing/test_diff_writer.py
+++ b/tests/test_diffing/test_diff_writer.py
@@ -57,7 +57,7 @@ class TestDiffWriter:
         self.output_stream = StringIO()
 
         self.diff_detected_message = (
-            f"--> Difference detected for stack {self.stack_name}!"
+            f"==> Difference detected for stack {self.stack_name}!"
         )
 
     @property
@@ -133,11 +133,11 @@ class TestDiffWriter:
             DiffWriter.STAR_BAR,
             self.diff_detected_message,
             "This stack is not deployed yet!",
-            DiffWriter.LINE_BAR,
+            DiffWriter.TILDE_BAR,
             "New Config:",
             "",
             config_serializer(dict(self.generated_config._asdict())),
-            DiffWriter.LINE_BAR,
+            DiffWriter.TILDE_BAR,
             "New Template:",
             "",
             self.generated_template,
@@ -152,11 +152,11 @@ class TestDiffWriter:
         self.assert_expected_output(
             DiffWriter.STAR_BAR,
             self.diff_detected_message,
-            DiffWriter.LINE_BAR,
+            DiffWriter.TILDE_BAR,
             f"Config difference for {self.stack_name}:",
             "",
             self.diff_output,
-            DiffWriter.LINE_BAR,
+            DiffWriter.TILDE_BAR,
             "No template difference",
         )
 
@@ -169,9 +169,9 @@ class TestDiffWriter:
         self.assert_expected_output(
             DiffWriter.STAR_BAR,
             self.diff_detected_message,
-            DiffWriter.LINE_BAR,
+            DiffWriter.TILDE_BAR,
             "No stack config difference",
-            DiffWriter.LINE_BAR,
+            DiffWriter.TILDE_BAR,
             f"Template difference for {self.stack_name}:",
             "",
             self.diff_output,
@@ -186,11 +186,11 @@ class TestDiffWriter:
         self.assert_expected_output(
             DiffWriter.STAR_BAR,
             self.diff_detected_message,
-            DiffWriter.LINE_BAR,
+            DiffWriter.TILDE_BAR,
             f"Config difference for {self.stack_name}:",
             "",
             self.diff_output,
-            DiffWriter.LINE_BAR,
+            DiffWriter.TILDE_BAR,
             f"Template difference for {self.stack_name}:",
             "",
             self.diff_output,


### PR DESCRIPTION
In order to produce output that does not confuse syntax highlighters that recognise diff-formatted output, it is decided here to replace the "-" character (which would often cause a diff highlighter to colour the line as red) instead with "~" which would tend to be ignored by diff highlighters.

Showing GitHub's rendering of before- and after- output:

_Before_:

(Note that lines are highlighted in red that should not be.)

```diff
*****************************************************************************************                                                                                                             
--> Difference detected for stack flink-prod!                                                                                                                                    
-----------------------------------------------------------------------------------------                                                                                                             
Config difference for flink-prod:                                                                                                                                          
                                                                                                                                                                                                      
--- deployed                                                                                                                                                                                          
+++ generated                                                                                                                                                                                         
@@ -7,4 +7,4 @@                                                                                                                                                                                       
   Project: Datalake                                                                                                                                                                                  
   SourceControlPath: fsa/sceptre-environment/prod/datalake-prod                                                                                                              
   Team: DevOps                                                                                                                                                                                       
-  Version: 7.0.0                                                                                                                                                                                     
+  Version: 8.0.0                                                                                                                                                                                     
-----------------------------------------------------------------------------------------                                                                                                             
No template difference                                                                                                                                                                                
*****************************************************************************************                                                                                                             
--> Difference detected for stack flink-prod!                                                                                                                                       
-----------------------------------------------------------------------------------------
Config difference for flink-prod:
```

_After_:

```diff
*****************************************************************************************                                                                                                             
==> Difference detected for stack flink-prod!                                                                                                                                    
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Config difference for flink-prod:                                                                                                                                          
                                                                                                                                                                                                      
--- deployed                                                                                                                                                                                          
+++ generated                                                                                                                                                                                         
@@ -7,4 +7,4 @@                                                                                                                                                                                       
   Project: Datalake                                                                                                                                                                                  
   SourceControlPath: fsa/sceptre-environment/prod/datalake-prod                                                                                                              
   Team: DevOps                                                                                                                                                                                       
-  Version: 7.0.0                                                                                                                                                                                     
+  Version: 8.0.0                                                                                                                                                                                     
*****************************************************************************************                                                                                                             
No template difference                                                                                                                                                                                
*****************************************************************************************                                                                                                             
==> Difference detected for stack flink-prod!                                                                                                                                       
*****************************************************************************************                                                                                                             
Config difference for flink-prod:
```


## PR Checklist

- [ ] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`poetry run tox`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes pre-commit validations (`poetry run pre-commit run --all-files`).
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
