### PR TITLE
Fix docker release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
       # docker convention: latest tag refers to the last stable release
-      - name: Build and push Docker image to sceptreorg/sceptre:${{ steps.meta.outputs.tags }}
+      - name: Build and push image with latest and sceptreorg/sceptre:${{ steps.meta.outputs.tags }} tags
         uses: docker/build-push-action@v5
         with:
           context: .

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,13 +19,6 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
       # docker convention: latest tag refers to the last stable release
-      - name: Build and push Docker image to sceptreorg/sceptre:latest
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: sceptreorg/sceptre:latest
-          labels: ${{ steps.meta.outputs.labels }}
       - name: Build and push Docker image to sceptreorg/sceptre:${{ steps.meta.outputs.tags }}
         uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
Docker build and push action changed, it now pushes the specified tag and `latest` tag in one command.

`--tag sceptreorg/sceptre:v4.5.3 --tag latest`

This causes the error `ERROR: denied: requested access to the resource is denied` on the 2nd push of the latest tag.

