### PR TITLE
[Resolve #1506] Remove unused __eq__ method

### DIFF
--- a/sceptre/stack.py
+++ b/sceptre/stack.py
@@ -354,30 +354,6 @@ class Stack:
     def __str__(self):
         return self.name
 
-    def __eq__(self, stack):
-        # We should not use any resolvable properties in __eq__, since it is used when adding the
-        # Stack to a set, which is done very early in plan resolution. Trying to reference resolvers
-        # before the plan is fully resolved can potentially blow up.
-        return (
-            self.name == stack.name
-            and self.external_name == stack.external_name
-            and self.project_code == stack.project_code
-            and self.template_path == stack.template_path
-            and self.region == stack.region
-            and self.template_key_prefix == stack.template_key_prefix
-            and self.required_version == stack.required_version
-            and self.sceptre_role_session_duration
-            == stack.sceptre_role_session_duration
-            and self.profile == stack.profile
-            and self.dependencies == stack.dependencies
-            and self.protected == stack.protected
-            and self.on_failure == stack.on_failure
-            and self.disable_rollback == stack.disable_rollback
-            and self.stack_timeout == stack.stack_timeout
-            and self.ignore == stack.ignore
-            and self.obsolete == stack.obsolete
-        )
-
     def __hash__(self):
         return hash(str(self))
 


### PR DESCRIPTION
Way back in 2018, the original team were adding the debug command, and in that context set about to improve the output in some debug circumstances during inspection of Sceptre's internal objects.

In response to https://github.com/Sceptre/sceptre/issues/570, a custom `__eq__` method was added in df9fc201aaed59c173b11b80e804244a5b2f3bfb.

Based on what can be seen of the original implementation of the custom `__eq__`, it has not been maintained in a long time, other than changes to it that appeared forced on the current maintainers.


A recent change 993ef0937d9a49a1683feb9591c4526ee0fe29af was done to improve the output during cyclical dependency errors. This change introduced a call to `nx.find_cycle`, a function that explicitly searches for a cycle in the graph. This appears to result in code testing for the equality of nodes in the graph and thus calls to the custom `__eq__` method.

The `__eq__` method however has been technically broken ever since `template_path` was made optional. This then results in `__eq__` failing. This fails as the code to announce the deprecation of `template_path` is then executed, which fails if the deprecated setting is not actually in use.


This PR proposes to simply remove `__eq__` since it is believed that it is no longer in use by anything. It has been more than 2 years since `template_path` was deprecrated and made optional, and the fact that this bug has not surfaced until now is good evidence that the code is not otherwise used or needed.


## PR Checklist

- [x] Wrote a good commit message & description [see guide below].
- [x] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [x] All unit tests (`poetry run tox`) are passing.
- [x] Used the same coding conventions as the rest of the project.
- [x] The new code passes pre-commit validations (`poetry run pre-commit run --all-files`).
- [x] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
