### PR TITLE
[Resolve #1517] Updated the Cloudformation Hook logging message

### DIFF
--- a/sceptre/plan/actions.py
+++ b/sceptre/plan/actions.py
@@ -919,7 +919,6 @@ class StackActions:
                         event["HookType"],
                         event["HookStatus"],
                         event.get("HookStatusReason", ""),
-                        event["HookFailureMode"],
                     ]
                 )
             self.logger.info(" ".join(stack_event_status))

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1125,7 +1125,6 @@ class TestStackActions(object):
                         "ResourceStatus": "resource-with-cf-hook",
                         "HookType": "type-3",
                         "HookStatus": "HOOK_COMPLETE_SUCCEEDED",
-                        "HookFailureMode": "WARN",
                     },
                     {
                         "Timestamp": datetime.datetime(
@@ -1138,7 +1137,6 @@ class TestStackActions(object):
                         "HookType": "type-4",
                         "HookStatus": "HOOK_IN_PROGRESS",
                         "HookStatusReason": "Good hook",
-                        "HookFailureMode": "WARN",
                     },
                 ]
             }
@@ -1153,7 +1151,6 @@ class TestStackActions(object):
                 self.actions.describe_events()["StackEvents"][1]["ResourceStatus"],
                 self.actions.describe_events()["StackEvents"][1]["HookType"],
                 self.actions.describe_events()["StackEvents"][1]["HookStatus"],
-                self.actions.describe_events()["StackEvents"][1]["HookFailureMode"],
             ].sort() == caplog.messages[0].split().sort()
             assert [
                 self.actions.stack.name,
@@ -1166,7 +1163,6 @@ class TestStackActions(object):
                 self.actions.describe_events()["StackEvents"][0]["HookType"],
                 self.actions.describe_events()["StackEvents"][0]["HookStatus"],
                 self.actions.describe_events()["StackEvents"][0]["HookStatusReason"],
-                self.actions.describe_events()["StackEvents"][0]["HookFailureMode"],
             ].sort() == caplog.messages[1].split().sort()
 
     @patch("sceptre.plan.actions.StackActions._get_cs_status")


### PR DESCRIPTION
Resolve https://github.com/Sceptre/sceptre/issues/1517

The Cloudformation hook logging message was bit confusing as it stated the hookmode at the end of the hook log.

The log is shown as below for the successful hook execution:

```
07:17:25  [2024-09-17 01:47:24] - sbox-01/sbucket Bucket AWS::S3::Bucket CREATE_IN_PROGRESS  sample::Generic::Megahookblock HOOK_COMPLETE_SUCCEEDED Hook succeeded with message: Hook Successfully completed **FAIL**
```

Even though the hook completed successfully, it mode mentioned at the end of the message is misleading to the end user looking into the logs.

As the failure/warn is mentioned in the hook message after the execution, removing the HOOKMODE from this log message.

Log when Hook Fails in the FAIL mode
```
07:17:33  [2024-09-17 01:47:33] - sbox-01/sbucket Bucket AWS::S3::Bucket CREATE_IN_PROGRESS  sample::Generic::Megahook HOOK_COMPLETE_FAILED Hook failed with message: Rule [
07:17:33          [CT.S3.PR.1]: Require an Amazon S3 bucket to have block public access settings configured
07:17:33          [FIX]: The parameters 'BlockPublicAcls', 'BlockPublicPolicy', 'IgnorePublicAcls', 'RestrictPublicBuckets' must be set to "true" under the bucket-level 'PublicAccessBlockConfiguration'.
07:17:33          ] failed. FAIL
07:17:33  [2024-09-17 01:47:33] - sbox-01/sbucket Bucket AWS::S3::Bucket CREATE_FAILED The following hook(s) failed: [sample::Generic::Megahook]
```
Log when Hook Fails in the WARN mode
```
13:14:32  [2024-09-12 07:44:32] - sbox-01/sbucket Bucket AWS::S3::Bucket CREATE_IN_PROGRESS  sample::Generic::Megahook HOOK_COMPLETE_FAILED Hook failed with message: Rule [
13:14:32          [CT.S3.PR.1]: Require an Amazon S3 bucket to have block public access settings configured
13:14:32          [FIX]: The parameters 'BlockPublicAcls', 'BlockPublicPolicy', 'IgnorePublicAcls', 'RestrictPublicBuckets' must be set to "true" under the bucket-level 'PublicAccessBlockConfiguration'.
13:14:32          ] failed.. Failure was ignored under WARN mode. WARN
13:14:32  [2024-09-12 07:44:32] - sbox-01/sbucket Bucket AWS::S3::Bucket CREATE_IN_PROGRESS Hook invocations complete.  Resource creation initiated
```
Hence removing the HOOKMODE at the end of the hook logging. Have not updated any logic.
