### PR TITLE
Fix/remove safe loads path

### DIFF
--- a/sceptre/cli/helpers.py
+++ b/sceptre/cli/helpers.py
@@ -153,10 +153,7 @@ def _generate_yaml(stream):
         return yaml.dump(stream, **kwargs)
 
     else:
-        try:
-            return yaml.safe_loads(stream)
-        except Exception:
-            return stream
+        return stream
 
 
 def _generate_text(stream):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -13,6 +13,7 @@ from sceptre.helpers import (
     create_deprecated_alias_property,
     delete_keys_from_containers,
 )
+from sceptre.cli.helpers import _generate_yaml
 from sceptre.helpers import normalise_path
 from sceptre.helpers import sceptreise_path
 from sceptre.helpers import extract_datetime_from_aws_response_headers, gen_repr
@@ -194,3 +195,7 @@ class TestHelpers(object):
         delete_keys_from_containers(arg)
         expected = ["keep me", "keep me"]
         assert a == b == expected
+
+    def test_generate_yaml_str_passthrough(self):
+        s = "---\na: 1\nb: [2,3]\n"
+        assert _generate_yaml(s) == s


### PR DESCRIPTION
This PR removes an unused code path in ` _generate_yaml() `in `sceptre/cli/helpers.py`

yaml.safe_loads() does not exist, so that code path has never done anything.

[https://github.com/Sceptre/sceptre/blob/69a8a5a648fb91bbda2c0e88881cf94102ccc32f/sceptre/cli/helpers.py#L157](https://github.com/Sceptre/sceptre/blob/69a8a5a648fb91bbda2c0e88881cf94102ccc32f/sceptre/cli/helpers.py#L157)

## PR Checklist

- [✓ ] Wrote a good commit message & description [see guide below].
- [ ✓] Commit message starts with `[Resolve #issue-number]`.
- [ ✓] Added/Updated unit tests.
- [ ] Added/Updated integration tests (if applicable).
- [ ✓] All unit tests (`poetry run tox`) are passing.
- [ ✓] Used the same coding conventions as the rest of the project.
- [ ✓] The new code passes pre-commit validations (`poetry run pre-commit run --all-files`).
- [ ✓] The PR relates to _only_ one subject with a clear title.
      and description in grammatically correct, complete sentences.

## Approver/Reviewer Checklist

- [ ] Before merge squash related commits.

## Other Information

[Guide to writing a good commit](http://chris.beams.io/posts/git-commit/)
