### PR TITLE
[Resolve #1520] Bugfix in differ

### DIFF
--- a/sceptre/diffing/stack_differ.py
+++ b/sceptre/diffing/stack_differ.py
@@ -201,7 +201,7 @@ class StackDiffer(Generic[DiffType]):
             if err.response["Error"]["Code"] == "ForbiddenException":
                 raise SceptreException(
                     "ForbiddenException: Confirm your current AWS profile is authenticated",
-                    "and has the necessary access."
+                    "and has the necessary access.",
                 )
 
             # This means the stack has not been deployed yet

--- a/sceptre/diffing/stack_differ.py
+++ b/sceptre/diffing/stack_differ.py
@@ -197,13 +197,6 @@ class StackDiffer(Generic[DiffType]):
         try:
             description = stack_actions.describe()
         except ClientError as err:
-            # Check for AWS access exceptions
-            if err.response["Error"]["Code"] == "ForbiddenException":
-                raise SceptreException(
-                    "ForbiddenException: Confirm your current AWS profile is authenticated",
-                    "and has the necessary access.",
-                )
-
             # This means the stack has not been deployed yet
             if err.response["Error"]["Message"].endswith("does not exist"):
                 return None

--- a/sceptre/diffing/stack_differ.py
+++ b/sceptre/diffing/stack_differ.py
@@ -197,9 +197,18 @@ class StackDiffer(Generic[DiffType]):
         try:
             description = stack_actions.describe()
         except ClientError as err:
+            # Check for AWS access exceptions
+            if err.response["Error"]["Code"] == "ForbiddenException":
+                raise SceptreException(
+                    "ForbiddenException: Confirm your current AWS profile is authenticated."
+                )
+
             # This means the stack has not been deployed yet
             if err.response["Error"]["Message"].endswith("does not exist"):
                 return None
+
+            # Unknown error, raise it as-is
+            raise err
 
         stacks = description["Stacks"]
         for stack in stacks:

--- a/sceptre/diffing/stack_differ.py
+++ b/sceptre/diffing/stack_differ.py
@@ -200,7 +200,8 @@ class StackDiffer(Generic[DiffType]):
             # Check for AWS access exceptions
             if err.response["Error"]["Code"] == "ForbiddenException":
                 raise SceptreException(
-                    "ForbiddenException: Confirm your current AWS profile is authenticated."
+                    "ForbiddenException: Confirm your current AWS profile is authenticated",
+                    "and has the necessary access."
                 )
 
             # This means the stack has not been deployed yet

--- a/tests/test_diffing/test_stack_differ.py
+++ b/tests/test_diffing/test_stack_differ.py
@@ -181,17 +181,6 @@ class TestStackDiffer:
             cloudformation_service_role=self.deployed_cloudformation_service_role,
         )
 
-    def test__create_deployed_stack_config__wraps_aws_ForbiddenException(self):
-        def fail_with_ForbiddenException():
-            raise ClientError(
-                {"Error": {"Code": "ForbiddenException", "Message": "No access"}},
-                "describe",
-            )
-
-        self._describe_fn = fail_with_ForbiddenException
-        with pytest.raises(SceptreException):
-            self.differ._create_deployed_stack_config(self.actions)
-
     def test_diff__compares_deployed_template_to_generated_template(self):
         self.differ.diff(self.actions)
 

--- a/tests/test_diffing/test_stack_differ.py
+++ b/tests/test_diffing/test_stack_differ.py
@@ -458,9 +458,9 @@ class TestStackDiffer:
         self.local_no_echo_parameters.append("hide_me")
 
         expected_generated_config = self.expected_generated_config
-        expected_generated_config.parameters[
-            "hide_me"
-        ] = StackDiffer.NO_ECHO_REPLACEMENT
+        expected_generated_config.parameters["hide_me"] = (
+            StackDiffer.NO_ECHO_REPLACEMENT
+        )
 
         self.differ.diff(self.actions)
 


### PR DESCRIPTION
I am adopting the bugfix portion of this PR
https://github.com/Sceptre/sceptre/pull/1522

Ensures that the differ does not swallow up client errors that should be raised.

## PR Checklist

- [ ] Wrote a good commit message & description [see guide below].
- [ ] Commit message starts with `[Resolve #issue-number]`.
- [ ] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ] All unit tests (`poetry run tox`) are passing.
- [ ] Used the same coding conventions as the rest of the project.
- [ ] The new code passes pre-commit validations (`poetry run pre-commit run --all-files`).
- [ ] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
