### PR TITLE
Update pre-commit auto update schedule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  autoupdate_schedule: monthly
+
 default_language_version:
   python: python3
 


### PR DESCRIPTION
By default pre-commit auto updates it's linters weekly[1].  This seems a big too aggressive so we are changing it to monthly.

[1] https://pre-commit.ci/#configuration-autoupdate_schedule
